### PR TITLE
242 Add CTranslate2 backend for OPUS-MT acceleration

### DIFF
--- a/resources/ct2-opus-mt-bridge.py
+++ b/resources/ct2-opus-mt-bridge.py
@@ -1,0 +1,196 @@
+#!/usr/bin/env python3
+"""
+Python subprocess bridge for CTranslate2-accelerated OPUS-MT translation.
+
+Protocol (stdin/stdout JSON lines):
+  Input:  {"action": "init", "model_ja_en": "Helsinki-NLP/opus-mt-ja-en", "model_en_ja": "Helsinki-NLP/opus-mt-en-jap", "device": "auto", "quantization": "int8"}
+  Input:  {"action": "translate", "text": "...", "direction": "ja-en"}
+  Input:  {"action": "dispose"}
+  Output: {"ready": true} | {"translated": "..."} | {"error": "..."}
+
+Dependencies: pip install ctranslate2 transformers sentencepiece
+"""
+import sys
+import json
+import os
+import shutil
+
+# Global state
+translators = {}  # direction -> ctranslate2.Translator
+tokenizers = {}   # direction -> transformers.AutoTokenizer
+_current_req_id = None
+
+
+def output(data):
+    """Write JSON response to stdout."""
+    if _current_req_id is not None:
+        data["_reqId"] = _current_req_id
+    print(json.dumps(data), flush=True)
+
+
+def get_cache_dir():
+    """Get the model cache directory."""
+    # Use XDG cache or fallback
+    base = os.environ.get("CT2_CACHE_DIR") or os.path.join(
+        os.path.expanduser("~"), ".cache", "live-translate", "ct2-models"
+    )
+    os.makedirs(base, exist_ok=True)
+    return base
+
+
+def convert_model(hf_model_name, quantization="int8"):
+    """Convert a HuggingFace OPUS-MT model to CTranslate2 format if not already done."""
+    import ctranslate2
+
+    safe_name = hf_model_name.replace("/", "_")
+    output_dir = os.path.join(get_cache_dir(), f"{safe_name}_ct2_{quantization}")
+
+    # Check if already converted
+    model_file = os.path.join(output_dir, "model.bin")
+    if os.path.exists(model_file):
+        return output_dir
+
+    # Convert using CTranslate2 converter
+    output({"status": f"Converting {hf_model_name} to CTranslate2 ({quantization})..."})
+
+    converter = ctranslate2.converters.TransformersConverter(hf_model_name)
+    converter.convert(output_dir, quantization=quantization, force=True)
+
+    return output_dir
+
+
+def init_model(
+    model_ja_en="Helsinki-NLP/opus-mt-ja-en",
+    model_en_ja="Helsinki-NLP/opus-mt-en-jap",
+    device="auto",
+    quantization="int8",
+):
+    """Initialize CTranslate2 translators for both directions."""
+    global translators, tokenizers
+
+    try:
+        import ctranslate2
+        from transformers import AutoTokenizer
+    except ImportError as e:
+        output(
+            {
+                "error": f"Missing dependency: {e}. "
+                "Run: pip install ctranslate2 transformers sentencepiece"
+            }
+        )
+        return
+
+    # Resolve device
+    if device == "auto":
+        device = "cuda" if ctranslate2.get_cuda_device_count() > 0 else "cpu"
+
+    directions = {"ja-en": model_ja_en, "en-ja": model_en_ja}
+
+    for direction, hf_model in directions.items():
+        try:
+            output({"status": f"Loading {direction} model..."})
+
+            # Convert model to CT2 format (cached)
+            ct2_dir = convert_model(hf_model, quantization)
+
+            # Load translator
+            translators[direction] = ctranslate2.Translator(
+                ct2_dir,
+                device=device,
+                compute_type=quantization,
+                inter_threads=1,
+                intra_threads=os.cpu_count() or 4,
+            )
+
+            # Load tokenizer from original HF model
+            tokenizers[direction] = AutoTokenizer.from_pretrained(hf_model)
+
+        except Exception as e:
+            output({"error": f"Failed to load {direction} model: {e}"})
+            return
+
+    output({"ready": True, "device": device, "quantization": quantization})
+
+
+def translate(text, direction):
+    """Translate text using CTranslate2."""
+    if direction not in translators:
+        output({"error": f"Model not initialized for direction: {direction}"})
+        return
+
+    if not text or not text.strip():
+        output({"translated": ""})
+        return
+
+    try:
+        translator = translators[direction]
+        tokenizer = tokenizers[direction]
+
+        # Tokenize using HF tokenizer
+        encoded = tokenizer.encode(text)
+        tokens = tokenizer.convert_ids_to_tokens(encoded)
+
+        # Translate
+        results = translator.translate_batch(
+            [tokens],
+            beam_size=4,
+            max_decoding_length=256,
+            repetition_penalty=1.2,
+        )
+
+        # Decode output tokens
+        target_tokens = results[0].hypotheses[0]
+        target_ids = tokenizer.convert_tokens_to_ids(target_tokens)
+        translated = tokenizer.decode(target_ids, skip_special_tokens=True)
+
+        output({"translated": translated})
+    except Exception as e:
+        output({"error": f"Translation failed: {e}"})
+
+
+def dispose():
+    """Release all model resources."""
+    global translators, tokenizers
+    translators.clear()
+    tokenizers.clear()
+    output({"disposed": True})
+    sys.exit(0)
+
+
+def main():
+    global _current_req_id
+
+    for line in sys.stdin:
+        line = line.strip()
+        if not line:
+            continue
+
+        try:
+            msg = json.loads(line)
+            _current_req_id = msg.get("_reqId")
+            action = msg.get("action")
+
+            if action == "init":
+                init_model(
+                    model_ja_en=msg.get("model_ja_en", "Helsinki-NLP/opus-mt-ja-en"),
+                    model_en_ja=msg.get("model_en_ja", "Helsinki-NLP/opus-mt-en-jap"),
+                    device=msg.get("device", "auto"),
+                    quantization=msg.get("quantization", "int8"),
+                )
+            elif action == "translate":
+                translate(msg.get("text", ""), msg.get("direction", "ja-en"))
+            elif action == "dispose":
+                dispose()
+            else:
+                output({"error": f"Unknown action: {action}"})
+        except json.JSONDecodeError:
+            _current_req_id = None
+            output({"error": "Invalid JSON"})
+        except Exception as e:
+            output({"error": str(e)})
+        finally:
+            _current_req_id = None
+
+
+if __name__ == "__main__":
+    main()

--- a/src/engines/translator/CT2OpusMTTranslator.ts
+++ b/src/engines/translator/CT2OpusMTTranslator.ts
@@ -1,0 +1,235 @@
+import { spawn, type ChildProcess } from 'child_process'
+import { join } from 'path'
+import type { TranslatorEngine, Language, TranslateContext } from '../types'
+
+const TRANSLATE_TIMEOUT_MS = 15_000
+const INIT_TIMEOUT_MS = 120_000
+
+/**
+ * CTranslate2-accelerated OPUS-MT translator (#242).
+ *
+ * Spawns a Python subprocess running ct2-opus-mt-bridge.py which uses
+ * CTranslate2 for 6-10x faster inference compared to ONNX-based OPUS-MT.
+ * Model conversion from HuggingFace format to CTranslate2 is handled
+ * automatically on first run and cached for subsequent launches.
+ *
+ * Requirements: pip install ctranslate2 transformers sentencepiece
+ */
+export class CT2OpusMTTranslator implements TranslatorEngine {
+  readonly id = 'ct2-opus-mt'
+  readonly name = 'OPUS-MT (CTranslate2 Accelerated)'
+  readonly isOffline = true
+
+  private process: ChildProcess | null = null
+  private onProgress?: (message: string) => void
+  private pendingRequests = new Map<number, (data: Record<string, unknown>) => void>()
+  private nextRequestId = 0
+  private buffer = ''
+  private stderrRateLimit = { count: 0, lastReset: Date.now() }
+
+  constructor(options?: { onProgress?: (message: string) => void }) {
+    this.onProgress = options?.onProgress
+  }
+
+  async initialize(): Promise<void> {
+    if (this.process) return
+
+    this.onProgress?.('Starting CTranslate2 OPUS-MT bridge...')
+
+    const bridgePath = join(__dirname, '../../resources/ct2-opus-mt-bridge.py')
+
+    const initTimeout = setTimeout(() => {
+      console.error('[ct2-opus-mt] Initialization timed out')
+      try {
+        this.process?.kill()
+      } catch {
+        /* ignore */
+      }
+      this.process = null
+    }, INIT_TIMEOUT_MS)
+
+    try {
+      this.process = spawn('python3', [bridgePath], {
+        stdio: ['pipe', 'pipe', 'pipe']
+      })
+    } catch (err) {
+      clearTimeout(initTimeout)
+      throw new Error(
+        'Python 3 not found. Install Python 3 and run: pip install ctranslate2 transformers sentencepiece'
+      )
+    }
+
+    this.process.on('error', (err) => {
+      clearTimeout(initTimeout)
+      console.error('[ct2-opus-mt] Failed to start Python bridge:', err.message)
+      this.process = null
+    })
+
+    this.process.stdout!.on('data', (data: Buffer) => {
+      this.buffer += data.toString()
+      const lines = this.buffer.split('\n')
+      this.buffer = lines.pop() ?? ''
+
+      for (const line of lines) {
+        if (!line.trim()) continue
+        try {
+          const msg = JSON.parse(line)
+
+          // Forward status messages as progress updates
+          if (msg.status && typeof msg.status === 'string') {
+            this.onProgress?.(msg.status)
+          }
+
+          const reqId = msg._reqId as number | undefined
+          if (reqId !== undefined && this.pendingRequests.has(reqId)) {
+            this.pendingRequests.get(reqId)!(msg)
+            this.pendingRequests.delete(reqId)
+          }
+        } catch {
+          console.warn('[ct2-opus-mt] Invalid JSON from bridge:', line)
+        }
+      }
+    })
+
+    this.process.stderr!.on('data', (data: Buffer) => {
+      const now = Date.now()
+      if (now - this.stderrRateLimit.lastReset > 5000) {
+        this.stderrRateLimit = { count: 0, lastReset: now }
+      }
+      if (this.stderrRateLimit.count < 10) {
+        this.stderrRateLimit.count++
+        console.warn('[ct2-opus-mt] stderr:', data.toString().trim())
+      }
+    })
+
+    this.process.on('exit', (code) => {
+      console.log(`[ct2-opus-mt] Bridge exited with code ${code}`)
+      this.process = null
+    })
+
+    // Send init command
+    try {
+      const result = await this.sendCommand({
+        action: 'init',
+        model_ja_en: 'Helsinki-NLP/opus-mt-ja-en',
+        model_en_ja: 'Helsinki-NLP/opus-mt-en-jap',
+        device: 'auto',
+        quantization: 'int8'
+      })
+      if (result.error) {
+        throw new Error(`CTranslate2 init failed: ${result.error}`)
+      }
+      this.onProgress?.(
+        `CTranslate2 OPUS-MT ready (device: ${result.device ?? 'cpu'}, quantization: ${result.quantization ?? 'int8'})`
+      )
+    } catch (err) {
+      if (this.process) {
+        try {
+          this.process.kill()
+        } catch {
+          /* ignore */
+        }
+        this.process = null
+      }
+      throw err
+    } finally {
+      clearTimeout(initTimeout)
+    }
+  }
+
+  async translate(
+    text: string,
+    from: Language,
+    to: Language,
+    _context?: TranslateContext
+  ): Promise<string> {
+    if (!text.trim()) return ''
+    if (from === to) return text
+    if (!this.process) {
+      console.error(`[ct2-opus-mt] Bridge not running for ${from}->${to}`)
+      return ''
+    }
+
+    const direction = from === 'ja' ? 'ja-en' : 'en-ja'
+
+    try {
+      const result = await this.sendCommand({
+        action: 'translate',
+        text,
+        direction
+      })
+
+      if (result.error) {
+        console.error('[ct2-opus-mt] Translation error:', result.error)
+        return ''
+      }
+
+      return (result.translated as string) || ''
+    } catch (err) {
+      console.error(
+        '[ct2-opus-mt] Bridge error:',
+        err instanceof Error ? err.message : err
+      )
+      return ''
+    }
+  }
+
+  async dispose(): Promise<void> {
+    console.log('[ct2-opus-mt] Disposing resources')
+    if (this.process) {
+      try {
+        this.sendCommand({ action: 'dispose' }).catch(() => {})
+        await new Promise((resolve) => setTimeout(resolve, 500))
+      } catch {
+        /* ignore */
+      }
+      try {
+        this.process.kill()
+      } catch {
+        /* ignore */
+      }
+      this.process = null
+    }
+    // Snapshot pending requests to avoid concurrent modification
+    const pending = Array.from(this.pendingRequests.values())
+    this.pendingRequests.clear()
+    for (const resolve of pending) {
+      resolve({ error: 'Engine disposed' })
+    }
+  }
+
+  private sendCommand(cmd: Record<string, unknown>): Promise<Record<string, unknown>> {
+    return new Promise((resolve, reject) => {
+      if (!this.process?.stdin) {
+        reject(new Error('Bridge process not running'))
+        return
+      }
+
+      const reqId = this.nextRequestId++ % 0xffffff
+
+      const timeout = setTimeout(() => {
+        this.pendingRequests.delete(reqId)
+        reject(new Error('Bridge command timed out'))
+      }, cmd.action === 'init' ? INIT_TIMEOUT_MS : TRANSLATE_TIMEOUT_MS)
+
+      this.pendingRequests.set(reqId, (data) => {
+        clearTimeout(timeout)
+        resolve(data)
+      })
+
+      const written = this.process.stdin.write(
+        JSON.stringify({ ...cmd, _reqId: reqId }) + '\n'
+      )
+      if (!written) {
+        this.process.stdin.once('drain', () => {
+          /* backpressure resolved */
+        })
+      }
+      this.process.stdin.once('error', (err) => {
+        this.pendingRequests.delete(reqId)
+        clearTimeout(timeout)
+        reject(new Error(`stdin write error: ${err.message}`))
+      })
+    })
+  }
+}

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -10,6 +10,7 @@ import { DeepLTranslator } from '../engines/translator/DeepLTranslator'
 import { GeminiTranslator } from '../engines/translator/GeminiTranslator'
 import { MicrosoftTranslator } from '../engines/translator/MicrosoftTranslator'
 import { OpusMTTranslator } from '../engines/translator/OpusMTTranslator'
+import { CT2OpusMTTranslator } from '../engines/translator/CT2OpusMTTranslator'
 import { ApiRotationController } from '../engines/translator/ApiRotationController'
 import type { ProviderConfig, QuotaStore } from '../engines/translator/ApiRotationController'
 import { SLMTranslator } from '../engines/translator/SLMTranslator'
@@ -152,6 +153,9 @@ function initPipeline(): void {
 
   // Register translator engines
   pipeline.registerTranslator('opus-mt', () => new OpusMTTranslator({
+    onProgress: (msg) => mainWindow?.webContents.send('status-update', msg)
+  }))
+  pipeline.registerTranslator('ct2-opus-mt', () => new CT2OpusMTTranslator({
     onProgress: (msg) => mainWindow?.webContents.send('status-update', msg)
   }))
   pipeline.registerTranslator('slm-translate', () => new SLMTranslator({

--- a/src/renderer/components/SettingsPanel.tsx
+++ b/src/renderer/components/SettingsPanel.tsx
@@ -10,7 +10,7 @@ function withIpcTimeout<T>(promise: Promise<T>, ms: number, label: string): Prom
   return Promise.race([promise, timeoutPromise]).finally(() => clearTimeout(timer))
 }
 
-type EngineMode = 'auto' | 'rotation' | 'online' | 'online-deepl' | 'online-gemini' | 'offline-opus' | 'offline-slm' | 'offline-hunyuan-mt' | 'offline-hybrid'
+type EngineMode = 'auto' | 'rotation' | 'online' | 'online-deepl' | 'online-gemini' | 'offline-opus' | 'offline-ct2-opus' | 'offline-slm' | 'offline-hunyuan-mt' | 'offline-hybrid'
 
 interface DisplayInfo {
   id: number
@@ -288,6 +288,12 @@ function SettingsPanel(): JSX.Element {
           mode: 'cascade' as const,
           sttEngineId: sttEngine,
           translatorEngineId: 'opus-mt'
+        }
+      } else if (resolvedMode === 'offline-ct2-opus') {
+        config = {
+          mode: 'cascade' as const,
+          sttEngineId: sttEngine,
+          translatorEngineId: 'ct2-opus-mt'
         }
       } else if (resolvedMode === 'offline-slm') {
         config = {
@@ -625,6 +631,24 @@ function SettingsPanel(): JSX.Element {
             <div style={{ fontSize: '12px', color: '#94a3b8' }}>JA↔EN, no internet, ~100MB model download</div>
           </div>
         </label>
+        <label style={radioLabelStyle}>
+          <input
+            type="radio"
+            name="engine"
+            checked={engineMode === 'offline-ct2-opus'}
+            onChange={() => setEngineMode('offline-ct2-opus')}
+            disabled={isRunning || isStarting}
+          />
+          <div>
+            <div style={{ fontWeight: 500 }}>OPUS-MT (CTranslate2 Accelerated)</div>
+            <div style={{ fontSize: '12px', color: '#94a3b8' }}>JA↔EN, 6-10x faster than standard OPUS-MT, requires Python 3</div>
+          </div>
+        </label>
+        {engineMode === 'offline-ct2-opus' && (
+          <div style={{ paddingLeft: '24px', fontSize: '11px', color: '#94a3b8', marginTop: '-4px', marginBottom: '4px' }}>
+            Requires: pip install ctranslate2 transformers sentencepiece
+          </div>
+        )}
         <label style={radioLabelStyle}>
           <input
             type="radio"


### PR DESCRIPTION
## Description

Add CTranslate2 as an alternative inference backend for OPUS-MT translation, providing 6-10x speed improvement over the current ONNX-based implementation.

### Implementation

- **Python subprocess bridge** (`resources/ct2-opus-mt-bridge.py`): Follows the mlx-whisper bridge pattern. Uses `ctranslate2` + `transformers` AutoTokenizer. Handles model conversion from HuggingFace format to CTranslate2 format automatically on first run (cached for subsequent launches). Supports CPU and CUDA inference with int8 quantization by default.
- **CT2OpusMTTranslator** (`src/engines/translator/CT2OpusMTTranslator.ts`): TranslatorEngine implementation with subprocess lifecycle management, request/response JSON-line protocol, timeout handling, and stderr rate limiting — same patterns as MlxWhisperEngine.
- **Engine registration** in `src/main/index.ts` and **UI option** in SettingsPanel as "OPUS-MT (CTranslate2 Accelerated)" under the Offline section.

### Requirements

Users need Python 3 with: `pip install ctranslate2 transformers sentencepiece`

### Design decisions

- Kept original OPUS-MT as fallback (no Python dependency required)
- Model conversion is automatic and cached — no manual `ct2-transformers-converter` step needed
- CTranslate2 bridge uses `beam_size=4` and `repetition_penalty=1.2` for translation quality
- ~5% BLEU reduction from int8 quantization is acceptable per issue discussion

Closes #242