### PR TITLE
Add HY-MT1.5-1.8B as default local translation engine

### DIFF
--- a/src/engines/model-downloader.ts
+++ b/src/engines/model-downloader.ts
@@ -66,6 +66,33 @@ export function getHunyuanMTVariants(): Record<string, GGUFVariant> {
   return HUNYUAN_MT_VARIANTS
 }
 
+/** HY-MT1.5-1.8B GGUF variants (official Tencent quantizations) */
+export const HUNYUAN_MT_15_VARIANTS: Record<string, GGUFVariant> = {
+  'Q4_K_M': {
+    filename: 'HY-MT1.5-1.8B-Q4_K_M.gguf',
+    url: 'https://huggingface.co/tencent/HY-MT1.5-1.8B-GGUF/resolve/main/HY-MT1.5-1.8B-Q4_K_M.gguf',
+    sizeMB: 1130,
+    label: 'Q4_K_M (Recommended, ~1.1GB)'
+  },
+  'Q6_K': {
+    filename: 'HY-MT1.5-1.8B-Q6_K.gguf',
+    url: 'https://huggingface.co/tencent/HY-MT1.5-1.8B-GGUF/resolve/main/HY-MT1.5-1.8B-Q6_K.gguf',
+    sizeMB: 1470,
+    label: 'Q6_K (Balanced, ~1.5GB)'
+  },
+  'Q8_0': {
+    filename: 'HY-MT1.5-1.8B-Q8_0.gguf',
+    url: 'https://huggingface.co/tencent/HY-MT1.5-1.8B-GGUF/resolve/main/HY-MT1.5-1.8B-Q8_0.gguf',
+    sizeMB: 1910,
+    label: 'Q8_0 (Best quality, ~1.9GB)'
+  }
+}
+
+/** Get HY-MT1.5-1.8B GGUF variants */
+export function getHunyuanMT15Variants(): Record<string, GGUFVariant> {
+  return HUNYUAN_MT_15_VARIANTS
+}
+
 export const GGUF_VARIANTS_4B: Record<string, GGUFVariant> = {
   'Q4_K_M': {
     filename: 'translategemma-4b-it.Q4_K_M.gguf',

--- a/src/engines/translator/HunyuanMT15Translator.ts
+++ b/src/engines/translator/HunyuanMT15Translator.ts
@@ -1,0 +1,203 @@
+import { utilityProcess } from 'electron'
+import { join } from 'path'
+import type { TranslatorEngine, Language, TranslateContext } from '../types'
+import { getGGUFDir, downloadGGUF, getHunyuanMT15Variants } from '../model-downloader'
+
+const TRANSLATE_TIMEOUT_MS = 30_000
+
+interface PendingRequest {
+  resolve: (text: string) => void
+  reject: (err: Error) => void
+  timer: ReturnType<typeof setTimeout>
+}
+
+/**
+ * HY-MT1.5-1.8B translator via node-llama-cpp UtilityProcess.
+ * Uses the same slm-worker.ts as Hunyuan-MT 7B but with HY-MT1.5 prompt format.
+ * 1.8B parameter model (~1.1GB Q4_K_M) supporting 36 languages.
+ * License: Tencent Hunyuan Community License (Apache 2.0 based, commercial OK < 100M MAU).
+ */
+export class HunyuanMT15Translator implements TranslatorEngine {
+  readonly id = 'hunyuan-mt-15'
+  readonly name = 'HY-MT1.5-1.8B (Offline)'
+  readonly isOffline = true
+
+  private worker: Electron.UtilityProcess | null = null
+  private pending = new Map<string, PendingRequest>()
+  private nextId = 0
+  private onProgress?: (message: string) => void
+  private variant: string
+  private kvCacheQuant: boolean
+
+  constructor(options?: { onProgress?: (message: string) => void; variant?: string; kvCacheQuant?: boolean }) {
+    this.onProgress = options?.onProgress
+    this.variant = options?.variant ?? 'Q4_K_M'
+    this.kvCacheQuant = options?.kvCacheQuant ?? true
+  }
+
+  async initialize(): Promise<void> {
+    if (this.worker) return
+
+    // Download model if needed
+    const variants = getHunyuanMT15Variants()
+    const variantConfig = variants[this.variant] ?? variants['Q4_K_M']!
+    const modelPath = join(getGGUFDir(), variantConfig.filename)
+    await downloadGGUF(variantConfig.filename, variantConfig.url, this.onProgress, variantConfig.sha256)
+
+    // Spawn UtilityProcess (reuses the same slm-worker)
+    this.onProgress?.('Starting HY-MT1.5-1.8B worker...')
+    const workerPath = join(__dirname, 'slm-worker.js')
+
+    this.worker = utilityProcess.fork(workerPath)
+
+    this.worker.on('exit', (code) => {
+      console.log(`[hunyuan-mt-15] Worker exited with code ${code}`)
+      this.worker = null
+      for (const [id, req] of this.pending) {
+        clearTimeout(req.timer)
+        req.reject(new Error('Worker process exited'))
+        this.pending.delete(id)
+      }
+    })
+
+    // Wait for init before registering the general message handler
+    await new Promise<void>((resolve, reject) => {
+      const timeout = setTimeout(() => {
+        this.worker?.removeListener('message', initHandler)
+        try { this.worker?.kill() } catch { /* ignore */ }
+        this.worker = null
+        reject(new Error('HY-MT1.5 initialization timed out'))
+      }, 5 * 60_000)
+
+      const initHandler = (msg: any): void => {
+        if (!this.worker) return
+
+        if (msg.type === 'ready') {
+          clearTimeout(timeout)
+          this.worker?.removeListener('message', initHandler)
+          this.onProgress?.('HY-MT1.5-1.8B model loaded')
+          resolve()
+        } else if (msg.type === 'error') {
+          clearTimeout(timeout)
+          this.worker?.removeListener('message', initHandler)
+          reject(new Error(msg.message))
+        }
+      }
+
+      this.worker!.on('message', initHandler)
+      this.worker!.postMessage({
+        type: 'init',
+        modelPath,
+        kvCacheQuant: this.kvCacheQuant,
+        modelType: 'hunyuan-mt-15'
+      })
+    })
+
+    if (!this.worker) {
+      throw new Error('Worker was killed during initialization')
+    }
+
+    // Clear any leftover listeners before registering to prevent duplicates
+    this.worker.removeAllListeners('message')
+    this.worker.on('message', (msg: any) => {
+      if (msg.type === 'result' && msg.id) {
+        const req = this.pending.get(msg.id)
+        if (req) {
+          clearTimeout(req.timer)
+          this.pending.delete(msg.id)
+          req.resolve(msg.text)
+        }
+        return
+      }
+      if (msg.type === 'error' && msg.id) {
+        const req = this.pending.get(msg.id)
+        if (req) {
+          clearTimeout(req.timer)
+          this.pending.delete(msg.id)
+          req.reject(new Error(msg.message))
+        }
+        return
+      }
+      if (msg.type === 'error') {
+        console.error('[hunyuan-mt-15] Worker error:', msg.message)
+      }
+    })
+  }
+
+  async translate(text: string, from: Language, to: Language, context?: TranslateContext): Promise<string> {
+    if (!text.trim()) return ''
+    if (from === to) return text
+    if (!this.worker) {
+      throw new Error('[hunyuan-mt-15] Not initialized')
+    }
+
+    const id = String(this.nextId++)
+
+    return new Promise<string>((resolve, reject) => {
+      const timer = setTimeout(() => {
+        this.pending.delete(id)
+        reject(new Error('HY-MT1.5 translation timed out'))
+      }, TRANSLATE_TIMEOUT_MS)
+
+      this.pending.set(id, { resolve, reject, timer })
+      this.worker!.postMessage({ type: 'translate', id, text, from, to, context })
+    })
+  }
+
+  async translateIncremental(
+    text: string,
+    previousOutput: string,
+    from: Language,
+    to: Language,
+    context?: TranslateContext
+  ): Promise<string> {
+    if (!text.trim()) return previousOutput || ''
+    if (from === to) return text
+    if (!this.worker) {
+      throw new Error('[hunyuan-mt-15] Not initialized')
+    }
+
+    const id = String(this.nextId++)
+
+    return new Promise<string>((resolve, reject) => {
+      const timer = setTimeout(() => {
+        this.pending.delete(id)
+        reject(new Error('HY-MT1.5 incremental translation timed out'))
+      }, TRANSLATE_TIMEOUT_MS)
+
+      this.pending.set(id, { resolve, reject, timer })
+      this.worker!.postMessage({
+        type: 'translate-incremental',
+        id,
+        text,
+        previousOutput,
+        from,
+        to,
+        context
+      })
+    })
+  }
+
+  async dispose(): Promise<void> {
+    if (this.worker) {
+      try {
+        this.worker.postMessage({ type: 'dispose' })
+        await new Promise((resolve) => setTimeout(resolve, 1000))
+      } catch {
+        // Ignore errors during disposal
+      }
+      try {
+        this.worker.kill()
+      } catch {
+        // Already exited
+      }
+      this.worker = null
+    }
+
+    for (const [, req] of this.pending) {
+      clearTimeout(req.timer)
+      req.reject(new Error('Translator disposed'))
+    }
+    this.pending.clear()
+  }
+}

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -15,10 +15,11 @@ import { ApiRotationController } from '../engines/translator/ApiRotationControll
 import type { ProviderConfig, QuotaStore } from '../engines/translator/ApiRotationController'
 import { SLMTranslator } from '../engines/translator/SLMTranslator'
 import { HunyuanMTTranslator } from '../engines/translator/HunyuanMTTranslator'
+import { HunyuanMT15Translator } from '../engines/translator/HunyuanMT15Translator'
 import { ANETranslator } from '../engines/translator/ANETranslator'
 import { HybridTranslator } from '../engines/translator/HybridTranslator'
 import { detectGpu } from '../engines/gpu-detector'
-import { isGGUFDownloaded, getGGUFVariants, getHunyuanMTVariants } from '../engines/model-downloader'
+import { isGGUFDownloaded, getGGUFVariants, getHunyuanMTVariants, getHunyuanMT15Variants } from '../engines/model-downloader'
 import type { SLMModelSize } from '../engines/model-downloader'
 import { listPlugins, discoverPlugins, loadPluginEngine } from '../engines/plugin-loader'
 import { TranscriptLogger } from '../logger/TranscriptLogger'
@@ -166,6 +167,10 @@ function initPipeline(): void {
     speculativeDecoding: store.get('slmSpeculativeDecoding')
   }))
   pipeline.registerTranslator('hunyuan-mt', () => new HunyuanMTTranslator({
+    onProgress: (msg) => mainWindow?.webContents.send('status-update', msg),
+    kvCacheQuant: store.get('slmKvCacheQuant')
+  }))
+  pipeline.registerTranslator('hunyuan-mt-15', () => new HunyuanMT15Translator({
     onProgress: (msg) => mainWindow?.webContents.send('status-update', msg),
     kvCacheQuant: store.get('slmKvCacheQuant')
   }))
@@ -652,6 +657,18 @@ ipcMain.handle('is-draft-model-available', () => {
 // #234: Hunyuan-MT GGUF model status
 ipcMain.handle('get-hunyuan-mt-variants', () => {
   const variants = getHunyuanMTVariants()
+  return Object.entries(variants).map(([key, v]) => ({
+    key,
+    label: v.label,
+    filename: v.filename,
+    sizeMB: v.sizeMB,
+    downloaded: isGGUFDownloaded(v.filename)
+  }))
+})
+
+// #259: HY-MT1.5-1.8B GGUF model status
+ipcMain.handle('get-hunyuan-mt-15-variants', () => {
+  const variants = getHunyuanMT15Variants()
   return Object.entries(variants).map(([key, v]) => ({
     key,
     label: v.label,

--- a/src/main/slm-worker.ts
+++ b/src/main/slm-worker.ts
@@ -14,11 +14,89 @@
  *   Worker → Main: { type: 'error', id?: string, message: string }
  */
 
-type ModelType = 'translategemma' | 'hunyuan-mt'
+type ModelType = 'translategemma' | 'hunyuan-mt' | 'hunyuan-mt-15'
 
 const LANG_NAMES: Record<string, string> = {
   ja: 'Japanese',
-  en: 'English'
+  en: 'English',
+  zh: 'Chinese',
+  'zh-Hant': 'Traditional Chinese',
+  fr: 'French',
+  de: 'German',
+  es: 'Spanish',
+  pt: 'Portuguese',
+  ru: 'Russian',
+  ko: 'Korean',
+  ar: 'Arabic',
+  th: 'Thai',
+  vi: 'Vietnamese',
+  id: 'Indonesian',
+  ms: 'Malay',
+  tr: 'Turkish',
+  it: 'Italian',
+  pl: 'Polish',
+  nl: 'Dutch',
+  cs: 'Czech',
+  uk: 'Ukrainian',
+  hi: 'Hindi',
+  tl: 'Filipino',
+  km: 'Khmer',
+  my: 'Burmese',
+  fa: 'Persian',
+  gu: 'Gujarati',
+  ur: 'Urdu',
+  te: 'Telugu',
+  mr: 'Marathi',
+  he: 'Hebrew',
+  bn: 'Bengali',
+  ta: 'Tamil',
+  bo: 'Tibetan',
+  kk: 'Kazakh',
+  mn: 'Mongolian',
+  ug: 'Uyghur',
+  yue: 'Cantonese'
+}
+
+/** Chinese language names used by HY-MT1.5 prompt template */
+const LANG_NAMES_ZH: Record<string, string> = {
+  ja: '日语',
+  en: '英语',
+  zh: '中文',
+  'zh-Hant': '繁体中文',
+  fr: '法语',
+  de: '德语',
+  es: '西班牙语',
+  pt: '葡萄牙语',
+  ru: '俄语',
+  ko: '韩语',
+  ar: '阿拉伯语',
+  th: '泰语',
+  vi: '越南语',
+  id: '印尼语',
+  ms: '马来语',
+  tr: '土耳其语',
+  it: '意大利语',
+  pl: '波兰语',
+  nl: '荷兰语',
+  cs: '捷克语',
+  uk: '乌克兰语',
+  hi: '印地语',
+  tl: '菲律宾语',
+  km: '高棉语',
+  my: '缅甸语',
+  fa: '波斯语',
+  gu: '古吉拉特语',
+  ur: '乌尔都语',
+  te: '泰卢固语',
+  mr: '马拉地语',
+  he: '希伯来语',
+  bn: '孟加拉语',
+  ta: '泰米尔语',
+  bo: '藏语',
+  kk: '哈萨克语',
+  mn: '蒙古语',
+  ug: '维吾尔语',
+  yue: '粤语'
 }
 
 let llama: any = null
@@ -171,7 +249,20 @@ async function handleTranslate(
     let prompt: string
     let inferenceParams: { temperature: number; maxTokens: number; topK?: number; topP?: number; repeatPenalty?: number }
 
-    if (activeModelType === 'hunyuan-mt') {
+    if (activeModelType === 'hunyuan-mt-15') {
+      // HY-MT1.5 uses the official Tencent prompt template:
+      // Chinese ↔ Other: Chinese prompt; Other ↔ Other: English prompt
+      const contextSection = buildContextPrompt(translateContext)
+      const isChinese = from === 'zh' || from === 'zh-Hant' || to === 'zh' || to === 'zh-Hant'
+      if (isChinese) {
+        const targetZh = LANG_NAMES_ZH[to] ?? to
+        prompt = `${contextSection}将以下文本翻译为${targetZh}，注意只需要输出翻译后的结果，不要额外解释：\n\n${text}`
+      } else {
+        prompt = `${contextSection}Translate the following segment into ${toLang}, without additional explanation.\n\n${text}`
+      }
+      // HY-MT1.5 recommended parameters (same as Hunyuan-MT)
+      inferenceParams = { temperature: 0.7, maxTokens: 512, topK: 20, topP: 0.6, repeatPenalty: 1.05 }
+    } else if (activeModelType === 'hunyuan-mt') {
       // Hunyuan-MT uses a specific prompt template:
       // Chinese ↔ Other: Chinese prompt; Other ↔ Other: English prompt
       const contextSection = buildContextPrompt(translateContext)
@@ -252,7 +343,15 @@ async function handleTranslateIncremental(
 
     // Build prompt with instruction to continue from previous output
     let prompt: string
-    if (activeModelType === 'hunyuan-mt') {
+    if (activeModelType === 'hunyuan-mt-15') {
+      const isChinese = from === 'zh' || from === 'zh-Hant' || to === 'zh' || to === 'zh-Hant'
+      if (isChinese) {
+        const targetZh = LANG_NAMES_ZH[to] ?? to
+        prompt = `${contextSection}将以下文本翻译为${targetZh}，注意只需要输出翻译后的结果，不要额外解释：\n\n${text}`
+      } else {
+        prompt = `${contextSection}Translate the following segment into ${toLang}, without additional explanation.\n\n${text}`
+      }
+    } else if (activeModelType === 'hunyuan-mt') {
       const isChinese = from === 'zh' || to === 'zh'
       if (isChinese && to !== 'zh') {
         prompt = `${contextSection}把下面的文本翻译成${toLang}，不要额外解释。\n\n${text}`
@@ -267,7 +366,7 @@ async function handleTranslateIncremental(
 
     // Use responsePrefix to force the model to continue from previous output
     // This implements prefix-constrained decoding for SimulMT consistency
-    const inferenceParams = activeModelType === 'hunyuan-mt'
+    const inferenceParams = (activeModelType === 'hunyuan-mt' || activeModelType === 'hunyuan-mt-15')
       ? { temperature: 0.7, maxTokens: 512, topK: 20, topP: 0.6, repeatPenalty: 1.05 }
       : { temperature: 0.1, maxTokens: 512 }
 

--- a/src/renderer/components/SettingsPanel.tsx
+++ b/src/renderer/components/SettingsPanel.tsx
@@ -10,7 +10,7 @@ function withIpcTimeout<T>(promise: Promise<T>, ms: number, label: string): Prom
   return Promise.race([promise, timeoutPromise]).finally(() => clearTimeout(timer))
 }
 
-type EngineMode = 'auto' | 'rotation' | 'online' | 'online-deepl' | 'online-gemini' | 'offline-opus' | 'offline-ct2-opus' | 'offline-slm' | 'offline-hunyuan-mt' | 'offline-ane' | 'offline-hybrid'
+type EngineMode = 'auto' | 'rotation' | 'online' | 'online-deepl' | 'online-gemini' | 'offline-opus' | 'offline-ct2-opus' | 'offline-slm' | 'offline-hunyuan-mt' | 'offline-hunyuan-mt-15' | 'offline-ane' | 'offline-hybrid'
 
 interface DisplayInfo {
   id: number
@@ -258,7 +258,7 @@ function SettingsPanel(): JSX.Element {
         if (hasKeys) {
           resolvedMode = 'rotation'
         } else if (gpuInfo?.hasGpu) {
-          resolvedMode = 'offline-slm'
+          resolvedMode = 'offline-hunyuan-mt-15'
         } else {
           resolvedMode = 'offline-opus'
         }
@@ -320,6 +320,12 @@ function SettingsPanel(): JSX.Element {
           mode: 'cascade' as const,
           sttEngineId: sttEngine,
           translatorEngineId: 'hunyuan-mt'
+        }
+      } else if (resolvedMode === 'offline-hunyuan-mt-15') {
+        config = {
+          mode: 'cascade' as const,
+          sttEngineId: sttEngine,
+          translatorEngineId: 'hunyuan-mt-15'
         }
       } else if (resolvedMode === 'offline-ane') {
         config = {
@@ -436,6 +442,7 @@ function SettingsPanel(): JSX.Element {
     switch (engineMode) {
       case 'offline-hybrid': return 'Hybrid (OPUS-MT + TranslateGemma)'
       case 'offline-slm': return 'TranslateGemma'
+      case 'offline-hunyuan-mt-15': return 'HY-MT1.5-1.8B'
       case 'offline-hunyuan-mt': return 'Hunyuan-MT 7B'
       case 'offline-opus': return 'OPUS-MT'
       case 'offline-ct2-opus': return 'OPUS-MT (CTranslate2)'
@@ -459,7 +466,7 @@ function SettingsPanel(): JSX.Element {
   }
 
   // Does the current engine use SLM options?
-  const showSlmOptions = ['offline-slm', 'offline-hunyuan-mt', 'offline-hybrid'].includes(engineMode)
+  const showSlmOptions = ['offline-slm', 'offline-hunyuan-mt', 'offline-hunyuan-mt-15', 'offline-hybrid'].includes(engineMode)
 
   return (
     <div style={containerStyle}>
@@ -657,6 +664,19 @@ function SettingsPanel(): JSX.Element {
               <div>
                 <div style={{ fontWeight: 500 }}>TranslateGemma</div>
                 <div style={{ fontSize: '12px', color: '#94a3b8' }}>GPU-accelerated offline translation</div>
+              </div>
+            </label>
+            <label style={radioLabelStyle}>
+              <input
+                type="radio"
+                name="engine"
+                checked={engineMode === 'offline-hunyuan-mt-15'}
+                onChange={() => setEngineMode('offline-hunyuan-mt-15')}
+                disabled={isRunning || isStarting}
+              />
+              <div>
+                <div style={{ fontWeight: 500 }}>HY-MT1.5-1.8B (Recommended)</div>
+                <div style={{ fontSize: '12px', color: '#94a3b8' }}>36 languages, ~1.1GB — fast and lightweight</div>
               </div>
             </label>
             <label style={radioLabelStyle}>


### PR DESCRIPTION
## Summary
- Add Tencent HY-MT1.5-1.8B (1.8B params, ~1.1GB Q4_K_M) as a new local translation engine supporting 36 languages
- Register `hunyuan-mt-15` engine in pipeline with dedicated `HunyuanMT15Translator` class
- Use official HY-MT1.5 prompt templates (Chinese/English variants) in slm-worker
- Expand `LANG_NAMES` map to cover all 36+ supported languages with Chinese name equivalents
- Add UI radio button and set as default auto-detection choice when GPU is available

Closes #259

## Test plan
- [ ] Verify `npm run build` passes with no errors
- [ ] Verify `npm test` passes (45/45)
- [ ] Select HY-MT1.5-1.8B in settings and start pipeline — model downloads (~1.1GB)
- [ ] Test Japanese → English and English → Japanese translation
- [ ] Test Chinese ↔ Other language pairs (uses Chinese prompt template)
- [ ] Test Non-Chinese pairs (uses English prompt template)
- [ ] Verify auto mode selects HY-MT1.5 when GPU is detected
- [ ] Verify KV cache quantization option works with the new engine