### PR TITLE
243 Add Windows platform support

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -24,6 +24,17 @@ mac:
   entitlementsInherit: build/entitlements.mac.plist
   extendInfo:
     NSMicrophoneUsageDescription: "live-translate needs microphone access for real-time speech recognition and translation."
+win:
+  target:
+    - target: nsis
+      arch:
+        - x64
+  icon: build/icon.ico
+nsis:
+  oneClick: false
+  perMachine: false
+  allowToChangeInstallationDirectory: true
+  deleteAppDataOnUninstall: false
 dmg:
   contents:
     - x: 130

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "preview": "electron-vite preview",
     "package": "electron-builder",
     "package:dmg": "electron-vite build && electron-builder --mac dmg",
+    "package:win": "electron-vite build && electron-builder --win nsis",
     "test": "vitest run",
     "test:watch": "vitest"
   },

--- a/scripts/after-pack.js
+++ b/scripts/after-pack.js
@@ -5,6 +5,8 @@ const path = require('path')
 const { execSync } = require('child_process')
 
 exports.default = async function afterPack(context) {
+  // macOS-specific fixes: symlinks and rpath for whisper-node-addon
+  // Windows uses .dll and doesn't need these fixes
   if (process.platform !== 'darwin') return
 
   const appOutDir = context.appOutDir

--- a/scripts/fix-whisper-addon.js
+++ b/scripts/fix-whisper-addon.js
@@ -13,23 +13,27 @@ if (!fs.existsSync(addonDist)) {
   process.exit(0)
 }
 
-// Fix 1: Create symlinks for platform naming
-const symlinkMappings = [
-  { from: 'mac-arm64', to: 'darwin-arm64' },
-  { from: 'mac-x64', to: 'darwin-x64' }
-]
+// Fix 1: Create symlinks for platform naming (macOS only)
+if (process.platform === 'darwin') {
+  const symlinkMappings = [
+    { from: 'mac-arm64', to: 'darwin-arm64' },
+    { from: 'mac-x64', to: 'darwin-x64' }
+  ]
 
-for (const { from, to } of symlinkMappings) {
-  const source = path.join(addonDist, from)
-  const target = path.join(addonDist, to)
+  for (const { from, to } of symlinkMappings) {
+    const source = path.join(addonDist, from)
+    const target = path.join(addonDist, to)
 
-  if (fs.existsSync(source) && !fs.existsSync(target)) {
-    fs.symlinkSync(from, target, 'dir')
-    console.log(`[fix-whisper-addon] Created symlink: ${to} -> ${from}`)
+    if (fs.existsSync(source) && !fs.existsSync(target)) {
+      fs.symlinkSync(from, target, 'dir')
+      console.log(`[fix-whisper-addon] Created symlink: ${to} -> ${from}`)
+    }
   }
+} else {
+  console.log('[fix-whisper-addon] Skipping symlinks on non-macOS platform')
 }
 
-// Fix 2: Add rpath for dylib loading on macOS
+// Fix 2: Add rpath for dylib loading (macOS only)
 if (process.platform === 'darwin') {
   const archDir = process.arch === 'arm64' ? 'mac-arm64' : 'mac-x64'
   const addonDir = path.join(addonDist, archDir)

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -140,9 +140,12 @@ function initPipeline(): void {
   pipeline.registerSTT('whisper-local', () => new WhisperLocalEngine({
     onProgress: (msg) => mainWindow?.webContents.send('status-update', msg)
   }))
-  pipeline.registerSTT('mlx-whisper', () => new MlxWhisperEngine({
-    onProgress: (msg) => mainWindow?.webContents.send('status-update', msg)
-  }))
+  // mlx-whisper is Apple Silicon only — skip registration on other platforms
+  if (process.platform === 'darwin') {
+    pipeline.registerSTT('mlx-whisper', () => new MlxWhisperEngine({
+      onProgress: (msg) => mainWindow?.webContents.send('status-update', msg)
+    }))
+  }
   pipeline.registerSTT('moonshine', () => new MoonshineEngine({
     onProgress: (msg) => mainWindow?.webContents.send('status-update', msg)
   }))
@@ -639,6 +642,9 @@ ipcMain.handle('list-plugins', () => listPlugins())
 ipcMain.handle('detect-gpu', async () => {
   return detectGpu()
 })
+
+// #243: Platform info for renderer to hide platform-specific options
+ipcMain.handle('get-platform', () => process.platform)
 
 // #116: Get session usage logs for feedback collection
 ipcMain.handle('get-session-logs', () => {

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -33,6 +33,7 @@ export interface ElectronAPI {
   saveSubtitleSettings: (settings: Record<string, unknown>) => Promise<void>
   onSubtitleSettingsChanged: (callback: (settings: unknown) => void) => (() => void)
   onDisplaysChanged: (callback: () => void) => (() => void)
+  getPlatform: () => Promise<string>
 }
 
 declare global {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -85,6 +85,9 @@ contextBridge.exposeInMainWorld('api', {
   saveGlossary: (terms: Array<{ source: string; target: string }>) =>
     ipcRenderer.invoke('save-glossary', terms),
 
+  // #243: Platform detection for hiding platform-specific options
+  getPlatform: () => ipcRenderer.invoke('get-platform'),
+
   // Display change notifications (#192)
   onDisplaysChanged: (callback: () => void) => {
     const handler = (): void => callback()

--- a/src/renderer/components/SettingsPanel.tsx
+++ b/src/renderer/components/SettingsPanel.tsx
@@ -59,6 +59,9 @@ function SettingsPanel(): JSX.Element {
   const [newGlossarySource, setNewGlossarySource] = useState('')
   const [newGlossaryTarget, setNewGlossaryTarget] = useState('')
 
+  // #243: Platform detection for hiding macOS-only options
+  const [platform, setPlatform] = useState<string>('darwin')
+
   // Meeting summary (#124)
   const [lastTranscriptPath, setLastTranscriptPath] = useState<string | null>(null)
   const [summaryText, setSummaryText] = useState<string | null>(null)
@@ -118,6 +121,9 @@ function SettingsPanel(): JSX.Element {
         if (sub.position) setSubtitlePosition(sub.position as 'top' | 'bottom')
       }
     })
+
+    // #243: detect platform to hide macOS-only options
+    window.api.getPlatform().then(setPlatform).catch(() => {})
 
     // #54: check for crashed session
     window.api.getCrashedSession().then((session) => {
@@ -472,7 +478,9 @@ function SettingsPanel(): JSX.Element {
         )}
         {!audio.hasVirtualAudioDevice && (
           <div style={{ marginTop: '6px', fontSize: '11px', color: '#94a3b8' }}>
-            To capture Zoom/Teams audio, install BlackHole (free) and select it as the input device
+            {platform === 'win32'
+              ? 'To capture Zoom/Teams audio, enable Stereo Mix in Sound settings or install VB-Audio Virtual Cable'
+              : 'To capture Zoom/Teams audio, install BlackHole (free) and select it as the input device'}
           </div>
         )}
       </Section>
@@ -487,7 +495,9 @@ function SettingsPanel(): JSX.Element {
           aria-label="STT engine"
         >
           <option value="whisper-local">Whisper (whisper.cpp)</option>
-          <option value="mlx-whisper">mlx-whisper (Apple Silicon, faster)</option>
+          {platform === 'darwin' && (
+            <option value="mlx-whisper">mlx-whisper (Apple Silicon, faster)</option>
+          )}
           <option value="moonshine">Moonshine AI (ultra-fast, experimental)</option>
         </select>
         {sttEngine === 'moonshine' && (

--- a/src/renderer/hooks/useAudioCapture.ts
+++ b/src/renderer/hooks/useAudioCapture.ts
@@ -60,8 +60,8 @@ export function useAudioCapture(): UseAudioCaptureReturn {
           .filter((d) => d.kind === 'audioinput')
           .map((d) => ({ deviceId: d.deviceId, label: d.label || `Microphone ${d.deviceId.slice(0, 6)}` }))
         setDevices(audioInputs)
-        // #125: Detect virtual audio devices (BlackHole, Soundflower, Loopback)
-        const virtualKeywords = ['blackhole', 'soundflower', 'loopback', 'virtual']
+        // #125/#243: Detect virtual audio devices (macOS: BlackHole/Soundflower, Windows: Stereo Mix/VB-Audio)
+        const virtualKeywords = ['blackhole', 'soundflower', 'loopback', 'virtual', 'stereo mix', 'vb-audio', 'voicemeeter']
         const hasVirtual = audioInputs.some((d) =>
           virtualKeywords.some((kw) => d.label.toLowerCase().includes(kw))
         )


### PR DESCRIPTION
## Description

Add Windows platform support. Most of the codebase was already cross-platform — this adds the remaining platform-specific guards and build configuration.

### Changes

- **electron-builder.yml**: Add `win:` target (NSIS installer, x64) and `nsis:` configuration
- **package.json**: Add `package:win` build script
- **src/main/index.ts**: Guard mlx-whisper STT registration with `process.platform === 'darwin'`; add `get-platform` IPC handler
- **src/preload/index.ts + index.d.ts**: Expose `getPlatform()` API to renderer
- **src/renderer/components/SettingsPanel.tsx**: Hide mlx-whisper option on non-macOS; show Windows-specific virtual audio device instructions (Stereo Mix, VB-Audio)
- **src/renderer/hooks/useAudioCapture.ts**: Add Windows virtual audio device keywords (Stereo Mix, VB-Audio, VoiceMeeter)
- **scripts/fix-whisper-addon.js**: Guard macOS-only symlink creation with platform check
- **scripts/after-pack.js**: Add clarifying comment for platform guard

Closes #243