### PR TITLE
Fix worker event listener leak in translator dispose()

### DIFF
--- a/src/engines/translator/HunyuanMT15Translator.ts
+++ b/src/engines/translator/HunyuanMT15Translator.ts
@@ -180,6 +180,8 @@ export class HunyuanMT15Translator implements TranslatorEngine {
 
   async dispose(): Promise<void> {
     if (this.worker) {
+      // Remove all listeners before killing to prevent exit handler from firing
+      this.worker.removeAllListeners()
       try {
         this.worker.postMessage({ type: 'dispose' })
         await new Promise((resolve) => setTimeout(resolve, 1000))

--- a/src/engines/translator/HunyuanMTTranslator.ts
+++ b/src/engines/translator/HunyuanMTTranslator.ts
@@ -180,6 +180,8 @@ export class HunyuanMTTranslator implements TranslatorEngine {
 
   async dispose(): Promise<void> {
     if (this.worker) {
+      // Remove all listeners before killing to prevent exit handler from firing
+      this.worker.removeAllListeners()
       try {
         this.worker.postMessage({ type: 'dispose' })
         await new Promise((resolve) => setTimeout(resolve, 1000))

--- a/src/engines/translator/SLMTranslator.ts
+++ b/src/engines/translator/SLMTranslator.ts
@@ -216,6 +216,8 @@ export class SLMTranslator implements TranslatorEngine {
 
   async dispose(): Promise<void> {
     if (this.worker) {
+      // Remove all listeners before killing to prevent exit handler from firing
+      this.worker.removeAllListeners()
       try {
         this.worker.postMessage({ type: 'dispose' })
         // Give worker time to clean up


### PR DESCRIPTION
## Summary
- Add `this.worker.removeAllListeners()` at the start of `dispose()` before killing the worker process
- Fixes leaked `exit` listener that was attached in `initialize()` but never removed during disposal
- Applied consistently across all three affected files: `SLMTranslator.ts`, `HunyuanMTTranslator.ts`, `HunyuanMT15Translator.ts`

## Test plan
- [x] `npm run typecheck` passes (pre-existing ws-audio-server errors only)
- [x] `npm test` passes (45/45)
- [ ] Manual: start/stop translation pipeline multiple times, verify no listener leak warnings

Closes #284