### PR TITLE
#236 Support TranslateGemma 12B for higher quality translation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,7 +29,7 @@ npm install          # Install deps (postinstall fixes whisper-node-addon)
 - whisper-node-addon (whisper.cpp native binding)
 - mlx-whisper (Python subprocess bridge, Apple Silicon)
 - Moonshine AI (ONNX via @huggingface/transformers)
-- node-llama-cpp (TranslateGemma 4B, meeting summaries, UtilityProcess)
+- node-llama-cpp (TranslateGemma 4B/12B, meeting summaries, UtilityProcess)
 - @ricky0123/vad-web (Silero VAD)
 - Multiple translation backends (Google, DeepL, Azure, Gemini, OPUS-MT, TranslateGemma)
 - Local Agreement algorithm for streaming subtitle display
@@ -65,7 +65,7 @@ live-translate/
 │   │       ├── GeminiTranslator.ts
 │   │       ├── MicrosoftTranslator.ts
 │   │       ├── OpusMTTranslator.ts
-│   │       ├── SLMTranslator.ts         # TranslateGemma 4B (UtilityProcess)
+│   │       ├── SLMTranslator.ts         # TranslateGemma 4B/12B (UtilityProcess)
 │   │       └── ApiRotationController.ts # Multi-provider rotation
 │   ├── pipeline/
 │   │   ├── TranslationPipeline.ts  # Orchestration, streaming, auto-recovery

--- a/src/engines/model-downloader.ts
+++ b/src/engines/model-downloader.ts
@@ -36,7 +36,10 @@ export interface GGUFVariant {
   label: string
 }
 
-export const GGUF_VARIANTS: Record<string, GGUFVariant> = {
+/** Model size identifier for TranslateGemma */
+export type SLMModelSize = '4b' | '12b'
+
+export const GGUF_VARIANTS_4B: Record<string, GGUFVariant> = {
   'Q4_K_M': {
     filename: 'translategemma-4b-it-Q4_K_M.gguf',
     url: 'https://huggingface.co/google/translategemma-4b-it-GGUF/resolve/main/translategemma-4b-it-Q4_K_M.gguf',
@@ -56,6 +59,35 @@ export const GGUF_VARIANTS: Record<string, GGUFVariant> = {
     label: 'Q2_K (Smallest, ~1.4GB)'
   }
 }
+
+export const GGUF_VARIANTS_12B: Record<string, GGUFVariant> = {
+  'Q4_K_M': {
+    filename: 'translategemma-12b-it-Q4_K_M.gguf',
+    url: 'https://huggingface.co/bullerwins/translategemma-12b-it-GGUF/resolve/main/translategemma-12b-it-Q4_K_M.gguf',
+    sizeMB: 7300,
+    label: 'Q4_K_M (Recommended, ~7.3GB)'
+  },
+  'Q3_K_L': {
+    filename: 'translategemma-12b-it-Q3_K_L.gguf',
+    url: 'https://huggingface.co/bullerwins/translategemma-12b-it-GGUF/resolve/main/translategemma-12b-it-Q3_K_L.gguf',
+    sizeMB: 6480,
+    label: 'Q3_K_L (Smallest, ~6.5GB)'
+  },
+  'Q8_0': {
+    filename: 'translategemma-12b-it-Q8_0.gguf',
+    url: 'https://huggingface.co/bullerwins/translategemma-12b-it-GGUF/resolve/main/translategemma-12b-it-Q8_0.gguf',
+    sizeMB: 12500,
+    label: 'Q8_0 (Best quality, ~12.5GB)'
+  }
+}
+
+/** Get GGUF variants for the given model size */
+export function getGGUFVariants(modelSize: SLMModelSize): Record<string, GGUFVariant> {
+  return modelSize === '12b' ? GGUF_VARIANTS_12B : GGUF_VARIANTS_4B
+}
+
+/** @deprecated Use getGGUFVariants() instead. Kept for backward compatibility. */
+export const GGUF_VARIANTS: Record<string, GGUFVariant> = GGUF_VARIANTS_4B
 
 // GGUF download lock uses shared activeDownloads map
 

--- a/src/engines/translator/SLMTranslator.ts
+++ b/src/engines/translator/SLMTranslator.ts
@@ -1,7 +1,8 @@
 import { utilityProcess } from 'electron'
 import { join } from 'path'
 import type { TranslatorEngine, Language, TranslateContext } from '../types'
-import { getGGUFDir, downloadGGUF, GGUF_VARIANTS } from '../model-downloader'
+import { getGGUFDir, downloadGGUF, getGGUFVariants } from '../model-downloader'
+import type { SLMModelSize } from '../model-downloader'
 
 const TRANSLATE_TIMEOUT_MS = 30_000
 
@@ -13,7 +14,7 @@ interface PendingRequest {
 
 export class SLMTranslator implements TranslatorEngine {
   readonly id = 'slm-translate'
-  readonly name = 'TranslateGemma 4B (Offline)'
+  readonly name: string
   readonly isOffline = true
 
   private worker: Electron.UtilityProcess | null = null
@@ -21,24 +22,28 @@ export class SLMTranslator implements TranslatorEngine {
   private nextId = 0
   private onProgress?: (message: string) => void
   private variant: string
+  private modelSize: SLMModelSize
   private kvCacheQuant: boolean
 
-  constructor(options?: { onProgress?: (message: string) => void; variant?: string; kvCacheQuant?: boolean }) {
+  constructor(options?: { onProgress?: (message: string) => void; variant?: string; modelSize?: SLMModelSize; kvCacheQuant?: boolean }) {
     this.onProgress = options?.onProgress
+    this.modelSize = options?.modelSize ?? '4b'
     this.variant = options?.variant ?? 'Q4_K_M'
     this.kvCacheQuant = options?.kvCacheQuant ?? true
+    this.name = `TranslateGemma ${this.modelSize.toUpperCase()} (Offline)`
   }
 
   async initialize(): Promise<void> {
     if (this.worker) return
 
     // Download model if needed
-    const variantConfig = GGUF_VARIANTS[this.variant] ?? GGUF_VARIANTS['Q4_K_M']!
+    const variants = getGGUFVariants(this.modelSize)
+    const variantConfig = variants[this.variant] ?? variants['Q4_K_M']!
     const modelPath = join(getGGUFDir(), variantConfig.filename)
     await downloadGGUF(variantConfig.filename, variantConfig.url, this.onProgress, variantConfig.sha256)
 
     // Spawn UtilityProcess
-    this.onProgress?.('Starting TranslateGemma worker...')
+    this.onProgress?.(`Starting TranslateGemma ${this.modelSize.toUpperCase()} worker...`)
     const workerPath = join(__dirname, 'slm-worker.js')
 
     this.worker = utilityProcess.fork(workerPath)
@@ -70,7 +75,7 @@ export class SLMTranslator implements TranslatorEngine {
         if (msg.type === 'ready') {
           clearTimeout(timeout)
           this.worker?.removeListener('message', initHandler)
-          this.onProgress?.('TranslateGemma model loaded')
+          this.onProgress?.(`TranslateGemma ${this.modelSize.toUpperCase()} model loaded`)
           resolve()
         } else if (msg.type === 'error') {
           clearTimeout(timeout)

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -14,7 +14,8 @@ import { ApiRotationController } from '../engines/translator/ApiRotationControll
 import type { ProviderConfig, QuotaStore } from '../engines/translator/ApiRotationController'
 import { SLMTranslator } from '../engines/translator/SLMTranslator'
 import { detectGpu } from '../engines/gpu-detector'
-import { isGGUFDownloaded, GGUF_VARIANTS } from '../engines/model-downloader'
+import { isGGUFDownloaded, getGGUFVariants } from '../engines/model-downloader'
+import type { SLMModelSize } from '../engines/model-downloader'
 import { listPlugins, discoverPlugins, loadPluginEngine } from '../engines/plugin-loader'
 import { TranscriptLogger } from '../logger/TranscriptLogger'
 import * as SessionManager from '../logger/SessionManager'
@@ -150,7 +151,8 @@ function initPipeline(): void {
   }))
   pipeline.registerTranslator('slm-translate', () => new SLMTranslator({
     onProgress: (msg) => mainWindow?.webContents.send('status-update', msg),
-    kvCacheQuant: store.get('slmKvCacheQuant')
+    kvCacheQuant: store.get('slmKvCacheQuant'),
+    modelSize: store.get('slmModelSize')
   }))
   // Auto-register discovered plugins (#145)
   for (const plugin of discoverPlugins()) {
@@ -482,7 +484,8 @@ ipcMain.handle('get-settings', () => {
     selectedMicrophone: store.get('selectedMicrophone'),
     selectedDisplay: store.get('selectedDisplay'),
     subtitleSettings: store.get('subtitleSettings'),
-    slmKvCacheQuant: store.get('slmKvCacheQuant')
+    slmKvCacheQuant: store.get('slmKvCacheQuant'),
+    slmModelSize: store.get('slmModelSize')
   }
 })
 
@@ -534,7 +537,8 @@ ipcMain.handle('generate-summary', async (_event, transcriptPath: string) => {
     // Use SLM translator for summarization
     const slm = new SLMTranslator({
       onProgress: (msg) => mainWindow?.webContents.send('status-update', msg),
-      kvCacheQuant: store.get('slmKvCacheQuant')
+      kvCacheQuant: store.get('slmKvCacheQuant'),
+      modelSize: store.get('slmModelSize')
     })
 
     try {
@@ -568,8 +572,9 @@ ipcMain.handle('export-session', (_event, id: string, format: 'text' | 'srt' | '
 })
 
 // #133: GGUF model status
-ipcMain.handle('get-gguf-variants', () => {
-  return Object.entries(GGUF_VARIANTS).map(([key, v]) => ({
+ipcMain.handle('get-gguf-variants', (_event, modelSize?: SLMModelSize) => {
+  const variants = getGGUFVariants(modelSize ?? store.get('slmModelSize'))
+  return Object.entries(variants).map(([key, v]) => ({
     key,
     label: v.label,
     filename: v.filename,

--- a/src/main/store.ts
+++ b/src/main/store.ts
@@ -43,6 +43,8 @@ export interface AppSettings {
   sessionLogs: SessionLog[]
   /** Enable KV cache quantization (Q8_0) for TranslateGemma to reduce VRAM usage ~50% */
   slmKvCacheQuant: boolean
+  /** TranslateGemma model size: 4B (lighter) or 12B (higher quality) */
+  slmModelSize: '4b' | '12b'
 }
 
 export const store = new Store<AppSettings>({
@@ -67,6 +69,7 @@ export const store = new Store<AppSettings>({
       position: 'bottom'
     },
     sessionLogs: [],
-    slmKvCacheQuant: true
+    slmKvCacheQuant: true,
+    slmModelSize: '4b'
   }
 })

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -24,7 +24,7 @@ export interface ElectronAPI {
   searchSessions: (query: string) => Promise<Array<{ sessionId: string; matches: unknown[] }>>
   deleteSession: (id: string) => Promise<{ success: boolean }>
   exportSession: (id: string, format: string) => Promise<{ content?: string; ext?: string; error?: string }>
-  getGgufVariants: () => Promise<Array<{ key: string; label: string; filename: string; sizeMB: number; downloaded: boolean }>>
+  getGgufVariants: (modelSize?: string) => Promise<Array<{ key: string; label: string; filename: string; sizeMB: number; downloaded: boolean }>>
   listPlugins: () => Promise<Array<{ name: string; version: string; engineType: string; engineId: string }>>
   getSessionLogs: () => Promise<Array<{ startedAt: number; endedAt: number; engineMode: string; durationMs: number }>>
   generateSummary: (transcriptPath: string) => Promise<{ summary?: string; error?: string }>

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -51,7 +51,7 @@ contextBridge.exposeInMainWorld('api', {
   exportSession: (id: string, format: string) => ipcRenderer.invoke('export-session', id, format),
 
   // GGUF model management (#133)
-  getGgufVariants: () => ipcRenderer.invoke('get-gguf-variants'),
+  getGgufVariants: (modelSize?: string) => ipcRenderer.invoke('get-gguf-variants', modelSize),
 
   // Plugin management (#127)
   listPlugins: () => ipcRenderer.invoke('list-plugins'),

--- a/src/renderer/components/SettingsPanel.tsx
+++ b/src/renderer/components/SettingsPanel.tsx
@@ -51,6 +51,9 @@ function SettingsPanel(): JSX.Element {
   // KV cache quantization (#237)
   const [slmKvCacheQuant, setSlmKvCacheQuant] = useState(true)
 
+  // Model size (#236)
+  const [slmModelSize, setSlmModelSize] = useState<'4b' | '12b'>('4b')
+
   // Meeting summary (#124)
   const [lastTranscriptPath, setLastTranscriptPath] = useState<string | null>(null)
   const [summaryText, setSummaryText] = useState<string | null>(null)
@@ -99,6 +102,7 @@ function SettingsPanel(): JSX.Element {
       if (s.selectedMicrophone) audio.setSelectedDevice(s.selectedMicrophone as string)
       if (s.sttEngine) setSttEngine(s.sttEngine as 'whisper-local' | 'mlx-whisper' | 'moonshine')
       if (s.slmKvCacheQuant !== undefined) setSlmKvCacheQuant(s.slmKvCacheQuant as boolean)
+      if (s.slmModelSize) setSlmModelSize(s.slmModelSize as '4b' | '12b')
       if (s.subtitleSettings) {
         const sub = s.subtitleSettings as Record<string, unknown>
         if (sub.fontSize) setSubtitleFontSize(sub.fontSize as number)
@@ -198,7 +202,8 @@ function SettingsPanel(): JSX.Element {
         selectedMicrophone: audio.selectedDevice,
         selectedDisplay,
         sttEngine,
-        slmKvCacheQuant
+        slmKvCacheQuant,
+        slmModelSize
       }), 10_000, 'saveSettings')
 
       // Resolve auto mode to concrete engine
@@ -582,8 +587,8 @@ function SettingsPanel(): JSX.Element {
             disabled={isRunning || isStarting}
           />
           <div>
-            <div style={{ fontWeight: 500 }}>TranslateGemma 4B</div>
-            <div style={{ fontSize: '12px', color: '#94a3b8' }}>JA↔EN, GPU-accelerated, ~2.6GB model download</div>
+            <div style={{ fontWeight: 500 }}>TranslateGemma</div>
+            <div style={{ fontSize: '12px', color: '#94a3b8' }}>JA↔EN, GPU-accelerated offline translation</div>
             {engineMode === 'offline-slm' && gpuInfo && !gpuInfo.hasGpu && (
               <div style={{ fontSize: '11px', color: '#f59e0b', marginTop: '2px' }}>
                 No GPU detected — translation may be slow on CPU-only systems
@@ -592,20 +597,51 @@ function SettingsPanel(): JSX.Element {
           </div>
         </label>
         {engineMode === 'offline-slm' && (
-          <label style={{ ...radioLabelStyle, paddingLeft: '24px' }}>
-            <input
-              type="checkbox"
-              checked={slmKvCacheQuant}
-              onChange={(e) => setSlmKvCacheQuant(e.target.checked)}
-              disabled={isRunning || isStarting}
-            />
-            <div>
-              <div style={{ fontWeight: 500, fontSize: '12px' }}>KV cache quantization (Q8_0)</div>
-              <div style={{ fontSize: '11px', color: '#94a3b8' }}>
-                Reduces VRAM usage ~50% with negligible quality impact
-              </div>
+          <>
+            <div style={{ paddingLeft: '24px', display: 'flex', flexDirection: 'column', gap: '2px' }}>
+              <div style={{ fontSize: '11px', fontWeight: 600, color: '#94a3b8', marginBottom: '2px' }}>Model Size</div>
+              <label style={radioLabelStyle}>
+                <input
+                  type="radio"
+                  name="slm-model-size"
+                  checked={slmModelSize === '4b'}
+                  onChange={() => setSlmModelSize('4b')}
+                  disabled={isRunning || isStarting}
+                />
+                <div>
+                  <div style={{ fontWeight: 500, fontSize: '12px' }}>4B (Faster, ~2.6GB)</div>
+                  <div style={{ fontSize: '11px', color: '#94a3b8' }}>Good quality, runs on most GPUs</div>
+                </div>
+              </label>
+              <label style={radioLabelStyle}>
+                <input
+                  type="radio"
+                  name="slm-model-size"
+                  checked={slmModelSize === '12b'}
+                  onChange={() => setSlmModelSize('12b')}
+                  disabled={isRunning || isStarting}
+                />
+                <div>
+                  <div style={{ fontWeight: 500, fontSize: '12px' }}>12B (Higher quality, ~7.3GB)</div>
+                  <div style={{ fontSize: '11px', color: '#94a3b8' }}>Best offline quality, requires M3 Pro+ or 8GB+ VRAM</div>
+                </div>
+              </label>
             </div>
-          </label>
+            <label style={{ ...radioLabelStyle, paddingLeft: '24px' }}>
+              <input
+                type="checkbox"
+                checked={slmKvCacheQuant}
+                onChange={(e) => setSlmKvCacheQuant(e.target.checked)}
+                disabled={isRunning || isStarting}
+              />
+              <div>
+                <div style={{ fontWeight: 500, fontSize: '12px' }}>KV cache quantization (Q8_0)</div>
+                <div style={{ fontSize: '11px', color: '#94a3b8' }}>
+                  Reduces VRAM usage ~50% with negligible quality impact
+                </div>
+              </div>
+            </label>
+          </>
         )}
       </Section>
 


### PR DESCRIPTION
## Description

Add TranslateGemma 12B as a translation engine option alongside the existing 4B model. The 12B model offers significantly better translation quality (MetricX 3.60 vs 5.32 for 4B) while remaining feasible on M3 Pro+ with Q4_K_M quantization (~7.3GB).

### Changes

- **model-downloader.ts**: Add `GGUF_VARIANTS_12B` with Q4_K_M (~7.3GB), Q3_K_L (~6.5GB), Q8_0 (~12.5GB) from `bullerwins/translategemma-12b-it-GGUF`. Add `getGGUFVariants(modelSize)` helper. Keep `GGUF_VARIANTS` as deprecated alias for backward compat.
- **store.ts**: Add `slmModelSize: '4b' | '12b'` setting (default `'4b'`)
- **SLMTranslator.ts**: Accept `modelSize` option, select correct variant set, reflect model size in engine name and status messages
- **main/index.ts**: Pass `slmModelSize` from store to SLMTranslator. Update `get-gguf-variants` handler to return variants for selected model size.
- **preload**: Update `getGgufVariants` to accept optional `modelSize` parameter
- **SettingsPanel.tsx**: Add model size radio selector (4B / 12B) under TranslateGemma section with size info and hardware requirements
- **AGENTS.md**: Update references from "4B" to "4B/12B"

### Notes

- 12B uses the same Gemma prompt format as 4B — no changes needed in `slm-worker.ts`
- Default remains 4B for backward compatibility
- 12B GGUF source: `bullerwins/translategemma-12b-it-GGUF` (verified filenames via HuggingFace)

Closes #236