### PR TITLE
#237 KV cache quantization for TranslateGemma

### DIFF
--- a/src/engines/translator/SLMTranslator.ts
+++ b/src/engines/translator/SLMTranslator.ts
@@ -21,10 +21,12 @@ export class SLMTranslator implements TranslatorEngine {
   private nextId = 0
   private onProgress?: (message: string) => void
   private variant: string
+  private kvCacheQuant: boolean
 
-  constructor(options?: { onProgress?: (message: string) => void; variant?: string }) {
+  constructor(options?: { onProgress?: (message: string) => void; variant?: string; kvCacheQuant?: boolean }) {
     this.onProgress = options?.onProgress
     this.variant = options?.variant ?? 'Q4_K_M'
+    this.kvCacheQuant = options?.kvCacheQuant ?? true
   }
 
   async initialize(): Promise<void> {
@@ -78,7 +80,7 @@ export class SLMTranslator implements TranslatorEngine {
       }
 
       this.worker!.on('message', initHandler)
-      this.worker!.postMessage({ type: 'init', modelPath })
+      this.worker!.postMessage({ type: 'init', modelPath, kvCacheQuant: this.kvCacheQuant })
     })
 
     // Guard: worker may have been killed during init timeout (#205)

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -149,7 +149,8 @@ function initPipeline(): void {
     onProgress: (msg) => mainWindow?.webContents.send('status-update', msg)
   }))
   pipeline.registerTranslator('slm-translate', () => new SLMTranslator({
-    onProgress: (msg) => mainWindow?.webContents.send('status-update', msg)
+    onProgress: (msg) => mainWindow?.webContents.send('status-update', msg),
+    kvCacheQuant: store.get('slmKvCacheQuant')
   }))
   // Auto-register discovered plugins (#145)
   for (const plugin of discoverPlugins()) {
@@ -480,7 +481,8 @@ ipcMain.handle('get-settings', () => {
     sttEngine: store.get('sttEngine'),
     selectedMicrophone: store.get('selectedMicrophone'),
     selectedDisplay: store.get('selectedDisplay'),
-    subtitleSettings: store.get('subtitleSettings')
+    subtitleSettings: store.get('subtitleSettings'),
+    slmKvCacheQuant: store.get('slmKvCacheQuant')
   }
 })
 
@@ -531,7 +533,8 @@ ipcMain.handle('generate-summary', async (_event, transcriptPath: string) => {
 
     // Use SLM translator for summarization
     const slm = new SLMTranslator({
-      onProgress: (msg) => mainWindow?.webContents.send('status-update', msg)
+      onProgress: (msg) => mainWindow?.webContents.send('status-update', msg),
+      kvCacheQuant: store.get('slmKvCacheQuant')
     })
 
     try {

--- a/src/main/slm-worker.ts
+++ b/src/main/slm-worker.ts
@@ -3,7 +3,7 @@
  * Runs in a separate process to avoid blocking the main process.
  *
  * IPC protocol:
- *   Main → Worker: { type: 'init', modelPath: string }
+ *   Main → Worker: { type: 'init', modelPath: string, kvCacheQuant?: boolean }
  *   Main → Worker: { type: 'translate', id: string, text: string, from: string, to: string }
  *   Main → Worker: { type: 'summarize', id: string, transcript: string }
  *   Main → Worker: { type: 'dispose' }
@@ -22,11 +22,17 @@ let model: any = null
 let context: any = null
 let requestQueue: Promise<void> = Promise.resolve()
 
-async function handleInit(modelPath: string): Promise<void> {
+async function handleInit(modelPath: string, kvCacheQuant?: boolean): Promise<void> {
   const { getLlama } = await import('node-llama-cpp')
   llama = await getLlama({ gpu: 'auto' })
   model = await llama.loadModel({ modelPath })
-  context = await model.createContext()
+
+  const contextOptions: Record<string, unknown> = {}
+  if (kvCacheQuant) {
+    contextOptions.experimentalKvCacheKeyType = 'Q8_0'
+    contextOptions.experimentalKvCacheValueType = 'Q8_0'
+  }
+  context = await model.createContext(contextOptions)
 
   process.parentPort!.postMessage({ type: 'ready' })
 }
@@ -149,7 +155,7 @@ process.parentPort!.on('message', (e: { data: any }) => {
     try {
       switch (msg.type) {
         case 'init':
-          await handleInit(msg.modelPath)
+          await handleInit(msg.modelPath, msg.kvCacheQuant)
           break
         case 'translate':
           await handleTranslate(msg.id, msg.text, msg.from, msg.to)

--- a/src/main/store.ts
+++ b/src/main/store.ts
@@ -41,6 +41,8 @@ export interface AppSettings {
   activeSession: ActiveSession | null
   subtitleSettings: SubtitleSettings
   sessionLogs: SessionLog[]
+  /** Enable KV cache quantization (Q8_0) for TranslateGemma to reduce VRAM usage ~50% */
+  slmKvCacheQuant: boolean
 }
 
 export const store = new Store<AppSettings>({
@@ -64,6 +66,7 @@ export const store = new Store<AppSettings>({
       backgroundOpacity: 78,
       position: 'bottom'
     },
-    sessionLogs: []
+    sessionLogs: [],
+    slmKvCacheQuant: true
   }
 })

--- a/src/renderer/components/SettingsPanel.tsx
+++ b/src/renderer/components/SettingsPanel.tsx
@@ -48,6 +48,9 @@ function SettingsPanel(): JSX.Element {
   // Session history (#144)
   const [sessions, setSessions] = useState<Array<{ id: string; startedAt: number; engineMode: string; entryCount: number }>>([])
 
+  // KV cache quantization (#237)
+  const [slmKvCacheQuant, setSlmKvCacheQuant] = useState(true)
+
   // Meeting summary (#124)
   const [lastTranscriptPath, setLastTranscriptPath] = useState<string | null>(null)
   const [summaryText, setSummaryText] = useState<string | null>(null)
@@ -95,6 +98,7 @@ function SettingsPanel(): JSX.Element {
       if (s.microsoftRegion) setMicrosoftRegion(s.microsoftRegion as string)
       if (s.selectedMicrophone) audio.setSelectedDevice(s.selectedMicrophone as string)
       if (s.sttEngine) setSttEngine(s.sttEngine as 'whisper-local' | 'mlx-whisper' | 'moonshine')
+      if (s.slmKvCacheQuant !== undefined) setSlmKvCacheQuant(s.slmKvCacheQuant as boolean)
       if (s.subtitleSettings) {
         const sub = s.subtitleSettings as Record<string, unknown>
         if (sub.fontSize) setSubtitleFontSize(sub.fontSize as number)
@@ -193,7 +197,8 @@ function SettingsPanel(): JSX.Element {
         microsoftRegion,
         selectedMicrophone: audio.selectedDevice,
         selectedDisplay,
-        sttEngine
+        sttEngine,
+        slmKvCacheQuant
       }), 10_000, 'saveSettings')
 
       // Resolve auto mode to concrete engine
@@ -586,6 +591,22 @@ function SettingsPanel(): JSX.Element {
             )}
           </div>
         </label>
+        {engineMode === 'offline-slm' && (
+          <label style={{ ...radioLabelStyle, paddingLeft: '24px' }}>
+            <input
+              type="checkbox"
+              checked={slmKvCacheQuant}
+              onChange={(e) => setSlmKvCacheQuant(e.target.checked)}
+              disabled={isRunning || isStarting}
+            />
+            <div>
+              <div style={{ fontWeight: 500, fontSize: '12px' }}>KV cache quantization (Q8_0)</div>
+              <div style={{ fontSize: '11px', color: '#94a3b8' }}>
+                Reduces VRAM usage ~50% with negligible quality impact
+              </div>
+            </div>
+          </label>
+        )}
       </Section>
 
       {/* API Keys */}


### PR DESCRIPTION
## Description

Enable KV cache quantization (Q8_0) in node-llama-cpp's `createContext()` to reduce VRAM usage ~50% with negligible quality impact.

### Changes
- **slm-worker.ts**: Pass `experimentalKvCacheKeyType` / `experimentalKvCacheValueType` as `Q8_0` to `model.createContext()` when enabled
- **SLMTranslator.ts**: Accept `kvCacheQuant` option and forward it via IPC init message
- **store.ts**: Add `slmKvCacheQuant` setting (default: `true`)
- **index.ts**: Read setting from store and pass to both translation and summarization SLMTranslator instances
- **SettingsPanel.tsx**: Add checkbox toggle under TranslateGemma engine option

Closes #237