### PR TITLE
Add Whisper large-v3-turbo STT option

### DIFF
--- a/src/engines/model-downloader.ts
+++ b/src/engines/model-downloader.ts
@@ -8,11 +8,48 @@ export const MODEL_FILENAME = 'ggml-kotoba-whisper-v2.0-q5_0.bin'
 export const MODEL_URL =
   'https://huggingface.co/kotoba-tech/kotoba-whisper-v2.0-ggml/resolve/main/ggml-kotoba-whisper-v2.0-q5_0.bin'
 
+/** Whisper model variant identifier */
+export type WhisperVariant = 'kotoba-v2.0' | 'large-v3-turbo'
+
+/** Whisper model variant configuration */
+export interface WhisperVariantConfig {
+  filename: string
+  url: string
+  sizeMB: number
+  label: string
+  description: string
+}
+
+/** Available Whisper model variants for local STT */
+export const WHISPER_VARIANTS: Record<WhisperVariant, WhisperVariantConfig> = {
+  'kotoba-v2.0': {
+    filename: 'ggml-kotoba-whisper-v2.0-q5_0.bin',
+    url: 'https://huggingface.co/kotoba-tech/kotoba-whisper-v2.0-ggml/resolve/main/ggml-kotoba-whisper-v2.0-q5_0.bin',
+    sizeMB: 540,
+    label: 'Kotoba Whisper v2.0 (Default)',
+    description: 'Optimized for Japanese, ~540MB'
+  },
+  'large-v3-turbo': {
+    filename: 'ggml-large-v3-turbo-q5_0.bin',
+    url: 'https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-large-v3-turbo-q5_0.bin',
+    sizeMB: 600,
+    label: 'Large v3 Turbo (OpenAI)',
+    description: 'Multilingual, 6x faster than large-v3, ~600MB'
+  }
+}
+
+/** Get available Whisper variants */
+export function getWhisperVariants(): Record<WhisperVariant, WhisperVariantConfig> {
+  return WHISPER_VARIANTS
+}
+
 // Global download lock — serializes all model downloads to prevent disk corruption (#208)
 const activeDownloads = new Map<string, Promise<string>>()
 
-export function getModelPath(): string {
-  return join(getModelsDir(), MODEL_FILENAME)
+export function getModelPath(variant?: WhisperVariant): string {
+  const config = variant ? WHISPER_VARIANTS[variant] : null
+  const filename = config ? config.filename : MODEL_FILENAME
+  return join(getModelsDir(), filename)
 }
 
 export function getModelsDir(): string {
@@ -23,8 +60,8 @@ export function getModelsDir(): string {
   return dir
 }
 
-export function isModelDownloaded(): boolean {
-  return existsSync(getModelPath())
+export function isModelDownloaded(variant?: WhisperVariant): boolean {
+  return existsSync(getModelPath(variant))
 }
 
 /** GGUF model variant configuration */
@@ -309,25 +346,32 @@ const MAX_RETRIES = 3
 const RETRY_DELAYS = [3_000, 10_000, 30_000]
 
 export async function downloadModel(
-  onProgress?: (message: string) => void
+  onProgress?: (message: string) => void,
+  variant?: WhisperVariant
 ): Promise<string> {
-  const modelPath = getModelPath()
+  const variantConfig = variant ? WHISPER_VARIANTS[variant] : null
+  const modelPath = getModelPath(variant)
+  const filename = variantConfig ? variantConfig.filename : MODEL_FILENAME
+  const url = variantConfig ? variantConfig.url : MODEL_URL
+  const label = variantConfig
+    ? `Whisper ${variantConfig.label} (~${variantConfig.sizeMB}MB)`
+    : 'Whisper model (~540MB)'
 
   if (existsSync(modelPath)) {
     return modelPath
   }
 
   // Serialize downloads via shared lock (#208)
-  if (activeDownloads.has(MODEL_FILENAME)) {
+  if (activeDownloads.has(filename)) {
     onProgress?.('Waiting for model download in progress...')
-    return activeDownloads.get(MODEL_FILENAME)!
+    return activeDownloads.get(filename)!
   }
 
-  const downloadPromise = doDownloadWithResume(modelPath, MODEL_URL, 'Whisper model (~540MB)', onProgress)
-  activeDownloads.set(MODEL_FILENAME, downloadPromise)
+  const downloadPromise = doDownloadWithResume(modelPath, url, label, onProgress)
+  activeDownloads.set(filename, downloadPromise)
   try {
     return await downloadPromise
   } finally {
-    activeDownloads.delete(MODEL_FILENAME)
+    activeDownloads.delete(filename)
   }
 }

--- a/src/engines/stt/WhisperLocalEngine.ts
+++ b/src/engines/stt/WhisperLocalEngine.ts
@@ -1,27 +1,33 @@
 import { transcribe } from '@kutalia/whisper-node-addon'
 import { getModelPath, isModelDownloaded, downloadModel } from '../model-downloader'
+import type { WhisperVariant } from '../model-downloader'
 import { filterWhisperHallucination } from '../../pipeline/whisper-filter'
 import type { STTEngine, STTResult, Language } from '../types'
 
 export class WhisperLocalEngine implements STTEngine {
   readonly id = 'whisper-local'
-  readonly name = 'Whisper Local (kotoba-whisper-v2.0)'
+  readonly name: string
   readonly isOffline = true
 
   private modelPath = ''
   private onProgress?: (message: string) => void
   private processing = false
+  private modelVariant?: WhisperVariant
 
-  constructor(options?: { onProgress?: (message: string) => void }) {
+  constructor(options?: { onProgress?: (message: string) => void; modelVariant?: WhisperVariant }) {
     this.onProgress = options?.onProgress
+    this.modelVariant = options?.modelVariant
+    this.name = this.modelVariant === 'large-v3-turbo'
+      ? 'Whisper Local (large-v3-turbo)'
+      : 'Whisper Local (kotoba-whisper-v2.0)'
   }
 
   async initialize(): Promise<void> {
     if (this.modelPath) return
-    if (!isModelDownloaded()) {
-      this.modelPath = await downloadModel(this.onProgress)
+    if (!isModelDownloaded(this.modelVariant)) {
+      this.modelPath = await downloadModel(this.onProgress, this.modelVariant)
     } else {
-      this.modelPath = getModelPath()
+      this.modelPath = getModelPath(this.modelVariant)
     }
   }
 

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -19,8 +19,8 @@ import { HunyuanMT15Translator } from '../engines/translator/HunyuanMT15Translat
 import { ANETranslator } from '../engines/translator/ANETranslator'
 import { HybridTranslator } from '../engines/translator/HybridTranslator'
 import { detectGpu } from '../engines/gpu-detector'
-import { isGGUFDownloaded, getGGUFVariants, getHunyuanMTVariants, getHunyuanMT15Variants } from '../engines/model-downloader'
-import type { SLMModelSize } from '../engines/model-downloader'
+import { isGGUFDownloaded, getGGUFVariants, getHunyuanMTVariants, getHunyuanMT15Variants, getWhisperVariants, isModelDownloaded as isWhisperModelDownloaded } from '../engines/model-downloader'
+import type { SLMModelSize, WhisperVariant } from '../engines/model-downloader'
 import { listPlugins, discoverPlugins, loadPluginEngine } from '../engines/plugin-loader'
 import { TranscriptLogger } from '../logger/TranscriptLogger'
 import * as SessionManager from '../logger/SessionManager'
@@ -141,7 +141,8 @@ function initPipeline(): void {
 
   // Register STT engines
   pipeline.registerSTT('whisper-local', () => new WhisperLocalEngine({
-    onProgress: (msg) => mainWindow?.webContents.send('status-update', msg)
+    onProgress: (msg) => mainWindow?.webContents.send('status-update', msg),
+    modelVariant: (store.get('whisperVariant') as WhisperVariant) || undefined
   }))
   // mlx-whisper is Apple Silicon only — skip registration on other platforms
   if (process.platform === 'darwin') {
@@ -540,7 +541,8 @@ ipcMain.handle('get-settings', () => {
     slmSpeculativeDecoding: store.get('slmSpeculativeDecoding'),
     glossaryTerms: store.get('glossaryTerms') || [],
     simulMtEnabled: store.get('simulMtEnabled'),
-    simulMtWaitK: store.get('simulMtWaitK')
+    simulMtWaitK: store.get('simulMtWaitK'),
+    whisperVariant: store.get('whisperVariant')
   }
 })
 
@@ -675,6 +677,19 @@ ipcMain.handle('get-hunyuan-mt-15-variants', () => {
     filename: v.filename,
     sizeMB: v.sizeMB,
     downloaded: isGGUFDownloaded(v.filename)
+  }))
+})
+
+// #261: Whisper model variant status
+ipcMain.handle('get-whisper-variants', () => {
+  const variants = getWhisperVariants()
+  return Object.entries(variants).map(([key, v]) => ({
+    key,
+    label: v.label,
+    description: v.description,
+    filename: v.filename,
+    sizeMB: v.sizeMB,
+    downloaded: isWhisperModelDownloaded(key as WhisperVariant)
   }))
 })
 

--- a/src/main/store.ts
+++ b/src/main/store.ts
@@ -54,6 +54,8 @@ export interface AppSettings {
   simulMtEnabled: boolean
   /** Wait-k value: start translating after k confirmed words (default 3) */
   simulMtWaitK: number
+  /** Whisper model variant for local STT: kotoba-v2.0 (Japanese-optimized) or large-v3-turbo (multilingual) */
+  whisperVariant: string
 }
 
 export const store = new Store<AppSettings>({
@@ -83,6 +85,7 @@ export const store = new Store<AppSettings>({
     glossaryTerms: [],
     slmSpeculativeDecoding: false,
     simulMtEnabled: false,
-    simulMtWaitK: 3
+    simulMtWaitK: 3,
+    whisperVariant: 'kotoba-v2.0'
   }
 })

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -33,6 +33,7 @@ export interface ElectronAPI {
   saveSubtitleSettings: (settings: Record<string, unknown>) => Promise<void>
   onSubtitleSettingsChanged: (callback: (settings: unknown) => void) => (() => void)
   onDisplaysChanged: (callback: () => void) => (() => void)
+  getWhisperVariants: () => Promise<Array<{ key: string; label: string; description: string; filename: string; sizeMB: number; downloaded: boolean }>>
   getPlatform: () => Promise<string>
 }
 

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -88,6 +88,9 @@ contextBridge.exposeInMainWorld('api', {
   // #238: Check if draft model (4B) is available for speculative decoding
   isDraftModelAvailable: () => ipcRenderer.invoke('is-draft-model-available'),
 
+  // #261: Whisper model variant info
+  getWhisperVariants: () => ipcRenderer.invoke('get-whisper-variants'),
+
   // #243: Platform detection for hiding platform-specific options
   getPlatform: () => ipcRenderer.invoke('get-platform'),
 

--- a/src/renderer/components/SettingsPanel.tsx
+++ b/src/renderer/components/SettingsPanel.tsx
@@ -36,6 +36,7 @@ function SettingsPanel(): JSX.Element {
   const [isStarting, setIsStarting] = useState(false)
 
   const [sttEngine, setSttEngine] = useState<'whisper-local' | 'mlx-whisper' | 'moonshine'>('whisper-local')
+  const [whisperVariant, setWhisperVariant] = useState<'kotoba-v2.0' | 'large-v3-turbo'>('kotoba-v2.0')
 
   const [subtitleFontSize, setSubtitleFontSize] = useState(30)
   const [subtitleSourceColor, setSubtitleSourceColor] = useState('#ffffff')
@@ -108,6 +109,7 @@ function SettingsPanel(): JSX.Element {
       if (s.microsoftRegion) setMicrosoftRegion(s.microsoftRegion as string)
       if (s.selectedMicrophone) audio.setSelectedDevice(s.selectedMicrophone as string)
       if (s.sttEngine) setSttEngine(s.sttEngine as 'whisper-local' | 'mlx-whisper' | 'moonshine')
+      if (s.whisperVariant) setWhisperVariant(s.whisperVariant as 'kotoba-v2.0' | 'large-v3-turbo')
       if (s.slmKvCacheQuant !== undefined) setSlmKvCacheQuant(s.slmKvCacheQuant as boolean)
       if (s.slmModelSize) setSlmModelSize(s.slmModelSize as '4b' | '12b')
       if (s.slmSpeculativeDecoding !== undefined) setSlmSpeculativeDecoding(s.slmSpeculativeDecoding as boolean)
@@ -244,6 +246,7 @@ function SettingsPanel(): JSX.Element {
         selectedMicrophone: audio.selectedDevice,
         selectedDisplay,
         sttEngine,
+        whisperVariant,
         slmKvCacheQuant,
         slmModelSize,
         slmSpeculativeDecoding,
@@ -459,7 +462,10 @@ function SettingsPanel(): JSX.Element {
   const sttDisplayName = (): string => {
     switch (sttEngine) {
       case 'mlx-whisper': return 'mlx-whisper (Apple Silicon)'
-      case 'whisper-local': return 'Whisper (whisper.cpp)'
+      case 'whisper-local':
+        return whisperVariant === 'large-v3-turbo'
+          ? 'Whisper (large-v3-turbo)'
+          : 'Whisper (kotoba-v2.0)'
       case 'moonshine': return 'Moonshine AI'
       default: return sttEngine
     }
@@ -628,6 +634,28 @@ function SettingsPanel(): JSX.Element {
               )}
               <option value="moonshine">Moonshine AI (ultra-fast, experimental)</option>
             </select>
+            {sttEngine === 'whisper-local' && (
+              <div style={{ marginTop: '8px' }}>
+                <div style={{ fontSize: '11px', fontWeight: 600, color: '#94a3b8', marginBottom: '4px' }}>
+                  Whisper Model
+                </div>
+                <select
+                  value={whisperVariant}
+                  onChange={(e) => setWhisperVariant(e.target.value as 'kotoba-v2.0' | 'large-v3-turbo')}
+                  style={selectStyle}
+                  disabled={isRunning || isStarting}
+                  aria-label="Whisper model variant"
+                >
+                  <option value="kotoba-v2.0">Kotoba Whisper v2.0 (Japanese-optimized, ~540MB)</option>
+                  <option value="large-v3-turbo">Large v3 Turbo (Multilingual, 6x faster, ~600MB)</option>
+                </select>
+                {whisperVariant === 'large-v3-turbo' && (
+                  <div style={{ marginTop: '4px', fontSize: '11px', color: '#94a3b8' }}>
+                    OpenAI large-v3-turbo: 809M params, 4 decoder layers, within 1-2% WER of large-v3.
+                  </div>
+                )}
+              </div>
+            )}
             {sttEngine === 'moonshine' && (
               <div style={{ marginTop: '4px', fontSize: '11px', color: '#f59e0b' }}>
                 Japanese accuracy is unverified. If results are poor, switch to Whisper.


### PR DESCRIPTION
## Description

Add whisper-large-v3-turbo as a selectable STT model variant alongside the existing kotoba-whisper-v2.0.

- Add `WHISPER_VARIANTS` config system in `model-downloader.ts` with kotoba-v2.0 (default) and large-v3-turbo
- Refactor `getModelPath()`, `isModelDownloaded()`, and `downloadModel()` to accept variant parameter
- Update `WhisperLocalEngine` to accept `modelVariant` option and use it for model download/path
- Add `whisperVariant` setting to `store.ts` (default: kotoba-v2.0)
- Add model variant selector dropdown in Settings Panel (visible when STT = whisper-local)
- Add `get-whisper-variants` IPC handler for querying available variants and download status
- Pass stored whisperVariant from settings to WhisperLocalEngine in pipeline registration

large-v3-turbo: 809M params, 4 decoder layers (vs 32 in large-v3), 6x faster, within 1-2% WER of large-v3.

Closes #261