### PR TITLE
Fix dispose() to release transformer pipeline memory

### DIFF
--- a/src/engines/stt/MoonshineEngine.ts
+++ b/src/engines/stt/MoonshineEngine.ts
@@ -79,6 +79,11 @@ export class MoonshineEngine implements STTEngine {
 
   async dispose(): Promise<void> {
     console.log('[moonshine] Disposing resources')
+    try {
+      await this.pipeline?.dispose()
+    } catch (err) {
+      console.error('[moonshine] Error during pipeline disposal:', err)
+    }
     this.pipeline = null
   }
 }

--- a/src/engines/translator/OpusMTTranslator.ts
+++ b/src/engines/translator/OpusMTTranslator.ts
@@ -3,7 +3,9 @@ import { join } from 'path'
 import type { TranslatorEngine, Language } from '../types'
 
 // Dynamic import for ESM-only @huggingface/transformers
-type TranslationPipeline = (text: string) => Promise<Array<{ translation_text: string }>>
+type TranslationPipeline = ((text: string) => Promise<Array<{ translation_text: string }>>) & {
+  dispose(): Promise<void>
+}
 
 export class OpusMTTranslator implements TranslatorEngine {
   readonly id = 'opus-mt'
@@ -68,6 +70,14 @@ export class OpusMTTranslator implements TranslatorEngine {
 
   async dispose(): Promise<void> {
     console.log('[opus-mt] Disposing resources')
+    try {
+      await Promise.all([
+        this.jaToEn?.dispose(),
+        this.enToJa?.dispose()
+      ])
+    } catch (err) {
+      console.error('[opus-mt] Error during pipeline disposal:', err)
+    }
     this.jaToEn = null
     this.enToJa = null
   }


### PR DESCRIPTION
## Summary
- Call `dispose()` on `@huggingface/transformers` pipeline objects in `OpusMTTranslator.dispose()` before nulling references, preventing ~2GB+ model memory leak
- Apply the same fix to `MoonshineEngine.dispose()` which had the identical issue
- Wrap disposal in try/catch to ensure references are always cleaned up even if dispose fails

## Test plan
- [x] `npm test` — 45 tests pass
- [x] `npm run typecheck` — no new errors (pre-existing `ws` type errors only)
- [ ] Manual: start translation pipeline, stop it, verify memory is reclaimed in Activity Monitor

Closes #285