### PR TITLE
Add GitHub Actions CI/CD workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,40 @@
+name: Build & Release
+
+on:
+  push:
+    tags: ["v*"]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  build-macos:
+    name: Build macOS DMG
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - run: npm ci
+
+      - run: npm run package:dmg
+
+      - name: Upload DMG artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: live-translate-macos-dmg
+          path: dist/*.dmg
+          if-no-files-found: error
+
+      - name: Upload to GitHub Release
+        if: startsWith(github.ref, 'refs/tags/v')
+        uses: softprops/action-gh-release@v2
+        with:
+          files: dist/*.dmg
+          draft: true
+          generate_release_notes: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,59 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  typecheck:
+    name: Type Check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      # Skip postinstall (native addon scripts are macOS-only)
+      - run: npm ci --ignore-scripts
+
+      # VAD assets are not needed for type checking
+      - run: npm run typecheck
+
+  test:
+    name: Unit Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - run: npm ci --ignore-scripts
+
+      - run: npm run test
+
+  build:
+    name: Vite Build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - run: npm ci --ignore-scripts
+
+      - run: npm run build

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ Real-time speech translation overlay for presentations and meetings.
 
 Bidirectional JA↔EN translation with transparent subtitles overlaid on any display. Local-first, GPU-accelerated, free.
 
+[![CI](https://github.com/rioX432/live-translate/actions/workflows/ci.yml/badge.svg)](https://github.com/rioX432/live-translate/actions/workflows/ci.yml)
 [![macOS](https://img.shields.io/badge/platform-macOS-lightgrey)](https://github.com/rioX432/live-translate)
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue)](LICENSE)
 

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "package": "electron-builder",
     "package:dmg": "electron-vite build && electron-builder --mac dmg",
     "package:win": "electron-vite build && electron-builder --win nsis",
+    "typecheck": "tsc --build",
     "test": "vitest run",
     "test:watch": "vitest"
   },


### PR DESCRIPTION
## Description

Add GitHub Actions workflows for automated CI and release builds.

**CI workflow** (`.github/workflows/ci.yml`):
- Runs on push to `main` and pull requests
- Three parallel jobs: type check, unit tests, vite build
- Uses `npm ci --ignore-scripts` to skip native addon postinstall (macOS-only)
- Concurrency control to cancel superseded runs

**Build workflow** (`.github/workflows/build.yml`):
- Runs on version tags (`v*`) and manual dispatch
- Builds macOS DMG on `macos-latest` (Apple Silicon)
- Uploads DMG as artifact and attaches to draft GitHub Release

**Other changes**:
- Add `typecheck` script (`tsc --build`) to package.json
- Add CI status badge to README

Closes #265