### PR TITLE
Add Madlad-400 for 450+ language translation support

### DIFF
--- a/resources/ct2-madlad400-bridge.py
+++ b/resources/ct2-madlad400-bridge.py
@@ -1,0 +1,246 @@
+#!/usr/bin/env python3
+"""
+Python subprocess bridge for CTranslate2-accelerated Madlad-400 translation.
+
+Madlad-400 is a T5-based multilingual translation model supporting 450+ languages.
+It uses language tags in the format "<2xx>" prepended to source text.
+
+Protocol (stdin/stdout JSON lines):
+  Input:  {"action": "init", "model": "Nextcloud-AI/madlad400-3b-mt-ct2-int8", "device": "auto"}
+  Input:  {"action": "translate", "text": "...", "target_lang": "en"}
+  Input:  {"action": "dispose"}
+  Output: {"ready": true} | {"translated": "..."} | {"error": "..."}
+
+Dependencies: pip install ctranslate2 sentencepiece
+"""
+import sys
+import json
+import os
+
+# Global state
+translator = None
+sp_processor = None
+_current_req_id = None
+
+
+def output(data):
+    """Write JSON response to stdout."""
+    if _current_req_id is not None:
+        data["_reqId"] = _current_req_id
+    print(json.dumps(data), flush=True)
+
+
+def get_cache_dir():
+    """Get the model cache directory."""
+    base = os.environ.get("CT2_CACHE_DIR") or os.path.join(
+        os.path.expanduser("~"), ".cache", "live-translate", "ct2-models"
+    )
+    os.makedirs(base, exist_ok=True)
+    return base
+
+
+def download_model(model_name):
+    """Download pre-converted CTranslate2 model from HuggingFace if not cached."""
+    safe_name = model_name.replace("/", "_")
+    model_dir = os.path.join(get_cache_dir(), safe_name)
+
+    model_file = os.path.join(model_dir, "model.bin")
+    if os.path.exists(model_file):
+        return model_dir
+
+    output({"status": f"Downloading {model_name}..."})
+
+    try:
+        from huggingface_hub import snapshot_download
+
+        snapshot_download(
+            repo_id=model_name,
+            local_dir=model_dir,
+            local_dir_use_symlinks=False,
+        )
+    except ImportError:
+        # Fallback: try using ctranslate2 converter from the original HF model
+        output({"status": "huggingface_hub not found, trying converter fallback..."})
+        try:
+            import ctranslate2
+
+            original_model = "google/madlad400-3b-mt"
+            output({"status": f"Converting {original_model} to CTranslate2 (int8)..."})
+            converter = ctranslate2.converters.TransformersConverter(original_model)
+            converter.convert(model_dir, quantization="int8", force=True)
+        except Exception as e:
+            output({"error": f"Model download/conversion failed: {e}. "
+                    "Run: pip install huggingface_hub ctranslate2 sentencepiece"})
+            return None
+
+    return model_dir
+
+
+def download_tokenizer():
+    """Download the SentencePiece tokenizer for Madlad-400."""
+    tokenizer_dir = os.path.join(get_cache_dir(), "madlad400_tokenizer")
+    spm_path = os.path.join(tokenizer_dir, "sentencepiece.model")
+
+    if os.path.exists(spm_path):
+        return spm_path
+
+    os.makedirs(tokenizer_dir, exist_ok=True)
+    output({"status": "Downloading Madlad-400 tokenizer..."})
+
+    try:
+        from huggingface_hub import hf_hub_download
+
+        downloaded = hf_hub_download(
+            repo_id="google/madlad400-3b-mt",
+            filename="sentencepiece.model",
+            local_dir=tokenizer_dir,
+            local_dir_use_symlinks=False,
+        )
+        return downloaded
+    except ImportError:
+        # Fallback: try transformers AutoTokenizer
+        try:
+            from transformers import AutoTokenizer
+
+            tokenizer = AutoTokenizer.from_pretrained("google/madlad400-3b-mt")
+            # Save the sp model from the tokenizer
+            if hasattr(tokenizer, "vocab_file") and os.path.exists(tokenizer.vocab_file):
+                import shutil
+                shutil.copy2(tokenizer.vocab_file, spm_path)
+                return spm_path
+        except Exception:
+            pass
+
+        output({"error": "Cannot download tokenizer. "
+                "Run: pip install huggingface_hub sentencepiece"})
+        return None
+
+
+def init_model(model_name="Nextcloud-AI/madlad400-3b-mt-ct2-int8", device="auto"):
+    """Initialize CTranslate2 translator with Madlad-400."""
+    global translator, sp_processor
+
+    try:
+        import ctranslate2
+        import sentencepiece as spm
+    except ImportError as e:
+        output({
+            "error": f"Missing dependency: {e}. "
+            "Run: pip install ctranslate2 sentencepiece huggingface_hub"
+        })
+        return
+
+    # Resolve device
+    if device == "auto":
+        device = "cuda" if ctranslate2.get_cuda_device_count() > 0 else "cpu"
+
+    # Download model
+    model_dir = download_model(model_name)
+    if not model_dir:
+        return
+
+    # Download tokenizer
+    spm_path = download_tokenizer()
+    if not spm_path:
+        return
+
+    try:
+        output({"status": "Loading Madlad-400 model..."})
+
+        translator = ctranslate2.Translator(
+            model_dir,
+            device=device,
+            compute_type="int8",
+            inter_threads=1,
+            intra_threads=os.cpu_count() or 4,
+        )
+
+        sp_processor = spm.SentencePieceProcessor()
+        sp_processor.Load(spm_path)
+
+        output({"ready": True, "device": device, "quantization": "int8"})
+    except Exception as e:
+        output({"error": f"Failed to load Madlad-400 model: {e}"})
+
+
+def translate(text, target_lang):
+    """Translate text using Madlad-400 via CTranslate2."""
+    if translator is None or sp_processor is None:
+        output({"error": "Model not initialized"})
+        return
+
+    if not text or not text.strip():
+        output({"translated": ""})
+        return
+
+    try:
+        # Prepend target language tag: "<2en> source text"
+        tagged_text = f"<2{target_lang}> {text}"
+
+        # Tokenize with SentencePiece
+        tokens = sp_processor.Encode(tagged_text, out_type=str)
+
+        # Add EOS token for T5 models
+        tokens.append("</s>")
+
+        # Translate
+        results = translator.translate_batch(
+            [tokens],
+            beam_size=4,
+            max_decoding_length=256,
+            repetition_penalty=1.2,
+        )
+
+        # Decode output tokens
+        target_tokens = results[0].hypotheses[0]
+        translated = sp_processor.Decode(target_tokens)
+
+        output({"translated": translated})
+    except Exception as e:
+        output({"error": f"Translation failed: {e}"})
+
+
+def dispose():
+    """Release all model resources."""
+    global translator, sp_processor
+    translator = None
+    sp_processor = None
+    output({"disposed": True})
+    sys.exit(0)
+
+
+def main():
+    global _current_req_id
+
+    for line in sys.stdin:
+        line = line.strip()
+        if not line:
+            continue
+
+        try:
+            msg = json.loads(line)
+            _current_req_id = msg.get("_reqId")
+            action = msg.get("action")
+
+            if action == "init":
+                init_model(
+                    model_name=msg.get("model", "Nextcloud-AI/madlad400-3b-mt-ct2-int8"),
+                    device=msg.get("device", "auto"),
+                )
+            elif action == "translate":
+                translate(msg.get("text", ""), msg.get("target_lang", "en"))
+            elif action == "dispose":
+                dispose()
+            else:
+                output({"error": f"Unknown action: {action}"})
+        except json.JSONDecodeError:
+            _current_req_id = None
+            output({"error": "Invalid JSON"})
+        except Exception as e:
+            output({"error": str(e)})
+        finally:
+            _current_req_id = None
+
+
+if __name__ == "__main__":
+    main()

--- a/src/engines/translator/CT2Madlad400Translator.ts
+++ b/src/engines/translator/CT2Madlad400Translator.ts
@@ -1,0 +1,230 @@
+import { spawn, type ChildProcess } from 'child_process'
+import { join } from 'path'
+import type { TranslatorEngine, Language, TranslateContext } from '../types'
+
+const TRANSLATE_TIMEOUT_MS = 15_000
+const INIT_TIMEOUT_MS = 180_000
+
+/**
+ * CTranslate2-accelerated Madlad-400 translator (#262).
+ *
+ * Spawns a Python subprocess running ct2-madlad400-bridge.py which uses
+ * CTranslate2 for fast multilingual translation with Madlad-400-3B.
+ * Supports 450+ languages via language tags (e.g. "<2en> source text").
+ * Uses a pre-converted int8 quantized model (~1.5GB) from HuggingFace.
+ *
+ * Requirements: pip install ctranslate2 sentencepiece huggingface_hub
+ */
+export class CT2Madlad400Translator implements TranslatorEngine {
+  readonly id = 'ct2-madlad-400'
+  readonly name = 'Madlad-400 (CTranslate2, 450+ Languages)'
+  readonly isOffline = true
+
+  private process: ChildProcess | null = null
+  private onProgress?: (message: string) => void
+  private pendingRequests = new Map<number, (data: Record<string, unknown>) => void>()
+  private nextRequestId = 0
+  private buffer = ''
+  private stderrRateLimit = { count: 0, lastReset: Date.now() }
+
+  constructor(options?: { onProgress?: (message: string) => void }) {
+    this.onProgress = options?.onProgress
+  }
+
+  async initialize(): Promise<void> {
+    if (this.process) return
+
+    this.onProgress?.('Starting CTranslate2 Madlad-400 bridge...')
+
+    const bridgePath = join(__dirname, '../../resources/ct2-madlad400-bridge.py')
+
+    const initTimeout = setTimeout(() => {
+      console.error('[ct2-madlad-400] Initialization timed out')
+      try {
+        this.process?.kill()
+      } catch {
+        /* ignore */
+      }
+      this.process = null
+    }, INIT_TIMEOUT_MS)
+
+    try {
+      this.process = spawn('python3', [bridgePath], {
+        stdio: ['pipe', 'pipe', 'pipe']
+      })
+    } catch (err) {
+      clearTimeout(initTimeout)
+      throw new Error(
+        'Python 3 not found. Install Python 3 and run: pip install ctranslate2 sentencepiece huggingface_hub'
+      )
+    }
+
+    this.process.on('error', (err) => {
+      clearTimeout(initTimeout)
+      console.error('[ct2-madlad-400] Failed to start Python bridge:', err.message)
+      this.process = null
+    })
+
+    this.process.stdout!.on('data', (data: Buffer) => {
+      this.buffer += data.toString()
+      const lines = this.buffer.split('\n')
+      this.buffer = lines.pop() ?? ''
+
+      for (const line of lines) {
+        if (!line.trim()) continue
+        try {
+          const msg = JSON.parse(line)
+
+          // Forward status messages as progress updates
+          if (msg.status && typeof msg.status === 'string') {
+            this.onProgress?.(msg.status)
+          }
+
+          const reqId = msg._reqId as number | undefined
+          if (reqId !== undefined && this.pendingRequests.has(reqId)) {
+            this.pendingRequests.get(reqId)!(msg)
+            this.pendingRequests.delete(reqId)
+          }
+        } catch {
+          console.warn('[ct2-madlad-400] Invalid JSON from bridge:', line)
+        }
+      }
+    })
+
+    this.process.stderr!.on('data', (data: Buffer) => {
+      const now = Date.now()
+      if (now - this.stderrRateLimit.lastReset > 5000) {
+        this.stderrRateLimit = { count: 0, lastReset: now }
+      }
+      if (this.stderrRateLimit.count < 10) {
+        this.stderrRateLimit.count++
+        console.warn('[ct2-madlad-400] stderr:', data.toString().trim())
+      }
+    })
+
+    this.process.on('exit', (code) => {
+      console.log(`[ct2-madlad-400] Bridge exited with code ${code}`)
+      this.process = null
+    })
+
+    // Send init command
+    try {
+      const result = await this.sendCommand({
+        action: 'init',
+        model: 'Nextcloud-AI/madlad400-3b-mt-ct2-int8',
+        device: 'auto'
+      })
+      if (result.error) {
+        throw new Error(`CTranslate2 Madlad-400 init failed: ${result.error}`)
+      }
+      this.onProgress?.(
+        `CTranslate2 Madlad-400 ready (device: ${result.device ?? 'cpu'}, quantization: ${result.quantization ?? 'int8'})`
+      )
+    } catch (err) {
+      if (this.process) {
+        try {
+          this.process.kill()
+        } catch {
+          /* ignore */
+        }
+        this.process = null
+      }
+      throw err
+    } finally {
+      clearTimeout(initTimeout)
+    }
+  }
+
+  async translate(
+    text: string,
+    _from: Language,
+    to: Language,
+    _context?: TranslateContext
+  ): Promise<string> {
+    if (!text.trim()) return ''
+    if (!this.process) {
+      console.error(`[ct2-madlad-400] Bridge not running for translation to ${to}`)
+      return ''
+    }
+
+    try {
+      const result = await this.sendCommand({
+        action: 'translate',
+        text,
+        target_lang: to
+      })
+
+      if (result.error) {
+        console.error('[ct2-madlad-400] Translation error:', result.error)
+        return ''
+      }
+
+      return (result.translated as string) || ''
+    } catch (err) {
+      console.error(
+        '[ct2-madlad-400] Bridge error:',
+        err instanceof Error ? err.message : err
+      )
+      return ''
+    }
+  }
+
+  async dispose(): Promise<void> {
+    console.log('[ct2-madlad-400] Disposing resources')
+    if (this.process) {
+      try {
+        this.sendCommand({ action: 'dispose' }).catch(() => {})
+        await new Promise((resolve) => setTimeout(resolve, 500))
+      } catch {
+        /* ignore */
+      }
+      try {
+        this.process.kill()
+      } catch {
+        /* ignore */
+      }
+      this.process = null
+    }
+    // Snapshot pending requests to avoid concurrent modification
+    const pending = Array.from(this.pendingRequests.values())
+    this.pendingRequests.clear()
+    for (const resolve of pending) {
+      resolve({ error: 'Engine disposed' })
+    }
+  }
+
+  private sendCommand(cmd: Record<string, unknown>): Promise<Record<string, unknown>> {
+    return new Promise((resolve, reject) => {
+      if (!this.process?.stdin) {
+        reject(new Error('Bridge process not running'))
+        return
+      }
+
+      const reqId = this.nextRequestId++ % 0xffffff
+
+      const timeout = setTimeout(() => {
+        this.pendingRequests.delete(reqId)
+        reject(new Error('Bridge command timed out'))
+      }, cmd.action === 'init' ? INIT_TIMEOUT_MS : TRANSLATE_TIMEOUT_MS)
+
+      this.pendingRequests.set(reqId, (data) => {
+        clearTimeout(timeout)
+        resolve(data)
+      })
+
+      const written = this.process.stdin.write(
+        JSON.stringify({ ...cmd, _reqId: reqId }) + '\n'
+      )
+      if (!written) {
+        this.process.stdin.once('drain', () => {
+          /* backpressure resolved */
+        })
+      }
+      this.process.stdin.once('error', (err) => {
+        this.pendingRequests.delete(reqId)
+        clearTimeout(timeout)
+        reject(new Error(`stdin write error: ${err.message}`))
+      })
+    })
+  }
+}

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -11,6 +11,7 @@ import { GeminiTranslator } from '../engines/translator/GeminiTranslator'
 import { MicrosoftTranslator } from '../engines/translator/MicrosoftTranslator'
 import { OpusMTTranslator } from '../engines/translator/OpusMTTranslator'
 import { CT2OpusMTTranslator } from '../engines/translator/CT2OpusMTTranslator'
+import { CT2Madlad400Translator } from '../engines/translator/CT2Madlad400Translator'
 import { ApiRotationController } from '../engines/translator/ApiRotationController'
 import type { ProviderConfig, QuotaStore } from '../engines/translator/ApiRotationController'
 import { SLMTranslator } from '../engines/translator/SLMTranslator'
@@ -159,6 +160,9 @@ function initPipeline(): void {
     onProgress: (msg) => mainWindow?.webContents.send('status-update', msg)
   }))
   pipeline.registerTranslator('ct2-opus-mt', () => new CT2OpusMTTranslator({
+    onProgress: (msg) => mainWindow?.webContents.send('status-update', msg)
+  }))
+  pipeline.registerTranslator('ct2-madlad-400', () => new CT2Madlad400Translator({
     onProgress: (msg) => mainWindow?.webContents.send('status-update', msg)
   }))
   pipeline.registerTranslator('slm-translate', () => new SLMTranslator({

--- a/src/renderer/components/SettingsPanel.tsx
+++ b/src/renderer/components/SettingsPanel.tsx
@@ -35,7 +35,7 @@ function withIpcTimeout<T>(promise: Promise<T>, ms: number, label: string): Prom
   return Promise.race([promise, timeoutPromise]).finally(() => clearTimeout(timer))
 }
 
-type EngineMode = 'auto' | 'rotation' | 'online' | 'online-deepl' | 'online-gemini' | 'offline-opus' | 'offline-ct2-opus' | 'offline-slm' | 'offline-hunyuan-mt' | 'offline-hunyuan-mt-15' | 'offline-ane' | 'offline-hybrid'
+type EngineMode = 'auto' | 'rotation' | 'online' | 'online-deepl' | 'online-gemini' | 'offline-opus' | 'offline-ct2-opus' | 'offline-madlad-400' | 'offline-slm' | 'offline-hunyuan-mt' | 'offline-hunyuan-mt-15' | 'offline-ane' | 'offline-hybrid'
 
 interface DisplayInfo {
   id: number
@@ -344,6 +344,12 @@ function SettingsPanel(): JSX.Element {
           sttEngineId: sttEngine,
           translatorEngineId: 'ct2-opus-mt'
         }
+      } else if (resolvedMode === 'offline-madlad-400') {
+        config = {
+          mode: 'cascade' as const,
+          sttEngineId: sttEngine,
+          translatorEngineId: 'ct2-madlad-400'
+        }
       } else if (resolvedMode === 'offline-slm') {
         config = {
           mode: 'cascade' as const,
@@ -481,6 +487,7 @@ function SettingsPanel(): JSX.Element {
       case 'offline-hunyuan-mt': return 'Hunyuan-MT 7B'
       case 'offline-opus': return 'OPUS-MT'
       case 'offline-ct2-opus': return 'OPUS-MT (CTranslate2)'
+      case 'offline-madlad-400': return 'Madlad-400 (450+ Languages)'
       case 'offline-ane': return 'ANEMLL (Apple Neural Engine)'
       case 'rotation': return 'API Auto Rotation'
       case 'online': return 'Google Translation'
@@ -831,6 +838,19 @@ function SettingsPanel(): JSX.Element {
               <div>
                 <div style={{ fontWeight: 500 }}>OPUS-MT (CTranslate2)</div>
                 <div style={{ fontSize: '12px', color: '#94a3b8' }}>6-10x faster, requires Python 3</div>
+              </div>
+            </label>
+            <label style={radioLabelStyle}>
+              <input
+                type="radio"
+                name="engine"
+                checked={engineMode === 'offline-madlad-400'}
+                onChange={() => setEngineMode('offline-madlad-400')}
+                disabled={isRunning || isStarting}
+              />
+              <div>
+                <div style={{ fontWeight: 500 }}>Madlad-400 (450+ Languages)</div>
+                <div style={{ fontSize: '12px', color: '#94a3b8' }}>Google T5-based, ~1.5GB, requires Python 3</div>
               </div>
             </label>
             {platform === 'darwin' && (


### PR DESCRIPTION
## Summary
- Add Madlad-400-3B CTranslate2 translator engine supporting 450+ languages
- Python bridge (`ct2-madlad400-bridge.py`) uses pre-converted int8 model from HuggingFace (~1.5GB)
- Uses `<2xx>` language tag format with SentencePiece tokenizer (T5-based)
- Follows existing CT2OpusMTTranslator pattern exactly

## Changes
- `resources/ct2-madlad400-bridge.py` — Python subprocess bridge for CTranslate2 Madlad-400
- `src/engines/translator/CT2Madlad400Translator.ts` — TypeScript engine wrapper
- `src/main/index.ts` — Register `ct2-madlad-400` engine in pipeline
- `src/renderer/components/SettingsPanel.tsx` — Add `offline-madlad-400` UI option

## Dependencies
`pip install ctranslate2 sentencepiece huggingface_hub`

Closes #262