### PR TITLE
Fix #165, #171-176: Final audit fixes

### DIFF
--- a/src/engines/plugin-loader.ts
+++ b/src/engines/plugin-loader.ts
@@ -81,15 +81,18 @@ export async function loadPluginEngine(
   plugin: LoadedPlugin
 ): Promise<STTEngine | TranslatorEngine | E2ETranslationEngine> {
   const { resolve } = await import('path')
+  const { realpathSync } = await import('fs')
   const entryPath = resolve(plugin.path, plugin.manifest.entryPoint)
-
-  // Prevent path traversal — entry must be within plugin directory
-  if (!entryPath.startsWith(resolve(plugin.path))) {
-    throw new Error(`Plugin entry point escapes plugin directory: ${plugin.manifest.entryPoint}`)
-  }
 
   if (!existsSync(entryPath)) {
     throw new Error(`Plugin entry point not found: ${entryPath}`)
+  }
+
+  // Prevent symlink escapes — resolve real paths
+  const realEntry = realpathSync(entryPath)
+  const realPlugin = realpathSync(plugin.path)
+  if (!realEntry.startsWith(realPlugin)) {
+    throw new Error(`Plugin entry point escapes plugin directory via symlink: ${plugin.manifest.entryPoint}`)
   }
 
   console.warn(`[plugin-loader] Loading plugin "${plugin.manifest.name}" — plugins run with full system access`)

--- a/src/engines/translator/OpusMTTranslator.ts
+++ b/src/engines/translator/OpusMTTranslator.ts
@@ -20,6 +20,9 @@ export class OpusMTTranslator implements TranslatorEngine {
 
   async initialize(): Promise<void> {
     if (this.jaToEn && this.enToJa) return
+    // Reset both to ensure clean retry after partial failure
+    this.jaToEn = null
+    this.enToJa = null
 
     const { pipeline, env } = await import('@huggingface/transformers')
     env.cacheDir = join(app.getPath('userData'), 'models', 'transformers')

--- a/src/logger/SessionManager.ts
+++ b/src/logger/SessionManager.ts
@@ -53,7 +53,7 @@ function sessionFilePath(id: string): string {
 
 /** Create a new session and return its ID */
 export function createSession(engineMode: string): string {
-  const id = new Date().toISOString().replace(/[:.]/g, '-').slice(0, 19)
+  const id = new Date().toISOString().replace(/[:.]/g, '-').replace('Z', '')
   const data: SessionData = {
     metadata: {
       id,

--- a/src/pipeline/SpeakerTracker.ts
+++ b/src/pipeline/SpeakerTracker.ts
@@ -7,6 +7,7 @@
 
 const SPEAKER_CHANGE_GAP_MS = 2000
 const SPEAKER_COLORS = ['#60a5fa', '#4ade80', '#f472b6', '#facc15', '#a78bfa', '#fb923c']
+const SPEAKER_NAMES = ['A', 'B', 'C', 'D', 'E', 'F']
 
 export class SpeakerTracker {
   private currentSpeaker = 0
@@ -30,7 +31,7 @@ export class SpeakerTracker {
   }
 
   getSpeakerId(): string {
-    return `Speaker ${String.fromCharCode(65 + this.currentSpeaker)}`
+    return `Speaker ${SPEAKER_NAMES[this.currentSpeaker % SPEAKER_NAMES.length]}`
   }
 
   getColor(): string {

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -4,7 +4,6 @@ export interface ElectronAPI {
   processAudio: (audioData: number[]) => Promise<unknown>
   processAudioStreaming: (audioData: number[]) => Promise<unknown>
   finalizeStreaming: (audioData: number[]) => Promise<unknown>
-  sendTranslationResult: (data: unknown) => void
   onTranslationResult: (callback: (data: unknown) => void) => (() => void)
   onInterimResult: (callback: (data: unknown) => void) => (() => void)
   onStatusUpdate: (callback: (message: string) => void) => (() => void)

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -9,7 +9,6 @@ contextBridge.exposeInMainWorld('api', {
   finalizeStreaming: (audioData: number[]) => ipcRenderer.invoke('finalize-streaming', audioData),
 
   // Translation results
-  sendTranslationResult: (data: unknown) => ipcRenderer.send('translation-result', data),
   onTranslationResult: (callback: (data: unknown) => void) => {
     const handler = (_event: Electron.IpcRendererEvent, data: unknown): void => callback(data)
     ipcRenderer.on('translation-result', handler)

--- a/src/renderer/components/SettingsPanel.tsx
+++ b/src/renderer/components/SettingsPanel.tsx
@@ -169,7 +169,7 @@ function SettingsPanel(): JSX.Element {
       setStatus('Starting pipeline...')
 
       // Persist settings (#49)
-      window.api.saveSettings({
+      await window.api.saveSettings({
         translationEngine: engineMode,
         googleApiKey: apiKey,
         deeplApiKey,
@@ -267,15 +267,19 @@ function SettingsPanel(): JSX.Element {
   }
 
   const handleStop = async (): Promise<void> => {
-    audio.stop()
-    stopSessionTimer()
-    const result = await window.api.pipelineStop()
-    setIsRunning(false)
-    setStatus(result.logPath ? `Saved: ${result.logPath}` : 'Stopped')
+    try {
+      audio.stop()
+      stopSessionTimer()
+      const result = await window.api.pipelineStop()
+      setStatus(result.logPath ? `Saved: ${result.logPath}` : 'Stopped')
 
-    // Offer summary generation if transcript exists
-    if (result.logPath) {
-      setLastTranscriptPath(result.logPath)
+      if (result.logPath) {
+        setLastTranscriptPath(result.logPath)
+      }
+    } catch (err) {
+      setStatus(`Stop error: ${err}`)
+    } finally {
+      setIsRunning(false)
     }
   }
 


### PR DESCRIPTION
## Summary
- Fix #171: SpeakerTracker uses bounded name array instead of fromCharCode
- Fix #172: Session ID includes milliseconds to prevent collision
- Fix #173: await saveSettings before starting pipeline
- Fix #174: handleStop wrapped in try-finally for isRunning reset
- Fix #175: Remove unused sendTranslationResult from preload
- Fix #176: Plugin loader uses realpathSync to prevent symlink escapes
- Fix #165: OpusMTTranslator resets both pipelines before retry

## Test Plan
- [x] npm run build passes
- [x] npm test — 32 tests pass