### PR TITLE
#240 Add glossary and context-aware translation

### DIFF
--- a/src/engines/translator/GeminiTranslator.ts
+++ b/src/engines/translator/GeminiTranslator.ts
@@ -1,4 +1,4 @@
-import type { TranslatorEngine, Language } from '../types'
+import type { TranslatorEngine, Language, TranslateContext } from '../types'
 
 const GEMINI_API_URL =
   'https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent'
@@ -32,11 +32,28 @@ export class GeminiTranslator implements TranslatorEngine {
     this.initialized = true
   }
 
-  async translate(text: string, from: Language, to: Language): Promise<string> {
+  async translate(text: string, from: Language, to: Language, context?: TranslateContext): Promise<string> {
     if (!text.trim()) return ''
     if (from === to) return text
 
-    const prompt = `Translate the following ${LANG_NAMES[from]} text to ${LANG_NAMES[to]}. Output ONLY the translated text, nothing else.\n\n${text}`
+    // Build context-enhanced prompt
+    const contextParts: string[] = []
+    if (context?.glossary && context.glossary.length > 0) {
+      const entries = context.glossary.map((g) => `  "${g.source}" → "${g.target}"`).join('\n')
+      contextParts.push(`Use these fixed translations for specific terms:\n${entries}`)
+    }
+    if (context?.previousSegments && context.previousSegments.length > 0) {
+      const history = context.previousSegments
+        .map((s) => `  ${s.source} → ${s.translated}`)
+        .join('\n')
+      contextParts.push(`Previous translations for context:\n${history}`)
+    }
+    if (context?.speakerId) {
+      contextParts.push(`Current speaker: ${context.speakerId}. Maintain consistent style.`)
+    }
+    const contextSection = contextParts.length > 0 ? contextParts.join('\n\n') + '\n\n' : ''
+
+    const prompt = `${contextSection}Translate the following ${LANG_NAMES[from]} text to ${LANG_NAMES[to]}. Output ONLY the translated text, nothing else.\n\n${text}`
 
     const controller = new AbortController()
     const timeout = setTimeout(() => controller.abort(), this.timeoutMs)

--- a/src/engines/translator/SLMTranslator.ts
+++ b/src/engines/translator/SLMTranslator.ts
@@ -120,7 +120,7 @@ export class SLMTranslator implements TranslatorEngine {
     })
   }
 
-  async translate(text: string, from: Language, to: Language, _context?: TranslateContext): Promise<string> {
+  async translate(text: string, from: Language, to: Language, context?: TranslateContext): Promise<string> {
     if (!text.trim()) return ''
     if (from === to) return text
     if (!this.worker) {
@@ -136,7 +136,7 @@ export class SLMTranslator implements TranslatorEngine {
       }, TRANSLATE_TIMEOUT_MS)
 
       this.pending.set(id, { resolve, reject, timer })
-      this.worker!.postMessage({ type: 'translate', id, text, from, to })
+      this.worker!.postMessage({ type: 'translate', id, text, from, to, context })
     })
   }
 

--- a/src/engines/types.ts
+++ b/src/engines/types.ts
@@ -96,10 +96,20 @@ export interface E2ETranslationEngine {
   dispose(): Promise<void>
 }
 
+/** A glossary entry mapping a source term to its fixed translation */
+export interface GlossaryEntry {
+  source: string
+  target: string
+}
+
 /** Context passed to translators that support context-aware translation */
 export interface TranslateContext {
   /** Previous confirmed translation segments for coherence */
-  previousSegments: Array<{ source: string; translated: string }>
+  previousSegments: Array<{ source: string; translated: string; speakerId?: string }>
+  /** Glossary terms that must use fixed translations */
+  glossary?: GlossaryEntry[]
+  /** Current speaker identifier for style adaptation */
+  speakerId?: string
 }
 
 /** Pipeline mode */

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -289,6 +289,10 @@ ipcMain.handle('pipeline-start', async (_event, config: PipelineStartConfig) => 
       throw err
     }
 
+    // Load glossary terms from store
+    const glossaryTerms = store.get('glossaryTerms') || []
+    pipeline!.setGlossary(glossaryTerms)
+
     // Start logger
     logger = new TranscriptLogger((msg) => mainWindow?.webContents.send('status-update', msg))
     const sessionLabel = config.mode === 'e2e'
@@ -485,7 +489,8 @@ ipcMain.handle('get-settings', () => {
     selectedDisplay: store.get('selectedDisplay'),
     subtitleSettings: store.get('subtitleSettings'),
     slmKvCacheQuant: store.get('slmKvCacheQuant'),
-    slmModelSize: store.get('slmModelSize')
+    slmModelSize: store.get('slmModelSize'),
+    glossaryTerms: store.get('glossaryTerms') || []
   }
 })
 
@@ -498,6 +503,15 @@ ipcMain.handle('save-subtitle-settings', (_event, settings: Record<string, unkno
 ipcMain.handle('save-settings', (_event, settings: Record<string, unknown>) => {
   for (const [key, value] of Object.entries(settings)) {
     store.set(key as keyof import('./store').AppSettings, value as never)
+  }
+})
+
+// Glossary terms persistence (#240)
+ipcMain.handle('save-glossary', (_event, terms: Array<{ source: string; target: string }>) => {
+  store.set('glossaryTerms', terms)
+  // Update running pipeline glossary in real-time
+  if (pipeline) {
+    pipeline.setGlossary(terms)
   }
 })
 

--- a/src/main/slm-worker.ts
+++ b/src/main/slm-worker.ts
@@ -37,11 +37,51 @@ async function handleInit(modelPath: string, kvCacheQuant?: boolean): Promise<vo
   process.parentPort!.postMessage({ type: 'ready' })
 }
 
+/** Build context sections for the translation prompt */
+function buildContextPrompt(ctx?: {
+  previousSegments?: Array<{ source: string; translated: string; speakerId?: string }>
+  glossary?: Array<{ source: string; target: string }>
+  speakerId?: string
+}): string {
+  if (!ctx) return ''
+
+  const parts: string[] = []
+
+  // Glossary terms
+  if (ctx.glossary && ctx.glossary.length > 0) {
+    const entries = ctx.glossary.map((g) => `  "${g.source}" → "${g.target}"`).join('\n')
+    parts.push(`Use these fixed translations for specific terms:\n${entries}`)
+  }
+
+  // Previous segments for coherence
+  if (ctx.previousSegments && ctx.previousSegments.length > 0) {
+    const history = ctx.previousSegments
+      .map((s) => {
+        const speaker = s.speakerId ? ` [${s.speakerId}]` : ''
+        return `  ${s.source}${speaker} → ${s.translated}`
+      })
+      .join('\n')
+    parts.push(`Previous translations for context:\n${history}`)
+  }
+
+  // Speaker hint
+  if (ctx.speakerId) {
+    parts.push(`Current speaker: ${ctx.speakerId}. Maintain consistent style for this speaker.`)
+  }
+
+  return parts.length > 0 ? parts.join('\n\n') + '\n\n' : ''
+}
+
 async function handleTranslate(
   id: string,
   text: string,
   from: string,
-  to: string
+  to: string,
+  translateContext?: {
+    previousSegments?: Array<{ source: string; translated: string; speakerId?: string }>
+    glossary?: Array<{ source: string; target: string }>
+    speakerId?: string
+  }
 ): Promise<void> {
   if (!context) {
     process.parentPort!.postMessage({
@@ -61,8 +101,9 @@ async function handleTranslate(
     const fromLang = LANG_NAMES[from] ?? from
     const toLang = LANG_NAMES[to] ?? to
 
-    // TranslateGemma optimized prompt format
-    const prompt = `Translate the following text from ${fromLang} to ${toLang}. Output only the translation, nothing else.\n\n${text}`
+    // Build context-enhanced prompt
+    const contextSection = buildContextPrompt(translateContext)
+    const prompt = `${contextSection}Translate the following text from ${fromLang} to ${toLang}. Output only the translation, nothing else.\n\n${text}`
 
     const response = await session.prompt(prompt, {
       temperature: 0.1,
@@ -158,7 +199,7 @@ process.parentPort!.on('message', (e: { data: any }) => {
           await handleInit(msg.modelPath, msg.kvCacheQuant)
           break
         case 'translate':
-          await handleTranslate(msg.id, msg.text, msg.from, msg.to)
+          await handleTranslate(msg.id, msg.text, msg.from, msg.to, msg.context)
           break
         case 'summarize':
           await handleSummarize(msg.id, msg.transcript)

--- a/src/main/store.ts
+++ b/src/main/store.ts
@@ -1,4 +1,5 @@
 import Store from 'electron-store'
+import type { GlossaryEntry } from '../engines/types'
 
 export interface QuotaRecord {
   monthKey: string
@@ -45,6 +46,8 @@ export interface AppSettings {
   slmKvCacheQuant: boolean
   /** TranslateGemma model size: 4B (lighter) or 12B (higher quality) */
   slmModelSize: '4b' | '12b'
+  /** User-defined glossary for fixed translation of specific terms */
+  glossaryTerms: GlossaryEntry[]
 }
 
 export const store = new Store<AppSettings>({
@@ -70,6 +73,7 @@ export const store = new Store<AppSettings>({
     },
     sessionLogs: [],
     slmKvCacheQuant: true,
-    slmModelSize: '4b'
+    slmModelSize: '4b',
+    glossaryTerms: []
   }
 })

--- a/src/pipeline/ContextBuffer.test.ts
+++ b/src/pipeline/ContextBuffer.test.ts
@@ -20,6 +20,16 @@ describe('ContextBuffer', () => {
     expect(ctx.previousSegments[0]).toEqual({ source: 'hello', translated: 'こんにちは' })
   })
 
+  it('stores segments with speakerId', () => {
+    buffer.add('hello', 'こんにちは', 'Speaker A')
+    const ctx = buffer.getContext()
+    expect(ctx.previousSegments[0]).toEqual({
+      source: 'hello',
+      translated: 'こんにちは',
+      speakerId: 'Speaker A'
+    })
+  })
+
   it('evicts oldest when max reached', () => {
     buffer.add('one', '1')
     buffer.add('two', '2')
@@ -43,5 +53,20 @@ describe('ContextBuffer', () => {
     const ctx2 = buffer.getContext()
     expect(ctx1.previousSegments).toHaveLength(1)
     expect(ctx2.previousSegments).toHaveLength(2)
+  })
+
+  it('passes glossary and speakerId in context', () => {
+    buffer.add('hello', 'world')
+    const glossary = [{ source: 'API', target: 'API' }]
+    const ctx = buffer.getContext(glossary, 'Speaker B')
+    expect(ctx.glossary).toEqual(glossary)
+    expect(ctx.speakerId).toBe('Speaker B')
+  })
+
+  it('returns undefined glossary and speakerId when not provided', () => {
+    buffer.add('hello', 'world')
+    const ctx = buffer.getContext()
+    expect(ctx.glossary).toBeUndefined()
+    expect(ctx.speakerId).toBeUndefined()
   })
 })

--- a/src/pipeline/ContextBuffer.ts
+++ b/src/pipeline/ContextBuffer.ts
@@ -1,4 +1,4 @@
-import type { TranslateContext } from '../engines/types'
+import type { TranslateContext, GlossaryEntry } from '../engines/types'
 
 const DEFAULT_MAX_SEGMENTS = 3
 
@@ -7,7 +7,7 @@ const DEFAULT_MAX_SEGMENTS = 3
  * Provides context to translators that support context-aware translation.
  */
 export class ContextBuffer {
-  private segments: Array<{ source: string; translated: string }> = []
+  private segments: Array<{ source: string; translated: string; speakerId?: string }> = []
   private maxSegments: number
 
   constructor(maxSegments = DEFAULT_MAX_SEGMENTS) {
@@ -15,16 +15,20 @@ export class ContextBuffer {
   }
 
   /** Add a confirmed translation segment */
-  add(source: string, translated: string): void {
-    this.segments.push({ source, translated })
+  add(source: string, translated: string, speakerId?: string): void {
+    this.segments.push({ source, translated, speakerId })
     if (this.segments.length > this.maxSegments) {
       this.segments.shift()
     }
   }
 
   /** Get the current context for translation */
-  getContext(): TranslateContext {
-    return { previousSegments: [...this.segments] }
+  getContext(glossary?: GlossaryEntry[], speakerId?: string): TranslateContext {
+    return {
+      previousSegments: [...this.segments],
+      glossary,
+      speakerId
+    }
   }
 
   /** Clear all stored segments */

--- a/src/pipeline/TranslationPipeline.ts
+++ b/src/pipeline/TranslationPipeline.ts
@@ -5,7 +5,8 @@ import type {
   TranslatorEngine,
   E2ETranslationEngine,
   TranslationResult,
-  Language
+  Language,
+  GlossaryEntry
 } from '../engines/types'
 import { LocalAgreement } from './LocalAgreement'
 import { ContextBuffer } from './ContextBuffer'
@@ -81,6 +82,9 @@ export class TranslationPipeline extends EventEmitter {
   // Auto-recovery state
   private consecutiveErrors = 0
 
+  // Glossary terms for context-aware translation
+  private glossary: GlossaryEntry[] = []
+
   // Memory monitoring
   private memoryTimer: ReturnType<typeof setInterval> | null = null
   private startedAt: number | null = null
@@ -130,6 +134,11 @@ export class TranslationPipeline extends EventEmitter {
       default:
         return false
     }
+  }
+
+  /** Set glossary terms for context-aware translation */
+  setGlossary(glossary: GlossaryEntry[]): void {
+    this.glossary = glossary
   }
 
   // --- Engine registration ---
@@ -315,15 +324,16 @@ export class TranslationPipeline extends EventEmitter {
     }
 
     try {
+      const speakerId = sttResult.speakerId ?? this.speakerTracker.update(Date.now())
+      const glossary = this.glossary.length > 0 ? this.glossary : undefined
       const translated = await this.translator.translate(
         sttResult.text,
         sttResult.language,
         targetLang,
-        this.contextBuffer.getContext()
+        this.contextBuffer.getContext(glossary, speakerId)
       )
 
-      this.contextBuffer.add(sttResult.text, translated)
-      const speakerId = sttResult.speakerId ?? this.speakerTracker.update(Date.now())
+      this.contextBuffer.add(sttResult.text, translated, speakerId)
 
       return {
         sourceText: sttResult.text,
@@ -402,20 +412,21 @@ export class TranslationPipeline extends EventEmitter {
       const agreement = this.agreement.update(sttResult.text)
       const targetLang = this.resolveTargetLanguage(sttResult.language)
 
+      const speakerId = sttResult.speakerId ?? this.speakerTracker.update(Date.now())
+      const glossary = this.glossary.length > 0 ? this.glossary : undefined
+
       let translatedText = ''
       if (agreement.newConfirmed && this.translator) {
         translatedText = await this.translator.translate(
           agreement.confirmedText,
           sttResult.language,
           targetLang,
-          this.contextBuffer.getContext()
+          this.contextBuffer.getContext(glossary, speakerId)
         )
         this.lastTranslatedConfirmed = translatedText
       } else {
         translatedText = this.lastTranslatedConfirmed
       }
-
-      const speakerId = sttResult.speakerId ?? this.speakerTracker.update(Date.now())
       const interimResult: TranslationResult = {
         sourceText: agreement.confirmedText + agreement.interimText,
         translatedText,
@@ -466,20 +477,21 @@ export class TranslationPipeline extends EventEmitter {
       const agreement = this.agreement.finalize(sttResult.text)
       const targetLang = this.resolveTargetLanguage(sttResult.language)
 
+      const speakerId = sttResult.speakerId ?? this.speakerTracker.update(Date.now())
+      const glossary = this.glossary.length > 0 ? this.glossary : undefined
+
       let translatedText = ''
       if (this.translator && agreement.confirmedText.trim()) {
         translatedText = await this.translator.translate(
           agreement.confirmedText,
           sttResult.language,
           targetLang,
-          this.contextBuffer.getContext()
+          this.contextBuffer.getContext(glossary, speakerId)
         )
-        this.contextBuffer.add(agreement.confirmedText, translatedText)
+        this.contextBuffer.add(agreement.confirmedText, translatedText, speakerId)
       }
 
       this.lastTranslatedConfirmed = ''
-
-      const speakerId = sttResult.speakerId ?? this.speakerTracker.update(Date.now())
       const result: TranslationResult = {
         sourceText: agreement.confirmedText,
         translatedText,

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -75,6 +75,10 @@ contextBridge.exposeInMainWorld('api', {
     return () => ipcRenderer.off('subtitle-settings-changed', handler)
   },
 
+  // Glossary management (#240)
+  saveGlossary: (terms: Array<{ source: string; target: string }>) =>
+    ipcRenderer.invoke('save-glossary', terms),
+
   // Display change notifications (#192)
   onDisplaysChanged: (callback: () => void) => {
     const handler = (): void => callback()

--- a/src/renderer/components/SettingsPanel.tsx
+++ b/src/renderer/components/SettingsPanel.tsx
@@ -54,6 +54,11 @@ function SettingsPanel(): JSX.Element {
   // Model size (#236)
   const [slmModelSize, setSlmModelSize] = useState<'4b' | '12b'>('4b')
 
+  // Glossary (#240)
+  const [glossaryTerms, setGlossaryTerms] = useState<Array<{ source: string; target: string }>>([])
+  const [newGlossarySource, setNewGlossarySource] = useState('')
+  const [newGlossaryTarget, setNewGlossaryTarget] = useState('')
+
   // Meeting summary (#124)
   const [lastTranscriptPath, setLastTranscriptPath] = useState<string | null>(null)
   const [summaryText, setSummaryText] = useState<string | null>(null)
@@ -103,6 +108,7 @@ function SettingsPanel(): JSX.Element {
       if (s.sttEngine) setSttEngine(s.sttEngine as 'whisper-local' | 'mlx-whisper' | 'moonshine')
       if (s.slmKvCacheQuant !== undefined) setSlmKvCacheQuant(s.slmKvCacheQuant as boolean)
       if (s.slmModelSize) setSlmModelSize(s.slmModelSize as '4b' | '12b')
+      if (s.glossaryTerms) setGlossaryTerms(s.glossaryTerms as Array<{ source: string; target: string }>)
       if (s.subtitleSettings) {
         const sub = s.subtitleSettings as Record<string, unknown>
         if (sub.fontSize) setSubtitleFontSize(sub.fontSize as number)
@@ -742,6 +748,95 @@ function SettingsPanel(): JSX.Element {
           />
         </Section>
       )}
+
+      {/* Glossary (#240) */}
+      <Section label="Translation Glossary">
+        <div style={{ fontSize: '12px', color: '#94a3b8', marginBottom: '8px' }}>
+          Define fixed translations for specific terms. These are injected into LLM-based translators (Gemini, TranslateGemma).
+        </div>
+        {glossaryTerms.length > 0 && (
+          <div style={{ marginBottom: '8px' }}>
+            {glossaryTerms.map((term, idx) => (
+              <div
+                key={idx}
+                style={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  gap: '8px',
+                  padding: '4px 0',
+                  borderBottom: '1px solid #1e293b',
+                  fontSize: '12px'
+                }}
+              >
+                <span style={{ flex: 1, color: '#e2e8f0' }}>{term.source}</span>
+                <span style={{ color: '#64748b' }}>&rarr;</span>
+                <span style={{ flex: 1, color: '#93c5fd' }}>{term.target}</span>
+                <button
+                  onClick={() => {
+                    const updated = glossaryTerms.filter((_, i) => i !== idx)
+                    setGlossaryTerms(updated)
+                    window.api.saveGlossary(updated)
+                  }}
+                  disabled={isRunning}
+                  style={{
+                    padding: '2px 6px',
+                    fontSize: '11px',
+                    background: '#334155',
+                    color: '#ef4444',
+                    border: 'none',
+                    borderRadius: '4px',
+                    cursor: isRunning ? 'not-allowed' : 'pointer'
+                  }}
+                >
+                  Remove
+                </button>
+              </div>
+            ))}
+          </div>
+        )}
+        <div style={{ display: 'flex', gap: '6px', alignItems: 'center' }}>
+          <input
+            type="text"
+            value={newGlossarySource}
+            onChange={(e) => setNewGlossarySource(e.target.value)}
+            placeholder="Source term"
+            style={{ ...inputStyle, flex: 1, fontFamily: 'inherit' }}
+            disabled={isRunning}
+          />
+          <input
+            type="text"
+            value={newGlossaryTarget}
+            onChange={(e) => setNewGlossaryTarget(e.target.value)}
+            placeholder="Translation"
+            style={{ ...inputStyle, flex: 1, fontFamily: 'inherit' }}
+            disabled={isRunning}
+          />
+          <button
+            onClick={() => {
+              if (!newGlossarySource.trim() || !newGlossaryTarget.trim()) return
+              const updated = [...glossaryTerms, { source: newGlossarySource.trim(), target: newGlossaryTarget.trim() }]
+              setGlossaryTerms(updated)
+              window.api.saveGlossary(updated)
+              setNewGlossarySource('')
+              setNewGlossaryTarget('')
+            }}
+            disabled={isRunning || !newGlossarySource.trim() || !newGlossaryTarget.trim()}
+            style={{
+              padding: '8px 12px',
+              fontSize: '12px',
+              fontWeight: 600,
+              background: '#334155',
+              color: '#e2e8f0',
+              border: 'none',
+              borderRadius: '6px',
+              cursor: (isRunning || !newGlossarySource.trim() || !newGlossaryTarget.trim()) ? 'not-allowed' : 'pointer',
+              whiteSpace: 'nowrap'
+            }}
+          >
+            Add
+          </button>
+        </div>
+      </Section>
 
       {/* Subtitle Appearance (#118) */}
       <Section label="Subtitle Appearance">


### PR DESCRIPTION
## Summary
- Add user-configurable glossary (source term → fixed translation pairs) with UI in Settings panel
- Inject glossary terms, previous translation history (with speaker IDs), and current speaker identity into LLM translation prompts for both TranslateGemma (SLM) and Gemini
- Pass context through the full pipeline: ContextBuffer stores speakerId per segment, TranslationPipeline passes glossary and speakerId to translators, SLMTranslator forwards context via IPC to slm-worker
- Extend `TranslateContext` interface with `glossary` and `speakerId` fields
- Add glossary persistence to electron-store with real-time pipeline updates
- 3 new unit tests for ContextBuffer (speakerId, glossary passthrough)

## Test plan
- [ ] Verify glossary UI: add/remove terms in Settings, confirm persistence across restart
- [ ] Run TranslateGemma with glossary terms and verify they appear in output
- [ ] Run Gemini translator with glossary and verify context-enhanced prompts
- [ ] Check speaker ID flows through to translation context
- [ ] `npm test` passes (35 tests)
- [ ] `npm run build` succeeds

Closes #240