### PR TITLE
234 Add Hunyuan-MT-7B translation engine

### DIFF
--- a/src/engines/model-downloader.ts
+++ b/src/engines/model-downloader.ts
@@ -39,6 +39,33 @@ export interface GGUFVariant {
 /** Model size identifier for TranslateGemma */
 export type SLMModelSize = '4b' | '12b'
 
+/** Hunyuan-MT-7B GGUF variants (Mungert quantizations) */
+export const HUNYUAN_MT_VARIANTS: Record<string, GGUFVariant> = {
+  'Q4_K_M': {
+    filename: 'Hunyuan-MT-7B-q4_k_m.gguf',
+    url: 'https://huggingface.co/Mungert/Hunyuan-MT-7B-GGUF/resolve/main/Hunyuan-MT-7B-q4_k_m.gguf',
+    sizeMB: 4700,
+    label: 'Q4_K_M (Recommended, ~4.7GB)'
+  },
+  'Q8_0': {
+    filename: 'Hunyuan-MT-7B-q8_0.gguf',
+    url: 'https://huggingface.co/Mungert/Hunyuan-MT-7B-GGUF/resolve/main/Hunyuan-MT-7B-q8_0.gguf',
+    sizeMB: 7980,
+    label: 'Q8_0 (Best quality, ~8.0GB)'
+  },
+  'Q3_K_M': {
+    filename: 'Hunyuan-MT-7B-q3_k_m.gguf',
+    url: 'https://huggingface.co/Mungert/Hunyuan-MT-7B-GGUF/resolve/main/Hunyuan-MT-7B-q3_k_m.gguf',
+    sizeMB: 3760,
+    label: 'Q3_K_M (Smallest, ~3.8GB)'
+  }
+}
+
+/** Get Hunyuan-MT GGUF variants */
+export function getHunyuanMTVariants(): Record<string, GGUFVariant> {
+  return HUNYUAN_MT_VARIANTS
+}
+
 export const GGUF_VARIANTS_4B: Record<string, GGUFVariant> = {
   'Q4_K_M': {
     filename: 'translategemma-4b-it-Q4_K_M.gguf',

--- a/src/engines/translator/HunyuanMTTranslator.ts
+++ b/src/engines/translator/HunyuanMTTranslator.ts
@@ -1,0 +1,169 @@
+import { utilityProcess } from 'electron'
+import { join } from 'path'
+import type { TranslatorEngine, Language, TranslateContext } from '../types'
+import { getGGUFDir, downloadGGUF, getHunyuanMTVariants } from '../model-downloader'
+
+const TRANSLATE_TIMEOUT_MS = 30_000
+
+interface PendingRequest {
+  resolve: (text: string) => void
+  reject: (err: Error) => void
+  timer: ReturnType<typeof setTimeout>
+}
+
+/**
+ * Hunyuan-MT-7B translator via node-llama-cpp UtilityProcess.
+ * Uses the same slm-worker.ts as TranslateGemma but with Hunyuan-MT prompt format.
+ * WMT25 winner: 30/31 categories, 33 languages, 15-65% improvement over Google Translate.
+ * License: Tencent Hunyuan Community License (Apache 2.0 based, commercial OK < 100M MAU).
+ */
+export class HunyuanMTTranslator implements TranslatorEngine {
+  readonly id = 'hunyuan-mt'
+  readonly name = 'Hunyuan-MT 7B (Offline)'
+  readonly isOffline = true
+
+  private worker: Electron.UtilityProcess | null = null
+  private pending = new Map<string, PendingRequest>()
+  private nextId = 0
+  private onProgress?: (message: string) => void
+  private variant: string
+  private kvCacheQuant: boolean
+
+  constructor(options?: { onProgress?: (message: string) => void; variant?: string; kvCacheQuant?: boolean }) {
+    this.onProgress = options?.onProgress
+    this.variant = options?.variant ?? 'Q4_K_M'
+    this.kvCacheQuant = options?.kvCacheQuant ?? true
+  }
+
+  async initialize(): Promise<void> {
+    if (this.worker) return
+
+    // Download model if needed
+    const variants = getHunyuanMTVariants()
+    const variantConfig = variants[this.variant] ?? variants['Q4_K_M']!
+    const modelPath = join(getGGUFDir(), variantConfig.filename)
+    await downloadGGUF(variantConfig.filename, variantConfig.url, this.onProgress, variantConfig.sha256)
+
+    // Spawn UtilityProcess (reuses the same slm-worker)
+    this.onProgress?.('Starting Hunyuan-MT 7B worker...')
+    const workerPath = join(__dirname, 'slm-worker.js')
+
+    this.worker = utilityProcess.fork(workerPath)
+
+    this.worker.on('exit', (code) => {
+      console.log(`[hunyuan-mt] Worker exited with code ${code}`)
+      this.worker = null
+      for (const [id, req] of this.pending) {
+        clearTimeout(req.timer)
+        req.reject(new Error('Worker process exited'))
+        this.pending.delete(id)
+      }
+    })
+
+    // Wait for init before registering the general message handler
+    await new Promise<void>((resolve, reject) => {
+      const timeout = setTimeout(() => {
+        this.worker?.removeListener('message', initHandler)
+        try { this.worker?.kill() } catch { /* ignore */ }
+        this.worker = null
+        reject(new Error('Hunyuan-MT initialization timed out'))
+      }, 5 * 60_000)
+
+      const initHandler = (msg: any): void => {
+        if (!this.worker) return
+
+        if (msg.type === 'ready') {
+          clearTimeout(timeout)
+          this.worker?.removeListener('message', initHandler)
+          this.onProgress?.('Hunyuan-MT 7B model loaded')
+          resolve()
+        } else if (msg.type === 'error') {
+          clearTimeout(timeout)
+          this.worker?.removeListener('message', initHandler)
+          reject(new Error(msg.message))
+        }
+      }
+
+      this.worker!.on('message', initHandler)
+      this.worker!.postMessage({
+        type: 'init',
+        modelPath,
+        kvCacheQuant: this.kvCacheQuant,
+        modelType: 'hunyuan-mt'
+      })
+    })
+
+    if (!this.worker) {
+      throw new Error('Worker was killed during initialization')
+    }
+
+    // Clear any leftover listeners before registering to prevent duplicates
+    this.worker.removeAllListeners('message')
+    this.worker.on('message', (msg: any) => {
+      if (msg.type === 'result' && msg.id) {
+        const req = this.pending.get(msg.id)
+        if (req) {
+          clearTimeout(req.timer)
+          this.pending.delete(msg.id)
+          req.resolve(msg.text)
+        }
+        return
+      }
+      if (msg.type === 'error' && msg.id) {
+        const req = this.pending.get(msg.id)
+        if (req) {
+          clearTimeout(req.timer)
+          this.pending.delete(msg.id)
+          req.reject(new Error(msg.message))
+        }
+        return
+      }
+      if (msg.type === 'error') {
+        console.error('[hunyuan-mt] Worker error:', msg.message)
+      }
+    })
+  }
+
+  async translate(text: string, from: Language, to: Language, context?: TranslateContext): Promise<string> {
+    if (!text.trim()) return ''
+    if (from === to) return text
+    if (!this.worker) {
+      throw new Error('[hunyuan-mt] Not initialized')
+    }
+
+    const id = String(this.nextId++)
+
+    return new Promise<string>((resolve, reject) => {
+      const timer = setTimeout(() => {
+        this.pending.delete(id)
+        reject(new Error('Hunyuan-MT translation timed out'))
+      }, TRANSLATE_TIMEOUT_MS)
+
+      this.pending.set(id, { resolve, reject, timer })
+      this.worker!.postMessage({ type: 'translate', id, text, from, to, context })
+    })
+  }
+
+  async dispose(): Promise<void> {
+    if (this.worker) {
+      try {
+        this.worker.postMessage({ type: 'dispose' })
+        await new Promise((resolve) => setTimeout(resolve, 1000))
+      } catch {
+        // Ignore errors during disposal
+      }
+      try {
+        this.worker.kill()
+      } catch {
+        // Already exited
+      }
+      this.worker = null
+    }
+
+    for (const [, req] of this.pending) {
+      clearTimeout(req.timer)
+      req.reject(new Error('Translator disposed'))
+    }
+    this.pending.clear()
+  }
+}

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -13,9 +13,10 @@ import { OpusMTTranslator } from '../engines/translator/OpusMTTranslator'
 import { ApiRotationController } from '../engines/translator/ApiRotationController'
 import type { ProviderConfig, QuotaStore } from '../engines/translator/ApiRotationController'
 import { SLMTranslator } from '../engines/translator/SLMTranslator'
+import { HunyuanMTTranslator } from '../engines/translator/HunyuanMTTranslator'
 import { HybridTranslator } from '../engines/translator/HybridTranslator'
 import { detectGpu } from '../engines/gpu-detector'
-import { isGGUFDownloaded, getGGUFVariants } from '../engines/model-downloader'
+import { isGGUFDownloaded, getGGUFVariants, getHunyuanMTVariants } from '../engines/model-downloader'
 import type { SLMModelSize } from '../engines/model-downloader'
 import { listPlugins, discoverPlugins, loadPluginEngine } from '../engines/plugin-loader'
 import { TranscriptLogger } from '../logger/TranscriptLogger'
@@ -154,6 +155,10 @@ function initPipeline(): void {
     onProgress: (msg) => mainWindow?.webContents.send('status-update', msg),
     kvCacheQuant: store.get('slmKvCacheQuant'),
     modelSize: store.get('slmModelSize')
+  }))
+  pipeline.registerTranslator('hunyuan-mt', () => new HunyuanMTTranslator({
+    onProgress: (msg) => mainWindow?.webContents.send('status-update', msg),
+    kvCacheQuant: store.get('slmKvCacheQuant')
   }))
   // Hybrid translator: OPUS-MT instant draft + TranslateGemma refinement (#235)
   pipeline.registerTranslator('hybrid', () => new HybridTranslator(
@@ -606,6 +611,18 @@ ipcMain.handle('export-session', (_event, id: string, format: 'text' | 'srt' | '
 // #133: GGUF model status
 ipcMain.handle('get-gguf-variants', (_event, modelSize?: SLMModelSize) => {
   const variants = getGGUFVariants(modelSize ?? store.get('slmModelSize'))
+  return Object.entries(variants).map(([key, v]) => ({
+    key,
+    label: v.label,
+    filename: v.filename,
+    sizeMB: v.sizeMB,
+    downloaded: isGGUFDownloaded(v.filename)
+  }))
+})
+
+// #234: Hunyuan-MT GGUF model status
+ipcMain.handle('get-hunyuan-mt-variants', () => {
+  const variants = getHunyuanMTVariants()
   return Object.entries(variants).map(([key, v]) => ({
     key,
     label: v.label,

--- a/src/main/slm-worker.ts
+++ b/src/main/slm-worker.ts
@@ -1,9 +1,10 @@
 /**
- * UtilityProcess worker for TranslateGemma 4B inference via node-llama-cpp.
+ * UtilityProcess worker for SLM inference via node-llama-cpp.
+ * Supports TranslateGemma and Hunyuan-MT models.
  * Runs in a separate process to avoid blocking the main process.
  *
  * IPC protocol:
- *   Main → Worker: { type: 'init', modelPath: string, kvCacheQuant?: boolean }
+ *   Main → Worker: { type: 'init', modelPath: string, kvCacheQuant?: boolean, modelType?: 'translategemma' | 'hunyuan-mt' }
  *   Main → Worker: { type: 'translate', id: string, text: string, from: string, to: string }
  *   Main → Worker: { type: 'summarize', id: string, transcript: string }
  *   Main → Worker: { type: 'dispose' }
@@ -11,6 +12,8 @@
  *   Worker → Main: { type: 'result', id: string, text: string }
  *   Worker → Main: { type: 'error', id?: string, message: string }
  */
+
+type ModelType = 'translategemma' | 'hunyuan-mt'
 
 const LANG_NAMES: Record<string, string> = {
   ja: 'Japanese',
@@ -21,8 +24,10 @@ let llama: any = null
 let model: any = null
 let context: any = null
 let requestQueue: Promise<void> = Promise.resolve()
+let activeModelType: ModelType = 'translategemma'
 
-async function handleInit(modelPath: string, kvCacheQuant?: boolean): Promise<void> {
+async function handleInit(modelPath: string, kvCacheQuant?: boolean, modelType?: ModelType): Promise<void> {
+  activeModelType = modelType ?? 'translategemma'
   const { getLlama } = await import('node-llama-cpp')
   llama = await getLlama({ gpu: 'auto' })
   model = await llama.loadModel({ modelPath })
@@ -101,14 +106,32 @@ async function handleTranslate(
     const fromLang = LANG_NAMES[from] ?? from
     const toLang = LANG_NAMES[to] ?? to
 
-    // Build context-enhanced prompt
-    const contextSection = buildContextPrompt(translateContext)
-    const prompt = `${contextSection}Translate the following text from ${fromLang} to ${toLang}. Output only the translation, nothing else.\n\n${text}`
+    // Build prompt based on model type
+    let prompt: string
+    let inferenceParams: { temperature: number; maxTokens: number; topK?: number; topP?: number; repeatPenalty?: number }
 
-    const response = await session.prompt(prompt, {
-      temperature: 0.1,
-      maxTokens: 512
-    })
+    if (activeModelType === 'hunyuan-mt') {
+      // Hunyuan-MT uses a specific prompt template:
+      // Chinese ↔ Other: Chinese prompt; Other ↔ Other: English prompt
+      const contextSection = buildContextPrompt(translateContext)
+      const isChinese = from === 'zh' || to === 'zh'
+      if (isChinese && to !== 'zh') {
+        prompt = `${contextSection}把下面的文本翻译成${toLang}，不要额外解释。\n\n${text}`
+      } else if (isChinese && to === 'zh') {
+        prompt = `${contextSection}把下面的文本翻译成中文，不要额外解释。\n\n${text}`
+      } else {
+        prompt = `${contextSection}Translate the following segment into ${toLang}, without additional explanation.\n\n${text}`
+      }
+      // Hunyuan-MT recommended parameters
+      inferenceParams = { temperature: 0.7, maxTokens: 512, topK: 20, topP: 0.6, repeatPenalty: 1.05 }
+    } else {
+      // TranslateGemma prompt
+      const contextSection = buildContextPrompt(translateContext)
+      prompt = `${contextSection}Translate the following text from ${fromLang} to ${toLang}. Output only the translation, nothing else.\n\n${text}`
+      inferenceParams = { temperature: 0.1, maxTokens: 512 }
+    }
+
+    const response = await session.prompt(prompt, inferenceParams)
 
     // Clean up the session context to free memory
     session.dispose?.()
@@ -196,7 +219,7 @@ process.parentPort!.on('message', (e: { data: any }) => {
     try {
       switch (msg.type) {
         case 'init':
-          await handleInit(msg.modelPath, msg.kvCacheQuant)
+          await handleInit(msg.modelPath, msg.kvCacheQuant, msg.modelType)
           break
         case 'translate':
           await handleTranslate(msg.id, msg.text, msg.from, msg.to, msg.context)

--- a/src/renderer/components/SettingsPanel.tsx
+++ b/src/renderer/components/SettingsPanel.tsx
@@ -10,7 +10,7 @@ function withIpcTimeout<T>(promise: Promise<T>, ms: number, label: string): Prom
   return Promise.race([promise, timeoutPromise]).finally(() => clearTimeout(timer))
 }
 
-type EngineMode = 'auto' | 'rotation' | 'online' | 'online-deepl' | 'online-gemini' | 'offline-opus' | 'offline-slm' | 'offline-hybrid'
+type EngineMode = 'auto' | 'rotation' | 'online' | 'online-deepl' | 'online-gemini' | 'offline-opus' | 'offline-slm' | 'offline-hunyuan-mt' | 'offline-hybrid'
 
 interface DisplayInfo {
   id: number
@@ -269,6 +269,12 @@ function SettingsPanel(): JSX.Element {
           mode: 'cascade' as const,
           sttEngineId: sttEngine,
           translatorEngineId: 'slm-translate'
+        }
+      } else if (resolvedMode === 'offline-hunyuan-mt') {
+        config = {
+          mode: 'cascade' as const,
+          sttEngineId: sttEngine,
+          translatorEngineId: 'hunyuan-mt'
         }
       } else if (resolvedMode === 'offline-hybrid') {
         config = {
@@ -608,7 +614,25 @@ function SettingsPanel(): JSX.Element {
             )}
           </div>
         </label>
-        {(engineMode === 'offline-slm' || engineMode === 'offline-hybrid') && (
+        <label style={radioLabelStyle}>
+          <input
+            type="radio"
+            name="engine"
+            checked={engineMode === 'offline-hunyuan-mt'}
+            onChange={() => setEngineMode('offline-hunyuan-mt')}
+            disabled={isRunning || isStarting}
+          />
+          <div>
+            <div style={{ fontWeight: 500 }}>Hunyuan-MT 7B (WMT25 Winner)</div>
+            <div style={{ fontSize: '12px', color: '#94a3b8' }}>JA↔EN, 33 languages, GPU-accelerated, ~4.7GB download</div>
+            {engineMode === 'offline-hunyuan-mt' && gpuInfo && !gpuInfo.hasGpu && (
+              <div style={{ fontSize: '11px', color: '#f59e0b', marginTop: '2px' }}>
+                No GPU detected — translation may be slow on CPU-only systems
+              </div>
+            )}
+          </div>
+        </label>
+        {(engineMode === 'offline-slm' || engineMode === 'offline-hunyuan-mt' || engineMode === 'offline-hybrid') && (
           <>
             <div style={{ paddingLeft: '24px', display: 'flex', flexDirection: 'column', gap: '2px' }}>
               <div style={{ fontSize: '11px', fontWeight: 600, color: '#94a3b8', marginBottom: '2px' }}>Model Size</div>


### PR DESCRIPTION
## Summary

- Add Hunyuan-MT-7B (WMT25 winner, 30/31 categories) as a new offline translation engine
- Reuse existing slm-worker.ts UtilityProcess with model-type-aware prompt formatting
- GGUF variants: Q4_K_M (~4.7GB), Q8_0 (~8.0GB), Q3_K_M (~3.8GB) via Mungert quantizations
- Uses Hunyuan-MT's official prompt template and recommended inference parameters (top_k=20, top_p=0.6, temp=0.7)

## Changes

- `src/engines/translator/HunyuanMTTranslator.ts` — New translator class (mirrors SLMTranslator pattern)
- `src/engines/model-downloader.ts` — Add HUNYUAN_MT_VARIANTS config and getHunyuanMTVariants()
- `src/main/slm-worker.ts` — Extend to support modelType field for Hunyuan-MT prompt format
- `src/main/index.ts` — Register hunyuan-mt engine factory and IPC handler
- `src/renderer/components/SettingsPanel.tsx` — Add Hunyuan-MT radio option in Offline section

## Test plan

- [ ] Select Hunyuan-MT 7B in settings and start pipeline — model downloads and loads
- [ ] Verify JA→EN and EN→JA translation quality against TranslateGemma 4B
- [ ] Benchmark inference speed on M-series Mac (tok/s)
- [ ] Verify KV cache quantization toggle works with Hunyuan-MT
- [ ] Verify model download resume works on interrupted download
- [ ] All 45 existing tests pass

Closes #234