### PR TITLE
Fix slm-worker process.exit before async dispose completes

### DIFF
--- a/src/main/slm-worker.ts
+++ b/src/main/slm-worker.ts
@@ -440,25 +440,31 @@ ${transcript}`
 }
 
 async function handleDispose(): Promise<void> {
-  if (draftContext) {
-    await draftContext.dispose?.()
-    draftContext = null
+  try {
+    if (draftContext) {
+      await draftContext.dispose()
+      draftContext = null
+    }
+    if (draftModel) {
+      await draftModel.dispose()
+      draftModel = null
+    }
+    speculativeEnabled = false
+    if (context) {
+      await context.dispose()
+      context = null
+    }
+    if (model) {
+      await model.dispose()
+      model = null
+    }
+    if (llama) {
+      await llama.dispose()
+      llama = null
+    }
+  } finally {
+    process.exit(0)
   }
-  if (draftModel) {
-    await draftModel.dispose?.()
-    draftModel = null
-  }
-  speculativeEnabled = false
-  if (context) {
-    await context.dispose?.()
-    context = null
-  }
-  if (model) {
-    await model.dispose?.()
-    model = null
-  }
-  llama = null
-  process.exit(0)
 }
 
 // Listen for messages from main process


### PR DESCRIPTION
## Summary
- Wrap all dispose calls in try/finally to guarantee `process.exit(0)` runs after async cleanup
- Await `llama.dispose()` which was previously missing (only nulled)
- Remove optional chaining (`?.`) on dispose calls — if the object exists, dispose must exist

Closes #287