### PR TITLE
#18 Implement Local Agreement streaming for lower latency

### DIFF
--- a/src/engines/types.ts
+++ b/src/engines/types.ts
@@ -25,6 +25,8 @@ export interface TranslationResult {
   targetLanguage: Language
   /** Unix timestamp in ms */
   timestamp: number
+  /** Whether this is an interim (unconfirmed) result from streaming mode */
+  isInterim?: boolean
 }
 
 /**

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -105,6 +105,12 @@ function initPipeline(): void {
     logger?.log(result)
   })
 
+  // Forward interim (streaming) results to subtitle window
+  pipeline.on('interim-result', (result: TranslationResult) => {
+    subtitleWindow?.webContents.send('interim-result', result)
+    mainWindow?.webContents.send('interim-result', result)
+  })
+
   pipeline.on('error', (err: Error) => {
     mainWindow?.webContents.send('status-update', `Error: ${err.message}`)
   })
@@ -215,10 +221,8 @@ ipcMain.handle('pipeline-stop', async () => {
   return { logPath }
 })
 
-// Process audio chunk from renderer
-ipcMain.handle('process-audio', async (_event, audioData: unknown) => {
-  if (!pipeline?.running) return null
-
+/** Convert IPC audio data to Float32Array */
+function toFloat32Array(audioData: unknown): Float32Array | null {
   let chunk: Float32Array
   if (audioData instanceof Float32Array) {
     chunk = audioData
@@ -230,12 +234,6 @@ ipcMain.handle('process-audio', async (_event, audioData: unknown) => {
     )
   } else {
     console.error('[audio] Unknown data type:', typeof audioData)
-    return null
-  }
-
-  // Minimum audio length check (at least 0.5 seconds at 16kHz)
-  if (chunk.length < 8000) {
-    console.log(`[audio] Chunk too short: ${chunk.length} samples, skipping`)
     return null
   }
 
@@ -252,10 +250,50 @@ ipcMain.handle('process-audio', async (_event, audioData: unknown) => {
     return null
   }
 
+  return chunk
+}
+
+// Process audio chunk from renderer
+ipcMain.handle('process-audio', async (_event, audioData: unknown) => {
+  if (!pipeline?.running) return null
+
+  const chunk = toFloat32Array(audioData)
+  if (!chunk || chunk.length < 8000) return null
+
   try {
     return await pipeline.process(chunk, 16000)
   } catch (err) {
     console.error('[audio] Pipeline error:', err)
+    return null
+  }
+})
+
+// Process streaming audio (rolling buffer during speech)
+ipcMain.handle('process-audio-streaming', async (_event, audioData: unknown) => {
+  if (!pipeline?.running) return null
+
+  const chunk = toFloat32Array(audioData)
+  if (!chunk || chunk.length < 8000) return null
+
+  try {
+    return await pipeline.processStreaming(chunk, 16000)
+  } catch (err) {
+    console.error('[audio] Streaming pipeline error:', err)
+    return null
+  }
+})
+
+// Finalize streaming (speech segment ended)
+ipcMain.handle('finalize-streaming', async (_event, audioData: unknown) => {
+  if (!pipeline?.running) return null
+
+  const chunk = toFloat32Array(audioData)
+  if (!chunk || chunk.length < 8000) return null
+
+  try {
+    return await pipeline.finalizeStreaming(chunk, 16000)
+  } catch (err) {
+    console.error('[audio] Finalize streaming error:', err)
     return null
   }
 })

--- a/src/pipeline/LocalAgreement.ts
+++ b/src/pipeline/LocalAgreement.ts
@@ -1,0 +1,99 @@
+/**
+ * Local Agreement algorithm for streaming speech recognition.
+ *
+ * Compares consecutive Whisper transcription results and only emits
+ * text that both results agree on (longest common prefix).
+ * This reduces flickering and provides stable interim display.
+ *
+ * Reference: "Turning Whisper into Real-Time Transcription System" (IJCNLP 2023)
+ */
+
+export interface AgreementResult {
+  /** Text confirmed by agreement between consecutive transcriptions */
+  confirmedText: string
+  /** New confirmed text since last update (delta) */
+  newConfirmed: string
+  /** Unconfirmed text beyond the agreed prefix */
+  interimText: string
+}
+
+export class LocalAgreement {
+  private previousTranscript = ''
+  private confirmedText = ''
+
+  /**
+   * Feed a new transcription result and compute agreement.
+   * Call this each time Whisper produces output on the rolling buffer.
+   */
+  update(newTranscript: string): AgreementResult {
+    const commonPrefix = longestCommonPrefix(this.previousTranscript, newTranscript)
+
+    let newConfirmed = ''
+    if (commonPrefix.length > this.confirmedText.length) {
+      newConfirmed = commonPrefix.slice(this.confirmedText.length)
+      this.confirmedText = commonPrefix
+    }
+
+    this.previousTranscript = newTranscript
+
+    // Interim is whatever extends beyond the confirmed prefix in the new transcript
+    const interimText = newTranscript.slice(this.confirmedText.length)
+
+    return {
+      confirmedText: this.confirmedText,
+      newConfirmed,
+      interimText
+    }
+  }
+
+  /**
+   * Finalize the current speech segment.
+   * Promotes all remaining text to confirmed and resets state.
+   */
+  finalize(finalTranscript: string): AgreementResult {
+    const fullText = finalTranscript || this.previousTranscript
+    const newConfirmed = fullText.slice(this.confirmedText.length)
+
+    const result: AgreementResult = {
+      confirmedText: fullText,
+      newConfirmed,
+      interimText: ''
+    }
+
+    this.reset()
+    return result
+  }
+
+  /** Reset state for a new speech segment */
+  reset(): void {
+    this.previousTranscript = ''
+    this.confirmedText = ''
+  }
+}
+
+/**
+ * Compute the longest common prefix of two strings.
+ * Breaks at word boundaries to avoid partial-word confirmation.
+ */
+function longestCommonPrefix(a: string, b: string): string {
+  const minLen = Math.min(a.length, b.length)
+  let i = 0
+  while (i < minLen && a[i] === b[i]) {
+    i++
+  }
+
+  // If we matched the entire shorter string, return as-is
+  if (i === a.length || i === b.length) {
+    return a.slice(0, i)
+  }
+
+  // Snap to last word boundary to avoid confirming partial words
+  const raw = a.slice(0, i)
+  const lastSpace = raw.lastIndexOf(' ')
+  if (lastSpace > 0) {
+    return raw.slice(0, lastSpace + 1)
+  }
+
+  // No word boundary found — return empty to avoid partial-word confirmation
+  return ''
+}

--- a/src/pipeline/TranslationPipeline.ts
+++ b/src/pipeline/TranslationPipeline.ts
@@ -7,9 +7,11 @@ import type {
   TranslationResult,
   Language
 } from '../engines/types'
+import { LocalAgreement } from './LocalAgreement'
 
 export interface PipelineEvents {
   result: (result: TranslationResult) => void
+  'interim-result': (result: TranslationResult) => void
   error: (error: Error) => void
   'engine-loading': (message: string) => void
   'engine-ready': () => void
@@ -29,6 +31,9 @@ export class TranslationPipeline extends EventEmitter {
   private translator: TranslatorEngine | null = null
   private e2eEngine: E2ETranslationEngine | null = null
   private isRunning = false
+  private agreement = new LocalAgreement()
+  private lastTranslatedConfirmed = ''
+  private streamingLock = false
 
   // Engine factories — registered externally
   private sttFactories = new Map<string, () => STTEngine>()
@@ -140,12 +145,124 @@ export class TranslationPipeline extends EventEmitter {
     }
   }
 
+  /**
+   * Process a rolling audio buffer for streaming (Local Agreement).
+   * Emits interim-result with confirmed + interim text.
+   * Only translates newly confirmed text.
+   */
+  async processStreaming(audioBuffer: Float32Array, sampleRate: number): Promise<TranslationResult | null> {
+    if (!this.isRunning || !this.config) return null
+    if (this.config.mode !== 'cascade' || !this.sttEngine) return null
+    if (this.streamingLock) return null
+
+    this.streamingLock = true
+    try {
+      const sttResult = await this.sttEngine.processAudio(audioBuffer, sampleRate)
+      if (!sttResult || !sttResult.text.trim()) return null
+
+      const agreement = this.agreement.update(sttResult.text)
+
+      const targetLang: Language = sttResult.language === 'ja' ? 'en' : 'ja'
+
+      // Translate only newly confirmed text
+      let translatedText = ''
+      if (agreement.newConfirmed && this.translator) {
+        // Translate the full confirmed text for better context
+        translatedText = await this.translator.translate(
+          agreement.confirmedText,
+          sttResult.language,
+          targetLang
+        )
+        this.lastTranslatedConfirmed = translatedText
+      } else {
+        translatedText = this.lastTranslatedConfirmed
+      }
+
+      // Emit interim result (confirmed + interim text for display)
+      const interimResult: TranslationResult = {
+        sourceText: agreement.confirmedText + agreement.interimText,
+        translatedText,
+        sourceLanguage: sttResult.language,
+        targetLanguage: targetLang,
+        timestamp: Date.now(),
+        isInterim: true
+      }
+
+      this.emit('interim-result', interimResult)
+      return interimResult
+    } catch (err) {
+      this.emit('error', err instanceof Error ? err : new Error(String(err)))
+      return null
+    } finally {
+      this.streamingLock = false
+    }
+  }
+
+  /**
+   * Finalize streaming for the current speech segment.
+   * Promotes all text to confirmed, translates, and emits a final result.
+   */
+  async finalizeStreaming(audioChunk: Float32Array, sampleRate: number): Promise<TranslationResult | null> {
+    if (!this.isRunning || !this.config) return null
+    if (this.config.mode !== 'cascade' || !this.sttEngine) return null
+
+    // Wait for any in-flight streaming operation to complete
+    while (this.streamingLock) {
+      await new Promise((resolve) => setTimeout(resolve, 50))
+    }
+    this.streamingLock = true
+
+    try {
+      const sttResult = await this.sttEngine.processAudio(audioChunk, sampleRate)
+      if (!sttResult || !sttResult.text.trim()) {
+        this.agreement.reset()
+        this.lastTranslatedConfirmed = ''
+        return null
+      }
+
+      const agreement = this.agreement.finalize(sttResult.text)
+      const targetLang: Language = sttResult.language === 'ja' ? 'en' : 'ja'
+
+      let translatedText = ''
+      if (this.translator && agreement.confirmedText.trim()) {
+        translatedText = await this.translator.translate(
+          agreement.confirmedText,
+          sttResult.language,
+          targetLang
+        )
+      }
+
+      this.lastTranslatedConfirmed = ''
+
+      const result: TranslationResult = {
+        sourceText: agreement.confirmedText,
+        translatedText,
+        sourceLanguage: sttResult.language,
+        targetLanguage: targetLang,
+        timestamp: Date.now(),
+        isInterim: false
+      }
+
+      this.emit('result', result)
+      return result
+    } catch (err) {
+      this.agreement.reset()
+      this.lastTranslatedConfirmed = ''
+      this.emit('error', err instanceof Error ? err : new Error(String(err)))
+      return null
+    } finally {
+      this.streamingLock = false
+    }
+  }
+
   start(): void {
     this.isRunning = true
   }
 
   stop(): void {
     this.isRunning = false
+    this.agreement.reset()
+    this.lastTranslatedConfirmed = ''
   }
 
   get running(): boolean {

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -2,8 +2,11 @@ export interface ElectronAPI {
   pipelineStart: (config: unknown) => Promise<{ success?: boolean; error?: string }>
   pipelineStop: () => Promise<{ logPath?: string }>
   processAudio: (audioData: number[]) => Promise<unknown>
+  processAudioStreaming: (audioData: number[]) => Promise<unknown>
+  finalizeStreaming: (audioData: number[]) => Promise<unknown>
   sendTranslationResult: (data: unknown) => void
   onTranslationResult: (callback: (data: unknown) => void) => void
+  onInterimResult: (callback: (data: unknown) => void) => void
   onStatusUpdate: (callback: (message: string) => void) => void
   getDisplays: () => Promise<
     Array<{

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -5,11 +5,16 @@ contextBridge.exposeInMainWorld('api', {
   pipelineStart: (config: unknown) => ipcRenderer.invoke('pipeline-start', config),
   pipelineStop: () => ipcRenderer.invoke('pipeline-stop'),
   processAudio: (audioData: number[]) => ipcRenderer.invoke('process-audio', audioData),
+  processAudioStreaming: (audioData: number[]) => ipcRenderer.invoke('process-audio-streaming', audioData),
+  finalizeStreaming: (audioData: number[]) => ipcRenderer.invoke('finalize-streaming', audioData),
 
   // Translation results
   sendTranslationResult: (data: unknown) => ipcRenderer.send('translation-result', data),
   onTranslationResult: (callback: (data: unknown) => void) => {
     ipcRenderer.on('translation-result', (_event, data) => callback(data))
+  },
+  onInterimResult: (callback: (data: unknown) => void) => {
+    ipcRenderer.on('interim-result', (_event, data) => callback(data))
   },
 
   // Status updates from main process

--- a/src/renderer/components/SettingsPanel.tsx
+++ b/src/renderer/components/SettingsPanel.tsx
@@ -30,12 +30,21 @@ function SettingsPanel(): JSX.Element {
     })
   }, [])
 
-  // Handle audio chunks → send to main process for pipeline processing
+  // Handle audio: streaming chunks during speech, final segment on speech end
   useEffect(() => {
+    // Legacy: VAD speech end → final processing (non-streaming fallback for e2e mode)
     audio.onAudioChunk((chunk) => {
-      // Send PCM data to main process for Whisper processing
-      // Convert Float32Array to plain array for IPC serialization
       window.api.processAudio(Array.from(chunk))
+    })
+
+    // Streaming: periodic rolling buffer during speech
+    audio.onStreamingChunk((buffer) => {
+      window.api.processAudioStreaming(Array.from(buffer))
+    })
+
+    // Streaming: finalize when speech ends
+    audio.onSpeechSegmentEnd((finalBuffer) => {
+      window.api.finalizeStreaming(Array.from(finalBuffer))
     })
   }, [audio])
 

--- a/src/renderer/components/SubtitleOverlay.tsx
+++ b/src/renderer/components/SubtitleOverlay.tsx
@@ -7,20 +7,41 @@ interface SubtitleLine {
   sourceLanguage: string
   timestamp: number
   opacity: number
+  isInterim?: boolean
 }
 
 const MAX_LINES = 3
 const FADE_DURATION_MS = 8000
+const INTERIM_LINE_ID = -1
 
 function SubtitleOverlay(): JSX.Element {
   const [lines, setLines] = useState<SubtitleLine[]>([])
   const fadeTimerRef = useRef<ReturnType<typeof setInterval> | null>(null)
 
   useEffect(() => {
+    // Final (confirmed) results — add as permanent line
     window.api.onTranslationResult((data) => {
       const result = data as Omit<SubtitleLine, 'id' | 'opacity'>
       setLines((prev) => {
-        const updated = [...prev, { ...result, id: Date.now(), opacity: 1 }]
+        // Remove any interim line, add the final result
+        const withoutInterim = prev.filter((l) => l.id !== INTERIM_LINE_ID)
+        const updated = [...withoutInterim, { ...result, id: Date.now(), opacity: 1 }]
+        return updated.slice(-MAX_LINES)
+      })
+    })
+
+    // Interim (streaming) results — replace the interim line in place
+    window.api.onInterimResult((data) => {
+      const result = data as Omit<SubtitleLine, 'id' | 'opacity' | 'isInterim'>
+      setLines((prev) => {
+        const withoutInterim = prev.filter((l) => l.id !== INTERIM_LINE_ID)
+        const interimLine: SubtitleLine = {
+          ...result,
+          id: INTERIM_LINE_ID,
+          opacity: 1,
+          isInterim: true
+        }
+        const updated = [...withoutInterim, interimLine]
         return updated.slice(-MAX_LINES)
       })
     })
@@ -30,6 +51,8 @@ function SubtitleOverlay(): JSX.Element {
       setLines((prev) =>
         prev
           .map((line) => {
+            // Don't fade interim lines
+            if (line.isInterim) return line
             const age = Date.now() - line.timestamp
             if (age > FADE_DURATION_MS) {
               return { ...line, opacity: Math.max(0, 1 - (age - FADE_DURATION_MS) / 2000) }
@@ -63,7 +86,7 @@ function SubtitleOverlay(): JSX.Element {
         <div
           key={line.id}
           style={{
-            background: 'rgba(0, 0, 0, 0.78)',
+            background: line.isInterim ? 'rgba(0, 0, 0, 0.65)' : 'rgba(0, 0, 0, 0.78)',
             borderRadius: '10px',
             padding: '10px 20px',
             marginBottom: '6px',
@@ -71,32 +94,46 @@ function SubtitleOverlay(): JSX.Element {
             transition: 'opacity 0.5s ease-out',
             backdropFilter: 'blur(8px)',
             WebkitBackdropFilter: 'blur(8px)',
-            borderLeft: `4px solid ${line.sourceLanguage === 'ja' ? '#4ade80' : '#60a5fa'}`
+            borderLeft: `4px solid ${
+              line.isInterim
+                ? '#94a3b8'
+                : line.sourceLanguage === 'ja'
+                  ? '#4ade80'
+                  : '#60a5fa'
+            }`
           }}
         >
           <div
             style={{
-              color: '#f0f0f0',
+              color: line.isInterim ? '#cbd5e1' : '#f0f0f0',
               fontSize: '30px',
               fontWeight: 600,
               lineHeight: 1.4,
-              textShadow: '0 1px 3px rgba(0,0,0,0.5)'
+              textShadow: '0 1px 3px rgba(0,0,0,0.5)',
+              fontStyle: line.isInterim ? 'italic' : 'normal'
             }}
           >
             {line.sourceText}
           </div>
-          <div
-            style={{
-              color: line.sourceLanguage === 'ja' ? '#93c5fd' : '#86efac',
-              fontSize: '28px',
-              fontWeight: 600,
-              lineHeight: 1.4,
-              marginTop: '2px',
-              textShadow: '0 1px 3px rgba(0,0,0,0.5)'
-            }}
-          >
-            {line.translatedText}
-          </div>
+          {line.translatedText && (
+            <div
+              style={{
+                color: line.isInterim
+                  ? '#94a3b8'
+                  : line.sourceLanguage === 'ja'
+                    ? '#93c5fd'
+                    : '#86efac',
+                fontSize: '28px',
+                fontWeight: 600,
+                lineHeight: 1.4,
+                marginTop: '2px',
+                textShadow: '0 1px 3px rgba(0,0,0,0.5)',
+                fontStyle: line.isInterim ? 'italic' : 'normal'
+              }}
+            >
+              {line.translatedText}
+            </div>
+          )}
         </div>
       ))}
     </div>

--- a/src/renderer/hooks/useAudioCapture.ts
+++ b/src/renderer/hooks/useAudioCapture.ts
@@ -14,8 +14,16 @@ export interface UseAudioCaptureReturn {
   volume: number // 0-1 for level meter
   start: () => Promise<void>
   stop: () => void
+  /** Callback for VAD-detected complete speech segments (legacy mode) */
   onAudioChunk: (callback: (chunk: Float32Array) => void) => void
+  /** Callback for periodic rolling buffer during speech (streaming mode) */
+  onStreamingChunk: (callback: (buffer: Float32Array) => void) => void
+  /** Callback when speech segment ends (streaming mode finalization) */
+  onSpeechSegmentEnd: (callback: (finalBuffer: Float32Array) => void) => void
 }
+
+const STREAMING_INTERVAL_MS = 2000
+const SAMPLE_RATE = 16000
 
 export function useAudioCapture(): UseAudioCaptureReturn {
   const [devices, setDevices] = useState<AudioDevice[]>([])
@@ -25,6 +33,13 @@ export function useAudioCapture(): UseAudioCaptureReturn {
 
   const vadRef = useRef<MicVAD | null>(null)
   const chunkCallbackRef = useRef<((chunk: Float32Array) => void) | null>(null)
+  const streamingCallbackRef = useRef<((buffer: Float32Array) => void) | null>(null)
+  const speechEndCallbackRef = useRef<((finalBuffer: Float32Array) => void) | null>(null)
+
+  // Rolling buffer state for streaming
+  const isSpeakingRef = useRef(false)
+  const rollingBufferRef = useRef<Float32Array[]>([])
+  const streamingTimerRef = useRef<ReturnType<typeof setInterval> | null>(null)
 
   // Enumerate audio input devices
   useEffect(() => {
@@ -47,6 +62,39 @@ export function useAudioCapture(): UseAudioCaptureReturn {
       }
     }
     enumerate()
+  }, [])
+
+  const getRollingBuffer = useCallback((): Float32Array | null => {
+    const frames = rollingBufferRef.current
+    if (frames.length === 0) return null
+    const totalLength = frames.reduce((sum, f) => sum + f.length, 0)
+    if (totalLength < SAMPLE_RATE * 0.5) return null // Need at least 0.5s
+    const buffer = new Float32Array(totalLength)
+    let offset = 0
+    for (const frame of frames) {
+      buffer.set(frame, offset)
+      offset += frame.length
+    }
+    return buffer
+  }, [])
+
+  const startStreamingTimer = useCallback(() => {
+    if (streamingTimerRef.current) return
+    streamingTimerRef.current = setInterval(() => {
+      if (!isSpeakingRef.current) return
+      const buffer = getRollingBuffer()
+      if (buffer) {
+        console.log(`[audio-capture] Streaming chunk: ${buffer.length} samples (${(buffer.length / SAMPLE_RATE).toFixed(1)}s)`)
+        streamingCallbackRef.current?.(buffer)
+      }
+    }, STREAMING_INTERVAL_MS)
+  }, [getRollingBuffer])
+
+  const stopStreamingTimer = useCallback(() => {
+    if (streamingTimerRef.current) {
+      clearInterval(streamingTimerRef.current)
+      streamingTimerRef.current = null
+    }
   }, [])
 
   const start = useCallback(async () => {
@@ -80,38 +128,71 @@ export function useAudioCapture(): UseAudioCaptureReturn {
         for (let i = 0; i < frame.length; i++) sum += frame[i] * frame[i]
         const rms = Math.sqrt(sum / frame.length)
         setVolume(Math.min(1, rms * 5))
+
+        // Accumulate frames for rolling buffer during speech
+        if (isSpeakingRef.current) {
+          rollingBufferRef.current.push(new Float32Array(frame))
+          // Cap rolling buffer at ~30 seconds to prevent memory growth
+          const maxFrames = (30 * SAMPLE_RATE) / frame.length
+          if (rollingBufferRef.current.length > maxFrames) {
+            rollingBufferRef.current = rollingBufferRef.current.slice(-Math.floor(maxFrames))
+          }
+        }
       },
       onSpeechEnd: (audio: Float32Array) => {
         // audio is 16kHz Float32Array from VAD
-        console.log(`[audio-capture] VAD speech segment: ${audio.length} samples (${(audio.length / 16000).toFixed(1)}s)`)
+        console.log(`[audio-capture] VAD speech segment: ${audio.length} samples (${(audio.length / SAMPLE_RATE).toFixed(1)}s)`)
+
+        // Finalize streaming with the VAD-provided segment
+        isSpeakingRef.current = false
+        speechEndCallbackRef.current?.(audio)
+        rollingBufferRef.current = []
+
+        // Also fire legacy callback
         chunkCallbackRef.current?.(audio)
       },
       onSpeechStart: () => {
         console.log('[audio-capture] VAD speech start')
+        isSpeakingRef.current = true
+        rollingBufferRef.current = []
       },
       onVADMisfire: () => {
         console.log('[audio-capture] VAD misfire (speech too short)')
+        isSpeakingRef.current = false
+        rollingBufferRef.current = []
       }
     })
 
     vadRef.current = vad
     vad.start()
+    startStreamingTimer()
     setIsCapturing(true)
-    console.log('[audio-capture] VAD started')
-  }, [selectedDevice, isCapturing])
+    console.log('[audio-capture] VAD started with streaming')
+  }, [selectedDevice, isCapturing, startStreamingTimer])
 
   const stop = useCallback(() => {
+    stopStreamingTimer()
     if (vadRef.current) {
       vadRef.current.destroy()
       vadRef.current = null
     }
+    isSpeakingRef.current = false
+    rollingBufferRef.current = []
     setIsCapturing(false)
     setVolume(0)
     console.log('[audio-capture] VAD stopped')
-  }, [])
+  }, [stopStreamingTimer])
 
   const onAudioChunk = useCallback((callback: (chunk: Float32Array) => void) => {
     chunkCallbackRef.current = callback
+  }, [])
+
+  const onStreamingChunk = useCallback((callback: (buffer: Float32Array) => void) => {
+    streamingCallbackRef.current = callback
+  }, [])
+
+  const onSpeechSegmentEnd = useCallback((callback: (finalBuffer: Float32Array) => void) => {
+    speechEndCallbackRef.current = callback
   }, [])
 
   return {
@@ -122,6 +203,8 @@ export function useAudioCapture(): UseAudioCaptureReturn {
     volume,
     start,
     stop,
-    onAudioChunk
+    onAudioChunk,
+    onStreamingChunk,
+    onSpeechSegmentEnd
   }
 }


### PR DESCRIPTION
## Description

Implements the Local Agreement algorithm (IJCNLP 2023) to reduce perceived latency from ~4-6s to ~2-3s by showing interim transcription results during speech.

### How it works
- During speech, audio is accumulated in a rolling buffer and sent to Whisper every 2 seconds
- Consecutive transcription results are compared via longest common prefix
- Only the agreed-upon prefix is "confirmed" and translated (avoids wasting API calls)
- Unconfirmed text is shown in a lighter, italic style as interim

### Changes
- **New** `src/pipeline/LocalAgreement.ts` — Agreement algorithm (~50 lines)
- **Modified** `TranslationPipeline.ts` — `processStreaming()` / `finalizeStreaming()` with processing lock
- **Modified** `useAudioCapture.ts` — Rolling buffer accumulation + periodic streaming callbacks
- **Modified** `SubtitleOverlay.tsx` — Interim vs confirmed text styling (WCAG AA contrast)
- **Modified** `main/index.ts` — Streaming IPC handlers + `toFloat32Array` helper extraction
- **Modified** preload — New IPC channels (`process-audio-streaming`, `finalize-streaming`, `interim-result`)
- **Modified** `types.ts` — `isInterim` field on `TranslationResult`

### Design decisions
- Streaming only works in cascade mode (STT + Translator); e2e mode uses existing VAD-based flow
- Translation is triggered only on confirmed text to minimize API usage
- Rolling buffer capped at 30 seconds to prevent memory growth
- Processing lock prevents race conditions between concurrent streaming and finalize calls

Closes #18