### PR TITLE
Add automatic language detection

### DIFF
--- a/src/engines/stt/MlxWhisperEngine.ts
+++ b/src/engines/stt/MlxWhisperEngine.ts
@@ -3,6 +3,7 @@ import { join } from 'path'
 import { writeFileSync, unlinkSync, existsSync } from 'fs'
 import { tmpdir, homedir } from 'os'
 import type { STTEngine, STTResult, Language } from '../types'
+import { ALL_LANGUAGES } from '../types'
 
 const TRANSCRIBE_TIMEOUT_MS = 30_000
 const INIT_TIMEOUT_MS = 60_000
@@ -144,7 +145,7 @@ export class MlxWhisperEngine implements STTEngine {
 
       return {
         text: result.text,
-        language: (result.language === 'ja' ? 'ja' : 'en') as Language,
+        language: (ALL_LANGUAGES.includes(result.language as Language) ? result.language : 'en') as Language,
         isFinal: true,
         timestamp: Date.now()
       }

--- a/src/engines/stt/MoonshineEngine.ts
+++ b/src/engines/stt/MoonshineEngine.ts
@@ -49,11 +49,22 @@ export class MoonshineEngine implements STTEngine {
       const text = (result?.text ?? '').trim()
       if (!text) return null
 
-      // Detect language using ratio-based heuristic (aligned with WhisperLocalEngine)
-      const matches = text.match(JA_REGEX)
-      const matchCount = matches?.length || 0
-      const japaneseRatio = text.length > 0 ? matchCount / text.length : 0
-      const language: Language = (japaneseRatio > 0.3 && matchCount >= 2) ? 'ja' : 'en'
+      // Detect language using script-based heuristic (Moonshine is primarily English-focused)
+      const jaKanaMatches = text.match(/[\u3040-\u309F\u30A0-\u30FF]/g)
+      const jaKanaCount = jaKanaMatches?.length || 0
+      const cjkMatches = text.match(/[\u4E00-\u9FFF\u3400-\u4DBF]/g)
+      const cjkCount = cjkMatches?.length || 0
+      const koMatches = text.match(/[\uAC00-\uD7AF]/g)
+      const koCount = koMatches?.length || 0
+
+      let language: Language = 'en'
+      if (jaKanaCount / text.length > 0.3 && jaKanaCount >= 2) {
+        language = 'ja'
+      } else if (cjkCount / text.length > 0.3 && cjkCount >= 2 && jaKanaCount === 0) {
+        language = 'zh'
+      } else if (koCount / text.length > 0.3 && koCount >= 2) {
+        language = 'ko'
+      }
 
       return {
         text,

--- a/src/engines/stt/WhisperLocalEngine.ts
+++ b/src/engines/stt/WhisperLocalEngine.ts
@@ -73,12 +73,43 @@ export class WhisperLocalEngine implements STTEngine {
 
   private detectLanguage(text: string): Language {
     if (!text || text.length === 0) return 'en'
-    const japanesePattern = /[\u3040-\u309F\u30A0-\u30FF\u4E00-\u9FFF\u3400-\u4DBF]/g
-    const matches = text.match(japanesePattern)
-    const matchCount = matches?.length || 0
-    // Require both ratio > 30% AND at least 2 Japanese characters (#39)
-    const japaneseRatio = matchCount / text.length
-    return (japaneseRatio > 0.3 && matchCount >= 2) ? 'ja' : 'en'
+
+    // Japanese: Hiragana, Katakana, CJK ideographs (when mixed with kana)
+    const japanesePattern = /[\u3040-\u309F\u30A0-\u30FF]/g
+    const jpMatches = text.match(japanesePattern)
+    const jpCount = jpMatches?.length || 0
+    const jpRatio = jpCount / text.length
+    if (jpRatio > 0.3 && jpCount >= 2) return 'ja'
+
+    // Chinese: CJK ideographs without Japanese kana
+    const cjkPattern = /[\u4E00-\u9FFF\u3400-\u4DBF]/g
+    const cjkMatches = text.match(cjkPattern)
+    const cjkCount = cjkMatches?.length || 0
+    const cjkRatio = cjkCount / text.length
+    if (cjkRatio > 0.3 && cjkCount >= 2 && jpCount === 0) return 'zh'
+
+    // Korean: Hangul syllables and jamo
+    const koreanPattern = /[\uAC00-\uD7AF\u1100-\u11FF\u3130-\u318F]/g
+    const koMatches = text.match(koreanPattern)
+    const koCount = koMatches?.length || 0
+    const koRatio = koCount / text.length
+    if (koRatio > 0.3 && koCount >= 2) return 'ko'
+
+    // Thai
+    const thaiPattern = /[\u0E00-\u0E7F]/g
+    const thMatches = text.match(thaiPattern)
+    const thCount = thMatches?.length || 0
+    if (thCount / text.length > 0.3 && thCount >= 2) return 'th'
+
+    // Arabic
+    const arabicPattern = /[\u0600-\u06FF\u0750-\u077F]/g
+    const arMatches = text.match(arabicPattern)
+    const arCount = arMatches?.length || 0
+    if (arCount / text.length > 0.3 && arCount >= 2) return 'ar'
+
+    // Default to English for Latin-script languages
+    // (more precise detection for fr/de/es/etc. relies on Whisper's own language detection)
+    return 'en'
   }
 
   private extractText(transcription: string[][] | string[]): string {

--- a/src/engines/translator/DeepLTranslator.ts
+++ b/src/engines/translator/DeepLTranslator.ts
@@ -4,9 +4,24 @@ const DEEPL_FREE_URL = 'https://api-free.deepl.com/v2/translate'
 const DEEPL_PRO_URL = 'https://api.deepl.com/v2/translate'
 const DEFAULT_TIMEOUT_MS = 15_000
 
+/** Map Language codes to DeepL API source/target codes */
 const LANG_MAP: Record<Language, { source: string; target: string }> = {
   ja: { source: 'JA', target: 'JA' },
-  en: { source: 'EN', target: 'EN-US' }
+  en: { source: 'EN', target: 'EN-US' },
+  zh: { source: 'ZH', target: 'ZH-HANS' },
+  ko: { source: 'KO', target: 'KO' },
+  fr: { source: 'FR', target: 'FR' },
+  de: { source: 'DE', target: 'DE' },
+  es: { source: 'ES', target: 'ES' },
+  pt: { source: 'PT', target: 'PT-BR' },
+  ru: { source: 'RU', target: 'RU' },
+  it: { source: 'IT', target: 'IT' },
+  nl: { source: 'NL', target: 'NL' },
+  pl: { source: 'PL', target: 'PL' },
+  ar: { source: 'AR', target: 'AR' },
+  th: { source: 'TH', target: 'TH' },
+  vi: { source: 'VI', target: 'VI' },
+  id: { source: 'ID', target: 'ID' }
 }
 
 export class DeepLTranslator implements TranslatorEngine {

--- a/src/engines/types.ts
+++ b/src/engines/types.ts
@@ -1,5 +1,31 @@
-/** Detected/target language */
-export type Language = 'ja' | 'en'
+/** Supported language codes (ISO 639-1) */
+export type Language = 'ja' | 'en' | 'zh' | 'ko' | 'fr' | 'de' | 'es' | 'pt' | 'ru' | 'it' | 'nl' | 'pl' | 'ar' | 'th' | 'vi' | 'id'
+
+/** Source language setting: specific language or auto-detect */
+export type SourceLanguage = 'auto' | Language
+
+/** Human-readable language labels */
+export const LANGUAGE_LABELS: Record<Language, string> = {
+  ja: 'Japanese',
+  en: 'English',
+  zh: 'Chinese',
+  ko: 'Korean',
+  fr: 'French',
+  de: 'German',
+  es: 'Spanish',
+  pt: 'Portuguese',
+  ru: 'Russian',
+  it: 'Italian',
+  nl: 'Dutch',
+  pl: 'Polish',
+  ar: 'Arabic',
+  th: 'Thai',
+  vi: 'Vietnamese',
+  id: 'Indonesian'
+}
+
+/** All supported language codes */
+export const ALL_LANGUAGES: Language[] = Object.keys(LANGUAGE_LABELS) as Language[]
 
 /** STT engine result */
 export interface STTResult {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -338,6 +338,9 @@ ipcMain.handle('pipeline-start', async (_event, config: PipelineStartConfig) => 
     const glossaryTerms = store.get('glossaryTerms') || []
     pipeline!.setGlossary(glossaryTerms)
 
+    // Configure language settings (#263)
+    pipeline!.setLanguageConfig(store.get('sourceLanguage'), store.get('targetLanguage'))
+
     // Configure SimulMT (#239)
     pipeline!.setSimulMt(store.get('simulMtEnabled'), store.get('simulMtWaitK'))
 
@@ -542,7 +545,9 @@ ipcMain.handle('get-settings', () => {
     glossaryTerms: store.get('glossaryTerms') || [],
     simulMtEnabled: store.get('simulMtEnabled'),
     simulMtWaitK: store.get('simulMtWaitK'),
-    whisperVariant: store.get('whisperVariant')
+    whisperVariant: store.get('whisperVariant'),
+    sourceLanguage: store.get('sourceLanguage'),
+    targetLanguage: store.get('targetLanguage')
   }
 })
 

--- a/src/main/store.ts
+++ b/src/main/store.ts
@@ -1,5 +1,5 @@
 import Store from 'electron-store'
-import type { GlossaryEntry } from '../engines/types'
+import type { GlossaryEntry, Language, SourceLanguage } from '../engines/types'
 
 export interface QuotaRecord {
   monthKey: string
@@ -56,6 +56,10 @@ export interface AppSettings {
   simulMtWaitK: number
   /** Whisper model variant for local STT: kotoba-v2.0 (Japanese-optimized) or large-v3-turbo (multilingual) */
   whisperVariant: string
+  /** Source language: 'auto' for auto-detection or a specific language code */
+  sourceLanguage: SourceLanguage
+  /** Target language for translation output */
+  targetLanguage: Language
 }
 
 export const store = new Store<AppSettings>({
@@ -86,6 +90,8 @@ export const store = new Store<AppSettings>({
     slmSpeculativeDecoding: false,
     simulMtEnabled: false,
     simulMtWaitK: 3,
-    whisperVariant: 'kotoba-v2.0'
+    whisperVariant: 'kotoba-v2.0',
+    sourceLanguage: 'auto',
+    targetLanguage: 'en'
   }
 })

--- a/src/pipeline/TranslationPipeline.ts
+++ b/src/pipeline/TranslationPipeline.ts
@@ -6,6 +6,7 @@ import type {
   E2ETranslationEngine,
   TranslationResult,
   Language,
+  SourceLanguage,
   GlossaryEntry
 } from '../engines/types'
 import { HybridTranslator } from '../engines/translator/HybridTranslator'
@@ -65,6 +66,10 @@ export class TranslationPipeline extends EventEmitter {
   private contextBuffer = new ContextBuffer()
   private speakerTracker = new SpeakerTracker()
   private lastTranslatedConfirmed = ''
+
+  // Language configuration
+  private sourceLanguage: SourceLanguage = 'auto'
+  private targetLanguage: Language = 'en'
 
   // SimulMT state
   private simulMtEnabled = false
@@ -147,6 +152,12 @@ export class TranslationPipeline extends EventEmitter {
   /** Set glossary terms for context-aware translation */
   setGlossary(glossary: GlossaryEntry[]): void {
     this.glossary = glossary
+  }
+
+  /** Configure source and target languages */
+  setLanguageConfig(source: SourceLanguage, target: Language): void {
+    this.sourceLanguage = source
+    this.targetLanguage = target
   }
 
   /** Configure simultaneous translation (Wait-k policy) */
@@ -571,21 +582,33 @@ export class TranslationPipeline extends EventEmitter {
   }
 
   /**
-   * Count words in text. For CJK text (Japanese/Chinese), count characters
+   * Count words in text. For CJK text (Japanese/Chinese/Korean), count characters
    * since there are no space-delimited word boundaries.
    */
   private countWords(text: string, language: Language): number {
-    if (language === 'ja') {
-      // For Japanese, each character roughly corresponds to a morpheme
+    if (language === 'ja' || language === 'zh') {
+      // For Japanese/Chinese, each character roughly corresponds to a morpheme
+      return text.replace(/\s/g, '').length
+    }
+    // Korean has spaces between words, but character count is a better proxy for SimulMT
+    if (language === 'ko') {
       return text.replace(/\s/g, '').length
     }
     return text.trim().split(/\s+/).filter(Boolean).length
   }
 
-  /** Resolve the target language for a given source language */
-  private resolveTargetLanguage(sourceLang: Language): Language {
-    // Currently only ja↔en is supported
-    return sourceLang === 'ja' ? 'en' : 'ja'
+  /**
+   * Resolve the target language based on user settings and detected source language.
+   * When source and target are the same, falls back to ja↔en swap for backward compatibility.
+   */
+  private resolveTargetLanguage(detectedLang: Language): Language {
+    const target = this.targetLanguage
+    // If detected language matches target, swap to avoid no-op translation
+    if (detectedLang === target) {
+      // Backward-compatible fallback: ja↔en
+      return detectedLang === 'ja' ? 'en' : 'ja'
+    }
+    return target
   }
 
   // --- Memory monitoring ---

--- a/src/renderer/components/SettingsPanel.tsx
+++ b/src/renderer/components/SettingsPanel.tsx
@@ -1,6 +1,31 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { useAudioCapture } from '../hooks/useAudioCapture'
 
+/** Supported language codes — must match Language type in types.ts */
+type Language = 'ja' | 'en' | 'zh' | 'ko' | 'fr' | 'de' | 'es' | 'pt' | 'ru' | 'it' | 'nl' | 'pl' | 'ar' | 'th' | 'vi' | 'id'
+type SourceLanguage = 'auto' | Language
+
+const LANGUAGE_LABELS: Record<Language, string> = {
+  ja: 'Japanese',
+  en: 'English',
+  zh: 'Chinese',
+  ko: 'Korean',
+  fr: 'French',
+  de: 'German',
+  es: 'Spanish',
+  pt: 'Portuguese',
+  ru: 'Russian',
+  it: 'Italian',
+  nl: 'Dutch',
+  pl: 'Polish',
+  ar: 'Arabic',
+  th: 'Thai',
+  vi: 'Vietnamese',
+  id: 'Indonesian'
+}
+
+const ALL_LANGUAGES = Object.keys(LANGUAGE_LABELS) as Language[]
+
 /** Wrap a promise with a timeout to prevent UI freezes when main process hangs */
 function withIpcTimeout<T>(promise: Promise<T>, ms: number, label: string): Promise<T> {
   let timer: ReturnType<typeof setTimeout>
@@ -34,6 +59,9 @@ function SettingsPanel(): JSX.Element {
   const sessionStartRef = useRef<number | null>(null)
 
   const [isStarting, setIsStarting] = useState(false)
+
+  const [sourceLanguage, setSourceLanguage] = useState<SourceLanguage>('auto')
+  const [targetLanguage, setTargetLanguage] = useState<Language>('en')
 
   const [sttEngine, setSttEngine] = useState<'whisper-local' | 'mlx-whisper' | 'moonshine'>('whisper-local')
   const [whisperVariant, setWhisperVariant] = useState<'kotoba-v2.0' | 'large-v3-turbo'>('kotoba-v2.0')
@@ -116,6 +144,8 @@ function SettingsPanel(): JSX.Element {
       if (s.glossaryTerms) setGlossaryTerms(s.glossaryTerms as Array<{ source: string; target: string }>)
       if (s.simulMtEnabled !== undefined) setSimulMtEnabled(s.simulMtEnabled as boolean)
       if (s.simulMtWaitK !== undefined) setSimulMtWaitK(s.simulMtWaitK as number)
+      if (s.sourceLanguage) setSourceLanguage(s.sourceLanguage as SourceLanguage)
+      if (s.targetLanguage) setTargetLanguage(s.targetLanguage as Language)
       if (s.subtitleSettings) {
         const sub = s.subtitleSettings as Record<string, unknown>
         if (sub.fontSize) setSubtitleFontSize(sub.fontSize as number)
@@ -251,7 +281,9 @@ function SettingsPanel(): JSX.Element {
         slmModelSize,
         slmSpeculativeDecoding,
         simulMtEnabled,
-        simulMtWaitK
+        simulMtWaitK,
+        sourceLanguage,
+        targetLanguage
       }), 10_000, 'saveSettings')
 
       // Resolve auto mode to concrete engine
@@ -471,6 +503,13 @@ function SettingsPanel(): JSX.Element {
     }
   }
 
+  // Language display name for config summary
+  const languageDisplayName = (): string => {
+    const src = sourceLanguage === 'auto' ? 'Auto-detect' : LANGUAGE_LABELS[sourceLanguage]
+    const tgt = LANGUAGE_LABELS[targetLanguage]
+    return `${src} → ${tgt}`
+  }
+
   // Does the current engine use SLM options?
   const showSlmOptions = ['offline-slm', 'offline-hunyuan-mt', 'offline-hunyuan-mt-15', 'offline-hybrid'].includes(engineMode)
 
@@ -581,6 +620,10 @@ function SettingsPanel(): JSX.Element {
           <span>Translation</span>
           <span style={{ color: '#e2e8f0' }}>{engineDisplayName()}</span>
         </div>
+        <div style={{ display: 'flex', justifyContent: 'space-between', marginTop: '4px' }}>
+          <span>Language</span>
+          <span style={{ color: '#e2e8f0' }}>{languageDisplayName()}</span>
+        </div>
         {gpuInfo && (
           <div style={{ display: 'flex', justifyContent: 'space-between', marginTop: '4px' }}>
             <span>GPU</span>
@@ -619,6 +662,50 @@ function SettingsPanel(): JSX.Element {
       {/* Advanced Settings content */}
       {showAdvanced && (
         <div style={{ marginBottom: '16px' }}>
+          {/* Language Settings */}
+          <Section label="Language">
+            <div style={{ display: 'flex', gap: '12px' }}>
+              <div style={{ flex: 1 }}>
+                <div style={{ fontSize: '11px', fontWeight: 600, color: '#94a3b8', marginBottom: '4px' }}>
+                  Source Language
+                </div>
+                <select
+                  value={sourceLanguage}
+                  onChange={(e) => setSourceLanguage(e.target.value as SourceLanguage)}
+                  style={selectStyle}
+                  disabled={isRunning || isStarting}
+                  aria-label="Source language"
+                >
+                  <option value="auto">Auto-detect</option>
+                  {ALL_LANGUAGES.map((lang) => (
+                    <option key={lang} value={lang}>{LANGUAGE_LABELS[lang]}</option>
+                  ))}
+                </select>
+              </div>
+              <div style={{ flex: 1 }}>
+                <div style={{ fontSize: '11px', fontWeight: 600, color: '#94a3b8', marginBottom: '4px' }}>
+                  Target Language
+                </div>
+                <select
+                  value={targetLanguage}
+                  onChange={(e) => setTargetLanguage(e.target.value as Language)}
+                  style={selectStyle}
+                  disabled={isRunning || isStarting}
+                  aria-label="Target language"
+                >
+                  {ALL_LANGUAGES.map((lang) => (
+                    <option key={lang} value={lang}>{LANGUAGE_LABELS[lang]}</option>
+                  ))}
+                </select>
+              </div>
+            </div>
+            {sourceLanguage !== 'auto' && sourceLanguage === targetLanguage && (
+              <div style={{ marginTop: '6px', fontSize: '11px', color: '#f59e0b' }}>
+                Source and target languages are the same. Translation will fall back to ja/en swap.
+              </div>
+            )}
+          </Section>
+
           {/* STT Engine */}
           <Section label="Speech Recognition">
             <select


### PR DESCRIPTION
## Summary

- Expand `Language` type from `ja | en` to 16 languages (zh, ko, fr, de, es, pt, ru, it, nl, pl, ar, th, vi, id)
- Add `sourceLanguage` (auto-detect or specific) and `targetLanguage` settings with persistence via electron-store
- Replace hardcoded `resolveTargetLanguage()` in `TranslationPipeline` with configurable logic using user settings
- Add language selector dropdowns (source + target) in Advanced Settings UI
- Update all STT engines to detect and surface expanded language codes
- Update DeepL `LANG_MAP` for all supported languages

### Backward compatibility
- Default: `sourceLanguage='auto'`, `targetLanguage='en'` — same behavior as before for existing users
- When detected source equals target, falls back to ja/en swap

Closes #263