### PR TITLE
#235 Hybrid translation: OPUS-MT instant draft + LLM refinement

### DIFF
--- a/src/engines/translator/HybridTranslator.test.ts
+++ b/src/engines/translator/HybridTranslator.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect, vi } from 'vitest'
+import { HybridTranslator } from './HybridTranslator'
+import type { TranslatorEngine, TranslationResult } from '../types'
+
+function createMockEngine(id: string, result = 'translated'): TranslatorEngine {
+  return {
+    id,
+    name: `Mock ${id}`,
+    isOffline: true,
+    initialize: vi.fn(async () => {}),
+    translate: vi.fn(async () => result),
+    dispose: vi.fn(async () => {})
+  }
+}
+
+describe('HybridTranslator', () => {
+  it('returns refined text when it differs from draft', async () => {
+    const draft = createMockEngine('draft', 'draft translation')
+    const refine = createMockEngine('refine', 'refined translation')
+    const hybrid = new HybridTranslator(draft, refine)
+
+    const result = await hybrid.translate('hello', 'en', 'ja')
+    expect(result).toBe('refined translation')
+  })
+
+  it('returns draft text when refined matches', async () => {
+    const draft = createMockEngine('draft', 'same translation')
+    const refine = createMockEngine('refine', 'same translation')
+    const hybrid = new HybridTranslator(draft, refine)
+
+    const result = await hybrid.translate('hello', 'en', 'ja')
+    expect(result).toBe('same translation')
+  })
+
+  it('emits draft via onDraft callback', async () => {
+    const draft = createMockEngine('draft', 'draft text')
+    const refine = createMockEngine('refine', 'refined text')
+    const hybrid = new HybridTranslator(draft, refine)
+
+    const drafts: TranslationResult[] = []
+    hybrid.setOnDraft((d) => drafts.push(d))
+
+    await hybrid.translate('hello', 'en', 'ja')
+
+    expect(drafts).toHaveLength(1)
+    expect(drafts[0].translatedText).toBe('draft text')
+    expect(drafts[0].translationStage).toBe('draft')
+    expect(drafts[0].sourceText).toBe('hello')
+  })
+
+  it('falls back to draft when refinement fails', async () => {
+    const draft = createMockEngine('draft', 'draft text')
+    const refine = createMockEngine('refine', '')
+    ;(refine.translate as ReturnType<typeof vi.fn>).mockRejectedValue(new Error('LLM error'))
+    const hybrid = new HybridTranslator(draft, refine)
+
+    const result = await hybrid.translate('hello', 'en', 'ja')
+    expect(result).toBe('draft text')
+  })
+
+  it('returns empty string for empty input', async () => {
+    const draft = createMockEngine('draft', 'x')
+    const refine = createMockEngine('refine', 'y')
+    const hybrid = new HybridTranslator(draft, refine)
+
+    expect(await hybrid.translate('', 'en', 'ja')).toBe('')
+    expect(await hybrid.translate('  ', 'en', 'ja')).toBe('')
+  })
+
+  it('returns input text when from === to', async () => {
+    const draft = createMockEngine('draft', 'x')
+    const refine = createMockEngine('refine', 'y')
+    const hybrid = new HybridTranslator(draft, refine)
+
+    expect(await hybrid.translate('hello', 'en', 'en')).toBe('hello')
+  })
+
+  it('initializes both engines', async () => {
+    const draft = createMockEngine('draft')
+    const refine = createMockEngine('refine')
+    const hybrid = new HybridTranslator(draft, refine)
+
+    await hybrid.initialize()
+    expect(draft.initialize).toHaveBeenCalled()
+    expect(refine.initialize).toHaveBeenCalled()
+  })
+
+  it('disposes both engines safely', async () => {
+    const draft = createMockEngine('draft')
+    const refine = createMockEngine('refine')
+    const hybrid = new HybridTranslator(draft, refine)
+
+    await hybrid.dispose()
+    expect(draft.dispose).toHaveBeenCalled()
+    expect(refine.dispose).toHaveBeenCalled()
+  })
+
+  it('disposes both engines even if one fails', async () => {
+    const draft = createMockEngine('draft')
+    const refine = createMockEngine('refine')
+    ;(draft.dispose as ReturnType<typeof vi.fn>).mockRejectedValue(new Error('fail'))
+    const hybrid = new HybridTranslator(draft, refine)
+
+    await hybrid.dispose()
+    expect(draft.dispose).toHaveBeenCalled()
+    expect(refine.dispose).toHaveBeenCalled()
+  })
+
+  it('passes context to both engines', async () => {
+    const draft = createMockEngine('draft', 'a')
+    const refine = createMockEngine('refine', 'b')
+    const hybrid = new HybridTranslator(draft, refine)
+
+    const ctx = { previousSegments: [{ source: 'x', translated: 'y' }] }
+    await hybrid.translate('hello', 'en', 'ja', ctx)
+
+    expect(draft.translate).toHaveBeenCalledWith('hello', 'en', 'ja', ctx)
+    expect(refine.translate).toHaveBeenCalledWith('hello', 'en', 'ja', ctx)
+  })
+})

--- a/src/engines/translator/HybridTranslator.ts
+++ b/src/engines/translator/HybridTranslator.ts
@@ -1,0 +1,93 @@
+import type { TranslatorEngine, Language, TranslateContext, TranslationResult } from '../types'
+
+/**
+ * Callback type for emitting draft translation results.
+ * Called by HybridTranslator after the draft engine produces a result,
+ * before the refine engine runs.
+ */
+export type OnDraftCallback = (draft: TranslationResult) => void
+
+/**
+ * Two-stage hybrid translator: fast OPUS-MT draft + LLM refinement (#235).
+ *
+ * Flow:
+ *   1. Run draftEngine.translate() -> emit draft via onDraft callback
+ *   2. Run refineEngine.translate() -> if different from draft, return refined
+ *   3. If refined matches draft, return draft (skip replacement)
+ *
+ * Both engines are owned by this translator and disposed together.
+ */
+export class HybridTranslator implements TranslatorEngine {
+  readonly id = 'hybrid'
+  readonly name = 'Hybrid (OPUS-MT + LLM)'
+  readonly isOffline = true
+
+  private draftEngine: TranslatorEngine
+  private refineEngine: TranslatorEngine
+  private onDraft: OnDraftCallback | null = null
+
+  constructor(draftEngine: TranslatorEngine, refineEngine: TranslatorEngine) {
+    this.draftEngine = draftEngine
+    this.refineEngine = refineEngine
+  }
+
+  /** Set the callback for draft result emission. Called by pipeline. */
+  setOnDraft(callback: OnDraftCallback): void {
+    this.onDraft = callback
+  }
+
+  async initialize(): Promise<void> {
+    // Initialize both engines (draft first since it's faster to load)
+    await this.draftEngine.initialize()
+    await this.refineEngine.initialize()
+  }
+
+  async translate(text: string, from: Language, to: Language, context?: TranslateContext): Promise<string> {
+    if (!text.trim()) return ''
+    if (from === to) return text
+
+    // Stage 1: Fast draft translation
+    const draftText = await this.draftEngine.translate(text, from, to, context)
+
+    // Emit draft result via callback so pipeline can forward it
+    if (this.onDraft && draftText) {
+      this.onDraft({
+        sourceText: text,
+        translatedText: draftText,
+        sourceLanguage: from,
+        targetLanguage: to,
+        timestamp: Date.now(),
+        translationStage: 'draft'
+      })
+    }
+
+    // Stage 2: LLM refinement
+    try {
+      const refinedText = await this.refineEngine.translate(text, from, to, context)
+
+      // Only return refined if it actually differs from draft (save visual churn)
+      if (refinedText && refinedText !== draftText) {
+        return refinedText
+      }
+    } catch (err) {
+      // If refinement fails, fall back to draft silently
+      console.warn('[hybrid] Refinement failed, using draft:', err)
+    }
+
+    return draftText
+  }
+
+  async dispose(): Promise<void> {
+    // Dispose both engines safely
+    try {
+      await this.draftEngine.dispose()
+    } catch (err) {
+      console.warn('[hybrid] Error disposing draft engine:', err)
+    }
+    try {
+      await this.refineEngine.dispose()
+    } catch (err) {
+      console.warn('[hybrid] Error disposing refine engine:', err)
+    }
+  }
+}

--- a/src/engines/types.ts
+++ b/src/engines/types.ts
@@ -31,6 +31,8 @@ export interface TranslationResult {
   isInterim?: boolean
   /** Speaker identifier (if diarization is enabled) */
   speakerId?: string
+  /** Translation stage for hybrid mode: 'draft' (OPUS-MT) or 'refined' (LLM) */
+  translationStage?: 'draft' | 'refined'
 }
 
 /**

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -13,6 +13,7 @@ import { OpusMTTranslator } from '../engines/translator/OpusMTTranslator'
 import { ApiRotationController } from '../engines/translator/ApiRotationController'
 import type { ProviderConfig, QuotaStore } from '../engines/translator/ApiRotationController'
 import { SLMTranslator } from '../engines/translator/SLMTranslator'
+import { HybridTranslator } from '../engines/translator/HybridTranslator'
 import { detectGpu } from '../engines/gpu-detector'
 import { isGGUFDownloaded, getGGUFVariants } from '../engines/model-downloader'
 import type { SLMModelSize } from '../engines/model-downloader'
@@ -154,6 +155,17 @@ function initPipeline(): void {
     kvCacheQuant: store.get('slmKvCacheQuant'),
     modelSize: store.get('slmModelSize')
   }))
+  // Hybrid translator: OPUS-MT instant draft + TranslateGemma refinement (#235)
+  pipeline.registerTranslator('hybrid', () => new HybridTranslator(
+    new OpusMTTranslator({
+      onProgress: (msg) => mainWindow?.webContents.send('status-update', msg)
+    }),
+    new SLMTranslator({
+      onProgress: (msg) => mainWindow?.webContents.send('status-update', msg),
+      kvCacheQuant: store.get('slmKvCacheQuant'),
+      modelSize: store.get('slmModelSize')
+    })
+  ))
   // Auto-register discovered plugins (#145)
   for (const plugin of discoverPlugins()) {
     const { manifest } = plugin
@@ -180,6 +192,12 @@ function initPipeline(): void {
   pipeline.on('interim-result', (result: TranslationResult) => {
     subtitleWindow?.webContents.send('interim-result', result)
     mainWindow?.webContents.send('interim-result', result)
+  })
+
+  // Forward draft results from hybrid translation (#235)
+  pipeline.on('draft-result', (result: TranslationResult) => {
+    subtitleWindow?.webContents.send('draft-result', result)
+    mainWindow?.webContents.send('draft-result', result)
   })
 
   pipeline.on('error', (err: Error) => {

--- a/src/pipeline/TranslationPipeline.ts
+++ b/src/pipeline/TranslationPipeline.ts
@@ -8,6 +8,7 @@ import type {
   Language,
   GlossaryEntry
 } from '../engines/types'
+import { HybridTranslator } from '../engines/translator/HybridTranslator'
 import { LocalAgreement } from './LocalAgreement'
 import { ContextBuffer } from './ContextBuffer'
 import { SpeakerTracker } from './SpeakerTracker'
@@ -15,6 +16,8 @@ import { SpeakerTracker } from './SpeakerTracker'
 export interface PipelineEvents {
   result: (result: TranslationResult) => void
   'interim-result': (result: TranslationResult) => void
+  /** Draft result from hybrid translation mode — shown immediately before LLM refinement */
+  'draft-result': (result: TranslationResult) => void
   error: (error: Error) => void
   'engine-loading': (message: string) => void
   'engine-ready': () => void
@@ -209,6 +212,13 @@ export class TranslationPipeline extends EventEmitter {
         this.emit('engine-loading', 'Initializing translator...')
         this.translator = await Promise.resolve(translatorFactory())
         await this.withTimeout(this.translator.initialize(), ENGINE_INIT_TIMEOUT_MS, 'Translator initialization')
+
+        // Wire up draft callback for hybrid translator (#235)
+        if (this.translator instanceof HybridTranslator) {
+          this.translator.setOnDraft((draft) => {
+            this.emit('draft-result', draft)
+          })
+        }
       } else if (config.mode === 'e2e') {
         const e2eId = config.e2eEngineId
         if (!e2eId) throw new Error('e2e mode requires e2eEngineId')

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -6,6 +6,7 @@ export interface ElectronAPI {
   finalizeStreaming: (audioData: number[]) => Promise<unknown>
   onTranslationResult: (callback: (data: unknown) => void) => (() => void)
   onInterimResult: (callback: (data: unknown) => void) => (() => void)
+  onDraftResult: (callback: (data: unknown) => void) => (() => void)
   onStatusUpdate: (callback: (message: string) => void) => (() => void)
   getSessionStartTime: () => Promise<number | null>
   getDisplays: () => Promise<

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -19,6 +19,12 @@ contextBridge.exposeInMainWorld('api', {
     ipcRenderer.on('interim-result', handler)
     return () => ipcRenderer.off('interim-result', handler)
   },
+  // Draft result from hybrid translation (#235)
+  onDraftResult: (callback: (data: unknown) => void) => {
+    const handler = (_event: Electron.IpcRendererEvent, data: unknown): void => callback(data)
+    ipcRenderer.on('draft-result', handler)
+    return () => ipcRenderer.off('draft-result', handler)
+  },
 
   // Status updates from main process
   onStatusUpdate: (callback: (message: string) => void) => {

--- a/src/renderer/components/SettingsPanel.tsx
+++ b/src/renderer/components/SettingsPanel.tsx
@@ -10,7 +10,7 @@ function withIpcTimeout<T>(promise: Promise<T>, ms: number, label: string): Prom
   return Promise.race([promise, timeoutPromise]).finally(() => clearTimeout(timer))
 }
 
-type EngineMode = 'auto' | 'rotation' | 'online' | 'online-deepl' | 'online-gemini' | 'offline-opus' | 'offline-slm'
+type EngineMode = 'auto' | 'rotation' | 'online' | 'online-deepl' | 'online-gemini' | 'offline-opus' | 'offline-slm' | 'offline-hybrid'
 
 interface DisplayInfo {
   id: number
@@ -269,6 +269,12 @@ function SettingsPanel(): JSX.Element {
           mode: 'cascade' as const,
           sttEngineId: sttEngine,
           translatorEngineId: 'slm-translate'
+        }
+      } else if (resolvedMode === 'offline-hybrid') {
+        config = {
+          mode: 'cascade' as const,
+          sttEngineId: sttEngine,
+          translatorEngineId: 'hybrid'
         }
       } else {
         config = {
@@ -602,7 +608,7 @@ function SettingsPanel(): JSX.Element {
             )}
           </div>
         </label>
-        {engineMode === 'offline-slm' && (
+        {(engineMode === 'offline-slm' || engineMode === 'offline-hybrid') && (
           <>
             <div style={{ paddingLeft: '24px', display: 'flex', flexDirection: 'column', gap: '2px' }}>
               <div style={{ fontSize: '11px', fontWeight: 600, color: '#94a3b8', marginBottom: '2px' }}>Model Size</div>
@@ -649,6 +655,24 @@ function SettingsPanel(): JSX.Element {
             </label>
           </>
         )}
+        <label style={radioLabelStyle}>
+          <input
+            type="radio"
+            name="engine"
+            checked={engineMode === 'offline-hybrid'}
+            onChange={() => setEngineMode('offline-hybrid')}
+            disabled={isRunning || isStarting}
+          />
+          <div>
+            <div style={{ fontWeight: 500 }}>Hybrid (OPUS-MT + TranslateGemma)</div>
+            <div style={{ fontSize: '12px', color: '#94a3b8' }}>Instant OPUS-MT draft + LLM refinement for best quality</div>
+            {engineMode === 'offline-hybrid' && gpuInfo && !gpuInfo.hasGpu && (
+              <div style={{ fontSize: '11px', color: '#f59e0b', marginTop: '2px' }}>
+                No GPU detected — LLM refinement may be slow on CPU-only systems
+              </div>
+            )}
+          </div>
+        </label>
       </Section>
 
       {/* API Keys */}

--- a/src/renderer/components/SubtitleOverlay.tsx
+++ b/src/renderer/components/SubtitleOverlay.tsx
@@ -9,6 +9,8 @@ interface SubtitleLine {
   opacity: number
   isInterim?: boolean
   speakerId?: string
+  /** Whether this line is a draft from hybrid translation, pending refinement */
+  isDraft?: boolean
 }
 
 interface SubtitleConfig {
@@ -30,6 +32,7 @@ const DEFAULT_CONFIG: SubtitleConfig = {
 const MAX_LINES = 3
 const FADE_DURATION_MS = 8000
 const INTERIM_LINE_ID = -1
+const DRAFT_LINE_ID = -2
 
 function SubtitleOverlay(): JSX.Element {
   const [lines, setLines] = useState<SubtitleLine[]>([])
@@ -56,12 +59,12 @@ function SubtitleOverlay(): JSX.Element {
     const unsubscribeResult = window.api.onTranslationResult((data) => {
       const result = data as Omit<SubtitleLine, 'id' | 'opacity'>
       setLines((prev) => {
-        // Remove any interim line, add the final result
-        const withoutInterim = prev.filter((l) => l.id !== INTERIM_LINE_ID)
+        // Remove any interim or draft line, add the final result
+        const cleaned = prev.filter((l) => l.id !== INTERIM_LINE_ID && l.id !== DRAFT_LINE_ID)
         if (nextLineIdRef.current >= Number.MAX_SAFE_INTEGER - 1000) {
           nextLineIdRef.current = 1
         }
-        const updated = [...withoutInterim, { ...result, id: nextLineIdRef.current++, opacity: 1 }]
+        const updated = [...cleaned, { ...result, id: nextLineIdRef.current++, opacity: 1 }]
         return updated.slice(-MAX_LINES)
       })
     })
@@ -82,14 +85,30 @@ function SubtitleOverlay(): JSX.Element {
       })
     })
 
+    // Draft results from hybrid translation (#235) — show immediately with dimmed style
+    const unsubscribeDraft = window.api.onDraftResult((data) => {
+      const result = data as Omit<SubtitleLine, 'id' | 'opacity' | 'isDraft'>
+      setLines((prev) => {
+        const withoutDraft = prev.filter((l) => l.id !== DRAFT_LINE_ID)
+        const draftLine: SubtitleLine = {
+          ...result,
+          id: DRAFT_LINE_ID,
+          opacity: 1,
+          isDraft: true
+        }
+        const updated = [...withoutDraft, draftLine]
+        return updated.slice(-MAX_LINES)
+      })
+    })
+
     // Fade old lines
     fadeTimerRef.current = setInterval(() => {
       setLines((prev) => {
         if (prev.length === 0) return prev
         return prev
           .map((line) => {
-            // Don't fade interim lines
-            if (line.isInterim) return line
+            // Don't fade interim or draft lines
+            if (line.isInterim || line.isDraft) return line
             const age = Date.now() - line.timestamp
             if (age > FADE_DURATION_MS) {
               return { ...line, opacity: Math.max(0, 1 - (age - FADE_DURATION_MS) / 2000) }
@@ -103,6 +122,7 @@ function SubtitleOverlay(): JSX.Element {
     return () => {
       unsubscribeResult?.()
       unsubscribeInterim?.()
+      unsubscribeDraft?.()
       if (fadeTimerRef.current) clearInterval(fadeTimerRef.current)
     }
   }, [])
@@ -127,28 +147,30 @@ function SubtitleOverlay(): JSX.Element {
         <div
           key={line.id}
           style={{
-            background: line.isInterim
+            background: (line.isInterim || line.isDraft)
               ? `rgba(0, 0, 0, ${Math.max(0, config.backgroundOpacity - 13) / 100})`
               : `rgba(0, 0, 0, ${config.backgroundOpacity / 100})`,
             borderRadius: '10px',
             padding: '10px 20px',
             marginBottom: '6px',
             opacity: line.opacity,
-            transition: 'opacity 0.5s ease-out',
+            transition: 'opacity 0.3s ease-out',
             backdropFilter: 'blur(8px)',
             WebkitBackdropFilter: 'blur(8px)',
             borderLeft: `4px solid ${
               line.isInterim
                 ? '#94a3b8'
-                : line.sourceLanguage === 'ja'
-                  ? '#4ade80'
-                  : '#60a5fa'
+                : line.isDraft
+                  ? '#f59e0b'
+                  : line.sourceLanguage === 'ja'
+                    ? '#4ade80'
+                    : '#60a5fa'
             }`
           }}
         >
           <div
             style={{
-              color: line.isInterim ? '#cbd5e1' : config.sourceTextColor,
+              color: line.isInterim ? '#cbd5e1' : line.isDraft ? '#d4d4d8' : config.sourceTextColor,
               fontSize: `${config.fontSize}px`,
               fontWeight: 600,
               lineHeight: 1.4,
@@ -166,7 +188,7 @@ function SubtitleOverlay(): JSX.Element {
           {line.translatedText && (
             <div
               style={{
-                color: line.isInterim ? '#94a3b8' : config.translatedTextColor,
+                color: line.isInterim ? '#94a3b8' : line.isDraft ? '#a1a1aa' : config.translatedTextColor,
                 fontSize: `${translatedFontSize}px`,
                 fontWeight: 600,
                 lineHeight: 1.4,


### PR DESCRIPTION
## Description

Implements two-stage hybrid translation strategy for offline mode:

1. **OPUS-MT** produces an instant draft translation (<50ms) displayed immediately
2. **TranslateGemma LLM** refines the translation (300-500ms) and seamlessly replaces the draft if different

### Changes

- **New `HybridTranslator`** (`src/engines/translator/HybridTranslator.ts`): Implements `TranslatorEngine`, orchestrates draft + refine engines with `onDraft` callback
- **`TranslationPipeline`**: Added `draft-result` event, wires up `HybridTranslator.setOnDraft()` after initialization
- **`TranslationResult`**: Added optional `translationStage: 'draft' | 'refined'` field
- **`main/index.ts`**: Registers `hybrid` translator factory (OPUS-MT + SLMTranslator), forwards `draft-result` IPC events
- **`preload/index.ts`**: Exposes `onDraftResult` IPC listener
- **`SubtitleOverlay.tsx`**: Handles `draft-result` events with amber border + slightly dimmed text; replaced seamlessly by final result
- **`SettingsPanel.tsx`**: Added "Hybrid (OPUS-MT + TranslateGemma)" engine option under Offline section
- **10 unit tests** for HybridTranslator covering draft emission, refinement fallback, dispose safety, context passing

### Design decisions

- Draft lines use a dedicated `DRAFT_LINE_ID = -2` (similar to `INTERIM_LINE_ID = -1`) for clean replacement
- If LLM refinement fails, falls back to draft silently (no error shown to user)
- If refined text matches draft, skip replacement (save visual churn)
- TranslateGemma model size / KV cache settings shared with standalone TranslateGemma mode

Closes #235