### PR TITLE
Add Moonshine model variant selection (tiny/base)

### DIFF
--- a/src/engines/model-downloader.ts
+++ b/src/engines/model-downloader.ts
@@ -43,6 +43,46 @@ export function getWhisperVariants(): Record<WhisperVariant, WhisperVariantConfi
   return WHISPER_VARIANTS
 }
 
+/** Moonshine model variant identifier */
+export type MoonshineVariant = 'tiny' | 'base'
+
+/** Moonshine model variant configuration (downloaded via @huggingface/transformers) */
+export interface MoonshineVariantConfig {
+  /** HuggingFace model ID used by @huggingface/transformers pipeline */
+  modelId: string
+  /** Approximate model size in MB (quantized q8) */
+  sizeMB: number
+  /** Human-readable label */
+  label: string
+  /** Description shown in UI */
+  description: string
+  /** Number of parameters */
+  params: string
+}
+
+/** Available Moonshine ONNX model variants for local STT */
+export const MOONSHINE_VARIANTS: Record<MoonshineVariant, MoonshineVariantConfig> = {
+  'tiny': {
+    modelId: 'onnx-community/moonshine-tiny-ONNX',
+    sizeMB: 60,
+    label: 'Tiny (Fastest)',
+    description: '27M params, ~60MB — lowest latency, good for voice commands',
+    params: '27M'
+  },
+  'base': {
+    modelId: 'onnx-community/moonshine-base-ONNX',
+    sizeMB: 130,
+    label: 'Base (Recommended)',
+    description: '61M params, ~130MB — best balance of speed and accuracy',
+    params: '61M'
+  }
+}
+
+/** Get available Moonshine variants */
+export function getMoonshineVariants(): Record<MoonshineVariant, MoonshineVariantConfig> {
+  return MOONSHINE_VARIANTS
+}
+
 // Global download lock — serializes all model downloads to prevent disk corruption (#208)
 const activeDownloads = new Map<string, Promise<string>>()
 

--- a/src/engines/stt/MoonshineEngine.ts
+++ b/src/engines/stt/MoonshineEngine.ts
@@ -1,13 +1,9 @@
 import { join } from 'path'
-import { existsSync } from 'fs'
 import type { STTEngine, STTResult, Language } from '../types'
-import { getModelsDir } from '../model-downloader'
+import { getModelsDir, MOONSHINE_VARIANTS } from '../model-downloader'
+import type { MoonshineVariant } from '../model-downloader'
 
-const MOONSHINE_MODEL = 'onnx-community/moonshine-base-ONNX'
 const MODELS_SUBDIR = 'moonshine'
-
-// Japanese detection heuristic (aligned with WhisperLocalEngine)
-const JA_REGEX = /[\u3040-\u309F\u30A0-\u30FF\u4E00-\u9FFF\u3400-\u4DBF]/g
 
 export class MoonshineEngine implements STTEngine {
   readonly id = 'moonshine'
@@ -16,26 +12,29 @@ export class MoonshineEngine implements STTEngine {
 
   private pipeline: any = null
   private onProgress?: (message: string) => void
+  private variant: MoonshineVariant
 
-  constructor(options?: { onProgress?: (message: string) => void }) {
+  constructor(options?: { onProgress?: (message: string) => void; variant?: MoonshineVariant }) {
     this.onProgress = options?.onProgress
+    this.variant = options?.variant ?? 'base'
   }
 
   async initialize(): Promise<void> {
     if (this.pipeline) return
 
-    this.onProgress?.('Loading Moonshine model...')
+    const config = MOONSHINE_VARIANTS[this.variant]
+    this.onProgress?.(`Loading Moonshine ${config.label} model...`)
 
     const { pipeline, env } = await import('@huggingface/transformers')
     env.cacheDir = join(getModelsDir(), MODELS_SUBDIR)
 
     this.pipeline = await pipeline(
       'automatic-speech-recognition',
-      MOONSHINE_MODEL,
+      config.modelId,
       { dtype: 'q8' }
     )
 
-    this.onProgress?.('Moonshine model loaded')
+    this.onProgress?.(`Moonshine ${config.label} model loaded`)
   }
 
   async processAudio(audioChunk: Float32Array, sampleRate: number): Promise<STTResult | null> {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -20,8 +20,8 @@ import { HunyuanMT15Translator } from '../engines/translator/HunyuanMT15Translat
 import { ANETranslator } from '../engines/translator/ANETranslator'
 import { HybridTranslator } from '../engines/translator/HybridTranslator'
 import { detectGpu } from '../engines/gpu-detector'
-import { isGGUFDownloaded, getGGUFVariants, getHunyuanMTVariants, getHunyuanMT15Variants, getWhisperVariants, isModelDownloaded as isWhisperModelDownloaded } from '../engines/model-downloader'
-import type { SLMModelSize, WhisperVariant } from '../engines/model-downloader'
+import { isGGUFDownloaded, getGGUFVariants, getHunyuanMTVariants, getHunyuanMT15Variants, getWhisperVariants, getMoonshineVariants, isModelDownloaded as isWhisperModelDownloaded } from '../engines/model-downloader'
+import type { SLMModelSize, WhisperVariant, MoonshineVariant } from '../engines/model-downloader'
 import { listPlugins, discoverPlugins, loadPluginEngine } from '../engines/plugin-loader'
 import { TranscriptLogger } from '../logger/TranscriptLogger'
 import * as SessionManager from '../logger/SessionManager'
@@ -152,7 +152,8 @@ function initPipeline(): void {
     }))
   }
   pipeline.registerSTT('moonshine', () => new MoonshineEngine({
-    onProgress: (msg) => mainWindow?.webContents.send('status-update', msg)
+    onProgress: (msg) => mainWindow?.webContents.send('status-update', msg),
+    variant: (store.get('moonshineVariant') as MoonshineVariant) || undefined
   }))
 
   // Register translator engines
@@ -550,6 +551,7 @@ ipcMain.handle('get-settings', () => {
     simulMtEnabled: store.get('simulMtEnabled'),
     simulMtWaitK: store.get('simulMtWaitK'),
     whisperVariant: store.get('whisperVariant'),
+    moonshineVariant: store.get('moonshineVariant'),
     sourceLanguage: store.get('sourceLanguage'),
     targetLanguage: store.get('targetLanguage')
   }
@@ -699,6 +701,19 @@ ipcMain.handle('get-whisper-variants', () => {
     filename: v.filename,
     sizeMB: v.sizeMB,
     downloaded: isWhisperModelDownloaded(key as WhisperVariant)
+  }))
+})
+
+// #260: Moonshine model variant info
+ipcMain.handle('get-moonshine-variants', () => {
+  const variants = getMoonshineVariants()
+  return Object.entries(variants).map(([key, v]) => ({
+    key,
+    label: v.label,
+    description: v.description,
+    modelId: v.modelId,
+    sizeMB: v.sizeMB,
+    params: v.params
   }))
 })
 

--- a/src/main/store.ts
+++ b/src/main/store.ts
@@ -56,6 +56,8 @@ export interface AppSettings {
   simulMtWaitK: number
   /** Whisper model variant for local STT: kotoba-v2.0 (Japanese-optimized) or large-v3-turbo (multilingual) */
   whisperVariant: string
+  /** Moonshine model variant for local STT: tiny (fastest) or base (recommended) */
+  moonshineVariant: string
   /** Source language: 'auto' for auto-detection or a specific language code */
   sourceLanguage: SourceLanguage
   /** Target language for translation output */
@@ -91,6 +93,7 @@ export const store = new Store<AppSettings>({
     simulMtEnabled: false,
     simulMtWaitK: 3,
     whisperVariant: 'kotoba-v2.0',
+    moonshineVariant: 'base',
     sourceLanguage: 'auto',
     targetLanguage: 'en'
   }

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -34,6 +34,7 @@ export interface ElectronAPI {
   onSubtitleSettingsChanged: (callback: (settings: unknown) => void) => (() => void)
   onDisplaysChanged: (callback: () => void) => (() => void)
   getWhisperVariants: () => Promise<Array<{ key: string; label: string; description: string; filename: string; sizeMB: number; downloaded: boolean }>>
+  getMoonshineVariants: () => Promise<Array<{ key: string; label: string; description: string; modelId: string; sizeMB: number; params: string }>>
   getPlatform: () => Promise<string>
 }
 

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -91,6 +91,9 @@ contextBridge.exposeInMainWorld('api', {
   // #261: Whisper model variant info
   getWhisperVariants: () => ipcRenderer.invoke('get-whisper-variants'),
 
+  // #260: Moonshine model variant info
+  getMoonshineVariants: () => ipcRenderer.invoke('get-moonshine-variants'),
+
   // #243: Platform detection for hiding platform-specific options
   getPlatform: () => ipcRenderer.invoke('get-platform'),
 

--- a/src/renderer/components/SettingsPanel.tsx
+++ b/src/renderer/components/SettingsPanel.tsx
@@ -65,6 +65,7 @@ function SettingsPanel(): JSX.Element {
 
   const [sttEngine, setSttEngine] = useState<'whisper-local' | 'mlx-whisper' | 'moonshine'>('whisper-local')
   const [whisperVariant, setWhisperVariant] = useState<'kotoba-v2.0' | 'large-v3-turbo'>('kotoba-v2.0')
+  const [moonshineVariant, setMoonshineVariant] = useState<'tiny' | 'base'>('base')
 
   const [subtitleFontSize, setSubtitleFontSize] = useState(30)
   const [subtitleSourceColor, setSubtitleSourceColor] = useState('#ffffff')
@@ -138,6 +139,7 @@ function SettingsPanel(): JSX.Element {
       if (s.selectedMicrophone) audio.setSelectedDevice(s.selectedMicrophone as string)
       if (s.sttEngine) setSttEngine(s.sttEngine as 'whisper-local' | 'mlx-whisper' | 'moonshine')
       if (s.whisperVariant) setWhisperVariant(s.whisperVariant as 'kotoba-v2.0' | 'large-v3-turbo')
+      if (s.moonshineVariant) setMoonshineVariant(s.moonshineVariant as 'tiny' | 'base')
       if (s.slmKvCacheQuant !== undefined) setSlmKvCacheQuant(s.slmKvCacheQuant as boolean)
       if (s.slmModelSize) setSlmModelSize(s.slmModelSize as '4b' | '12b')
       if (s.slmSpeculativeDecoding !== undefined) setSlmSpeculativeDecoding(s.slmSpeculativeDecoding as boolean)
@@ -277,6 +279,7 @@ function SettingsPanel(): JSX.Element {
         selectedDisplay,
         sttEngine,
         whisperVariant,
+        moonshineVariant,
         slmKvCacheQuant,
         slmModelSize,
         slmSpeculativeDecoding,
@@ -751,8 +754,23 @@ function SettingsPanel(): JSX.Element {
               </div>
             )}
             {sttEngine === 'moonshine' && (
-              <div style={{ marginTop: '4px', fontSize: '11px', color: '#f59e0b' }}>
-                Japanese accuracy is unverified. If results are poor, switch to Whisper.
+              <div style={{ marginTop: '8px' }}>
+                <div style={{ fontSize: '11px', fontWeight: 600, color: '#94a3b8', marginBottom: '4px' }}>
+                  Moonshine Model
+                </div>
+                <select
+                  value={moonshineVariant}
+                  onChange={(e) => setMoonshineVariant(e.target.value as 'tiny' | 'base')}
+                  style={selectStyle}
+                  disabled={isRunning || isStarting}
+                  aria-label="Moonshine model variant"
+                >
+                  <option value="base">Base — 61M params, best accuracy (~130MB)</option>
+                  <option value="tiny">Tiny — 27M params, fastest (~60MB)</option>
+                </select>
+                <div style={{ marginTop: '4px', fontSize: '11px', color: '#f59e0b' }}>
+                  English-focused. Japanese/CJK accuracy is unverified — switch to Whisper if results are poor.
+                </div>
               </div>
             )}
           </Section>


### PR DESCRIPTION
## Description

Add model variant selection for Moonshine STT engine, allowing users to choose between Tiny (27M params, ~60MB, fastest) and Base (61M params, ~130MB, best accuracy) ONNX models from onnx-community on HuggingFace.

### Changes
- **MoonshineEngine.ts**: Accept `variant` option in constructor, load correct HuggingFace model ID based on selection
- **model-downloader.ts**: Add `MoonshineVariant` type, `MOONSHINE_VARIANTS` config, and `getMoonshineVariants()` export
- **store.ts**: Add `moonshineVariant` setting with 'base' default
- **main/index.ts**: Pass stored moonshine variant to engine constructor, add `get-moonshine-variants` IPC handler, include `moonshineVariant` in settings response
- **preload**: Expose `getMoonshineVariants` IPC channel with type definitions
- **SettingsPanel.tsx**: Add Moonshine model selector dropdown when Moonshine STT is selected, persist variant in settings

### Note on Moonshine v2 Streaming
Moonshine v2 Streaming models (tiny/small/medium from UsefulSensors) exist on HuggingFace but are **not yet supported by transformers.js** — no ONNX conversions exist on onnx-community and `MoonshineStreamingForConditionalGeneration` is not in the transformers.js model registry. This PR adds variant selection for the available v1 ONNX models. v2 streaming support can be added when transformers.js adds the architecture.

Closes #260