### PR TITLE
239 Add simultaneous translation with Wait-k policy

### DIFF
--- a/src/engines/translator/HunyuanMTTranslator.ts
+++ b/src/engines/translator/HunyuanMTTranslator.ts
@@ -144,6 +144,40 @@ export class HunyuanMTTranslator implements TranslatorEngine {
     })
   }
 
+  async translateIncremental(
+    text: string,
+    previousOutput: string,
+    from: Language,
+    to: Language,
+    context?: TranslateContext
+  ): Promise<string> {
+    if (!text.trim()) return previousOutput || ''
+    if (from === to) return text
+    if (!this.worker) {
+      throw new Error('[hunyuan-mt] Not initialized')
+    }
+
+    const id = String(this.nextId++)
+
+    return new Promise<string>((resolve, reject) => {
+      const timer = setTimeout(() => {
+        this.pending.delete(id)
+        reject(new Error('Hunyuan-MT incremental translation timed out'))
+      }, TRANSLATE_TIMEOUT_MS)
+
+      this.pending.set(id, { resolve, reject, timer })
+      this.worker!.postMessage({
+        type: 'translate-incremental',
+        id,
+        text,
+        previousOutput,
+        from,
+        to,
+        context
+      })
+    })
+  }
+
   async dispose(): Promise<void> {
     if (this.worker) {
       try {

--- a/src/engines/translator/SLMTranslator.ts
+++ b/src/engines/translator/SLMTranslator.ts
@@ -161,6 +161,40 @@ export class SLMTranslator implements TranslatorEngine {
     })
   }
 
+  async translateIncremental(
+    text: string,
+    previousOutput: string,
+    from: Language,
+    to: Language,
+    context?: TranslateContext
+  ): Promise<string> {
+    if (!text.trim()) return previousOutput || ''
+    if (from === to) return text
+    if (!this.worker) {
+      throw new Error('[slm-translator] Not initialized')
+    }
+
+    const id = String(this.nextId++)
+
+    return new Promise<string>((resolve, reject) => {
+      const timer = setTimeout(() => {
+        this.pending.delete(id)
+        reject(new Error('TranslateGemma incremental translation timed out'))
+      }, TRANSLATE_TIMEOUT_MS)
+
+      this.pending.set(id, { resolve, reject, timer })
+      this.worker!.postMessage({
+        type: 'translate-incremental',
+        id,
+        text,
+        previousOutput,
+        from,
+        to,
+        context
+      })
+    })
+  }
+
   async summarize(transcript: string): Promise<string> {
     if (!this.worker) {
       throw new Error('[slm-translator] Not initialized')

--- a/src/engines/types.ts
+++ b/src/engines/types.ts
@@ -72,6 +72,20 @@ export interface TranslatorEngine {
   /** Translate text from one language to another */
   translate(text: string, from: Language, to: Language, context?: TranslateContext): Promise<string>
 
+  /**
+   * Incremental translation for SimulMT (Wait-k policy).
+   * Translates partial source text while maintaining consistency with previous output.
+   * The returned translation must extend (not replace) previousOutput.
+   * Optional — only offline LLM engines (TranslateGemma, Hunyuan-MT) support this.
+   */
+  translateIncremental?(
+    text: string,
+    previousOutput: string,
+    from: Language,
+    to: Language,
+    context?: TranslateContext
+  ): Promise<string>
+
   /** Release resources */
   dispose(): Promise<void>
 }

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -321,6 +321,9 @@ ipcMain.handle('pipeline-start', async (_event, config: PipelineStartConfig) => 
     const glossaryTerms = store.get('glossaryTerms') || []
     pipeline!.setGlossary(glossaryTerms)
 
+    // Configure SimulMT (#239)
+    pipeline!.setSimulMt(store.get('simulMtEnabled'), store.get('simulMtWaitK'))
+
     // Start logger
     logger = new TranscriptLogger((msg) => mainWindow?.webContents.send('status-update', msg))
     const sessionLabel = config.mode === 'e2e'
@@ -519,7 +522,9 @@ ipcMain.handle('get-settings', () => {
     slmKvCacheQuant: store.get('slmKvCacheQuant'),
     slmModelSize: store.get('slmModelSize'),
     slmSpeculativeDecoding: store.get('slmSpeculativeDecoding'),
-    glossaryTerms: store.get('glossaryTerms') || []
+    glossaryTerms: store.get('glossaryTerms') || [],
+    simulMtEnabled: store.get('simulMtEnabled'),
+    simulMtWaitK: store.get('simulMtWaitK')
   }
 })
 

--- a/src/main/slm-worker.ts
+++ b/src/main/slm-worker.ts
@@ -6,6 +6,7 @@
  * IPC protocol:
  *   Main → Worker: { type: 'init', modelPath: string, kvCacheQuant?: boolean, modelType?: 'translategemma' | 'hunyuan-mt', draftModelPath?: string }
  *   Main → Worker: { type: 'translate', id: string, text: string, from: string, to: string }
+ *   Main → Worker: { type: 'translate-incremental', id: string, text: string, previousOutput: string, from: string, to: string }
  *   Main → Worker: { type: 'summarize', id: string, transcript: string }
  *   Main → Worker: { type: 'dispose' }
  *   Worker → Main: { type: 'ready' }
@@ -199,6 +200,81 @@ async function handleTranslate(
   }
 }
 
+async function handleTranslateIncremental(
+  id: string,
+  text: string,
+  previousOutput: string,
+  from: string,
+  to: string,
+  translateContext?: {
+    previousSegments?: Array<{ source: string; translated: string; speakerId?: string }>
+    glossary?: Array<{ source: string; target: string }>
+    speakerId?: string
+  }
+): Promise<void> {
+  if (!context) {
+    process.parentPort!.postMessage({
+      type: 'error',
+      id,
+      message: 'Model not initialized'
+    })
+    return
+  }
+
+  try {
+    const { LlamaChatSession } = await import('node-llama-cpp')
+
+    const contextSequence = context.getSequence()
+    const session = new LlamaChatSession({ contextSequence })
+
+    const fromLang = LANG_NAMES[from] ?? from
+    const toLang = LANG_NAMES[to] ?? to
+
+    const contextSection = buildContextPrompt(translateContext)
+
+    // Build prompt with instruction to continue from previous output
+    let prompt: string
+    if (activeModelType === 'hunyuan-mt') {
+      const isChinese = from === 'zh' || to === 'zh'
+      if (isChinese && to !== 'zh') {
+        prompt = `${contextSection}把下面的文本翻译成${toLang}，不要额外解释。\n\n${text}`
+      } else if (isChinese && to === 'zh') {
+        prompt = `${contextSection}把下面的文本翻译成中文，不要额外解释。\n\n${text}`
+      } else {
+        prompt = `${contextSection}Translate the following segment into ${toLang}, without additional explanation.\n\n${text}`
+      }
+    } else {
+      prompt = `${contextSection}Translate the following text from ${fromLang} to ${toLang}. Output only the translation, nothing else.\n\n${text}`
+    }
+
+    // Use responsePrefix to force the model to continue from previous output
+    // This implements prefix-constrained decoding for SimulMT consistency
+    const inferenceParams = activeModelType === 'hunyuan-mt'
+      ? { temperature: 0.7, maxTokens: 512, topK: 20, topP: 0.6, repeatPenalty: 1.05 }
+      : { temperature: 0.1, maxTokens: 512 }
+
+    const response = await session.prompt(prompt, {
+      ...inferenceParams,
+      ...(previousOutput.trim() && { responsePrefix: previousOutput })
+    })
+
+    contextSequence.dispose?.()
+    session.dispose?.()
+
+    process.parentPort!.postMessage({
+      type: 'result',
+      id,
+      text: response.trim()
+    })
+  } catch (err) {
+    process.parentPort!.postMessage({
+      type: 'error',
+      id,
+      message: err instanceof Error ? err.message : String(err)
+    })
+  }
+}
+
 async function handleSummarize(id: string, transcript: string): Promise<void> {
   if (!context) {
     process.parentPort!.postMessage({
@@ -282,6 +358,9 @@ process.parentPort!.on('message', (e: { data: any }) => {
         case 'translate':
           await handleTranslate(msg.id, msg.text, msg.from, msg.to, msg.context)
           break
+        case 'translate-incremental':
+          await handleTranslateIncremental(msg.id, msg.text, msg.previousOutput, msg.from, msg.to, msg.context)
+          break
         case 'summarize':
           await handleSummarize(msg.id, msg.transcript)
           break
@@ -298,7 +377,7 @@ process.parentPort!.on('message', (e: { data: any }) => {
     }
   }
 
-  if (msg.type === 'translate' || msg.type === 'summarize') {
+  if (msg.type === 'translate' || msg.type === 'translate-incremental' || msg.type === 'summarize') {
     // Queue to serialize context access
     requestQueue = requestQueue.then(handleMessage, handleMessage)
   } else {

--- a/src/main/store.ts
+++ b/src/main/store.ts
@@ -50,6 +50,10 @@ export interface AppSettings {
   glossaryTerms: GlossaryEntry[]
   /** Enable speculative decoding: 4B draft model + 12B verifier for 2-3x throughput */
   slmSpeculativeDecoding: boolean
+  /** Enable simultaneous translation (SimulMT) with Wait-k policy for lower latency */
+  simulMtEnabled: boolean
+  /** Wait-k value: start translating after k confirmed words (default 3) */
+  simulMtWaitK: number
 }
 
 export const store = new Store<AppSettings>({
@@ -77,6 +81,8 @@ export const store = new Store<AppSettings>({
     slmKvCacheQuant: true,
     slmModelSize: '4b',
     glossaryTerms: [],
-    slmSpeculativeDecoding: false
+    slmSpeculativeDecoding: false,
+    simulMtEnabled: false,
+    simulMtWaitK: 3
   }
 })

--- a/src/pipeline/TranslationPipeline.ts
+++ b/src/pipeline/TranslationPipeline.ts
@@ -66,6 +66,11 @@ export class TranslationPipeline extends EventEmitter {
   private speakerTracker = new SpeakerTracker()
   private lastTranslatedConfirmed = ''
 
+  // SimulMT state
+  private simulMtEnabled = false
+  private simulMtWaitK = 3
+  private simulMtPreviousOutput = ''
+
   // Streaming mutex (separate from lifecycle state)
   private streamingLock = false
   private streamingLockResolvers: Array<() => void> = []
@@ -142,6 +147,12 @@ export class TranslationPipeline extends EventEmitter {
   /** Set glossary terms for context-aware translation */
   setGlossary(glossary: GlossaryEntry[]): void {
     this.glossary = glossary
+  }
+
+  /** Configure simultaneous translation (Wait-k policy) */
+  setSimulMt(enabled: boolean, waitK: number): void {
+    this.simulMtEnabled = enabled
+    this.simulMtWaitK = Math.max(1, Math.min(waitK, 10))
   }
 
   // --- Engine registration ---
@@ -271,6 +282,7 @@ export class TranslationPipeline extends EventEmitter {
     this.contextBuffer.reset()
     this.speakerTracker.reset()
     this.lastTranslatedConfirmed = ''
+    this.simulMtPreviousOutput = ''
     // Dispose engines to free memory (#211)
     await this.disposeEngines()
   }
@@ -381,6 +393,7 @@ export class TranslationPipeline extends EventEmitter {
       this.agreement.reset()
       this.contextBuffer.reset()
       this.lastTranslatedConfirmed = ''
+      this.simulMtPreviousOutput = ''
 
       // Temporarily go to IDLE so switchEngine can transition to INITIALIZING
       this.setState(PipelineState.IDLE)
@@ -416,6 +429,7 @@ export class TranslationPipeline extends EventEmitter {
         // Reset agreement on silence to prevent stale state accumulation (#75)
         this.agreement.reset()
         this.lastTranslatedConfirmed = ''
+        this.simulMtPreviousOutput = ''
         return null
       }
 
@@ -426,7 +440,29 @@ export class TranslationPipeline extends EventEmitter {
       const glossary = this.glossary.length > 0 ? this.glossary : undefined
 
       let translatedText = ''
-      if (agreement.newConfirmed && this.translator) {
+
+      // SimulMT path: use incremental translation with Wait-k policy
+      if (
+        this.simulMtEnabled &&
+        this.translator?.translateIncremental &&
+        agreement.confirmedText.trim()
+      ) {
+        const wordCount = this.countWords(agreement.confirmedText, sttResult.language)
+        if (wordCount >= this.simulMtWaitK) {
+          translatedText = await this.translator.translateIncremental(
+            agreement.confirmedText,
+            this.simulMtPreviousOutput,
+            sttResult.language,
+            targetLang,
+            this.contextBuffer.getContext(glossary, speakerId)
+          )
+          this.simulMtPreviousOutput = translatedText
+          this.lastTranslatedConfirmed = translatedText
+        } else {
+          translatedText = this.simulMtPreviousOutput || this.lastTranslatedConfirmed
+        }
+      } else if (agreement.newConfirmed && this.translator) {
+        // Standard path: translate only when new confirmed text appears
         translatedText = await this.translator.translate(
           agreement.confirmedText,
           sttResult.language,
@@ -437,6 +473,7 @@ export class TranslationPipeline extends EventEmitter {
       } else {
         translatedText = this.lastTranslatedConfirmed
       }
+
       const interimResult: TranslationResult = {
         sourceText: agreement.confirmedText + agreement.interimText,
         translatedText,
@@ -481,6 +518,7 @@ export class TranslationPipeline extends EventEmitter {
       if (!sttResult || !sttResult.text.trim()) {
         this.agreement.reset()
         this.lastTranslatedConfirmed = ''
+        this.simulMtPreviousOutput = ''
         return null
       }
 
@@ -502,6 +540,7 @@ export class TranslationPipeline extends EventEmitter {
       }
 
       this.lastTranslatedConfirmed = ''
+      this.simulMtPreviousOutput = ''
       const result: TranslationResult = {
         sourceText: agreement.confirmedText,
         translatedText,
@@ -529,6 +568,18 @@ export class TranslationPipeline extends EventEmitter {
       for (const r of this.streamingLockResolvers) r()
       this.streamingLockResolvers = []
     }
+  }
+
+  /**
+   * Count words in text. For CJK text (Japanese/Chinese), count characters
+   * since there are no space-delimited word boundaries.
+   */
+  private countWords(text: string, language: Language): number {
+    if (language === 'ja') {
+      // For Japanese, each character roughly corresponds to a morpheme
+      return text.replace(/\s/g, '').length
+    }
+    return text.trim().split(/\s+/).filter(Boolean).length
   }
 
   /** Resolve the target language for a given source language */

--- a/src/renderer/components/SettingsPanel.tsx
+++ b/src/renderer/components/SettingsPanel.tsx
@@ -58,6 +58,10 @@ function SettingsPanel(): JSX.Element {
   const [slmSpeculativeDecoding, setSlmSpeculativeDecoding] = useState(false)
   const [draftModelAvailable, setDraftModelAvailable] = useState(false)
 
+  // SimulMT (#239)
+  const [simulMtEnabled, setSimulMtEnabled] = useState(false)
+  const [simulMtWaitK, setSimulMtWaitK] = useState(3)
+
   // Glossary (#240)
   const [glossaryTerms, setGlossaryTerms] = useState<Array<{ source: string; target: string }>>([])
   const [newGlossarySource, setNewGlossarySource] = useState('')
@@ -117,6 +121,8 @@ function SettingsPanel(): JSX.Element {
       if (s.slmModelSize) setSlmModelSize(s.slmModelSize as '4b' | '12b')
       if (s.slmSpeculativeDecoding !== undefined) setSlmSpeculativeDecoding(s.slmSpeculativeDecoding as boolean)
       if (s.glossaryTerms) setGlossaryTerms(s.glossaryTerms as Array<{ source: string; target: string }>)
+      if (s.simulMtEnabled !== undefined) setSimulMtEnabled(s.simulMtEnabled as boolean)
+      if (s.simulMtWaitK !== undefined) setSimulMtWaitK(s.simulMtWaitK as number)
       if (s.subtitleSettings) {
         const sub = s.subtitleSettings as Record<string, unknown>
         if (sub.fontSize) setSubtitleFontSize(sub.fontSize as number)
@@ -226,7 +232,9 @@ function SettingsPanel(): JSX.Element {
         sttEngine,
         slmKvCacheQuant,
         slmModelSize,
-        slmSpeculativeDecoding
+        slmSpeculativeDecoding,
+        simulMtEnabled,
+        simulMtWaitK
       }), 10_000, 'saveSettings')
 
       // Resolve auto mode to concrete engine
@@ -720,6 +728,44 @@ function SettingsPanel(): JSX.Element {
                   )}
                 </div>
               </label>
+            )}
+            {/* SimulMT (#239) */}
+            <label style={{ ...radioLabelStyle, paddingLeft: '24px' }}>
+              <input
+                type="checkbox"
+                checked={simulMtEnabled}
+                onChange={(e) => setSimulMtEnabled(e.target.checked)}
+                disabled={isRunning || isStarting}
+              />
+              <div>
+                <div style={{ fontWeight: 500, fontSize: '12px' }}>
+                  Simultaneous translation (SimulMT)
+                </div>
+                <div style={{ fontSize: '11px', color: '#94a3b8' }}>
+                  Start translating before the speaker finishes. Lower latency, requires offline LLM engine.
+                </div>
+              </div>
+            </label>
+            {simulMtEnabled && (
+              <div style={{ paddingLeft: '48px', marginTop: '-4px', marginBottom: '4px' }}>
+                <div style={{ fontSize: '11px', color: '#94a3b8', marginBottom: '4px' }}>
+                  Wait-k: start after {simulMtWaitK} confirmed words
+                </div>
+                <input
+                  type="range"
+                  aria-label="Wait-k value"
+                  min={1}
+                  max={10}
+                  value={simulMtWaitK}
+                  onChange={(e) => setSimulMtWaitK(Number(e.target.value))}
+                  disabled={isRunning || isStarting}
+                  style={{ width: '100%' }}
+                />
+                <div style={{ display: 'flex', justifyContent: 'space-between', fontSize: '10px', color: '#64748b' }}>
+                  <span>1 (faster, less stable)</span>
+                  <span>10 (slower, more stable)</span>
+                </div>
+              </div>
             )}
           </>
         )}


### PR DESCRIPTION
## Summary

- Implement SimulMT (simultaneous machine translation) with Wait-k policy for lower-latency streaming translation
- Translation begins after k confirmed words from STT instead of waiting for the full sentence to complete
- Uses prefix-constrained decoding (`responsePrefix` in node-llama-cpp) to maintain consistency across incremental translation updates
- Only available for offline LLM engines (TranslateGemma, Hunyuan-MT) which support low-latency incremental inference

## Changes

- **types.ts**: Add optional `translateIncremental()` method to `TranslatorEngine` interface
- **SLMTranslator.ts / HunyuanMTTranslator.ts**: Implement `translateIncremental` via IPC to slm-worker
- **slm-worker.ts**: Add `translate-incremental` message handler using `responsePrefix` for prefix-constrained decoding
- **TranslationPipeline.ts**: Add SimulMT logic in `processStreaming()` — tracks confirmed word count, triggers incremental translation when >= k, resets state on silence/finalize
- **SettingsPanel.tsx**: Add SimulMT toggle checkbox and Wait-k slider (1-10) in offline engine settings
- **store.ts**: Persist `simulMtEnabled` and `simulMtWaitK` settings

## Test plan

- [x] Build passes (`npm run build`)
- [x] All 45 unit tests pass (`npm test`)
- [ ] Manual: Enable SimulMT with TranslateGemma, verify translation starts after k words
- [ ] Manual: Verify translation output extends (not replaces) previous output during streaming
- [ ] Manual: Verify final translation replaces incremental output on speech end
- [ ] Manual: Test with different k values (1, 3, 5, 10) and verify latency/quality tradeoff
- [ ] Manual: Verify SimulMT toggle is disabled for online-only engines

Closes #239