### PR TITLE
Fix initialize() race condition on double-call in all engines

### DIFF
--- a/src/engines/stt/MlxWhisperEngine.ts
+++ b/src/engines/stt/MlxWhisperEngine.ts
@@ -14,6 +14,7 @@ export class MlxWhisperEngine implements STTEngine {
   readonly isOffline = true
 
   private process: ChildProcess | null = null
+  private initPromise: Promise<void> | null = null
   private model: string
   private onProgress?: (message: string) => void
   private pendingRequests = new Map<number, (data: any) => void>()
@@ -30,6 +31,12 @@ export class MlxWhisperEngine implements STTEngine {
   }
 
   async initialize(): Promise<void> {
+    if (this.initPromise) return this.initPromise
+    this.initPromise = this.doInitialize()
+    return this.initPromise
+  }
+
+  private async doInitialize(): Promise<void> {
     if (this.process) return
 
     this.onProgress?.('Starting mlx-whisper bridge...')
@@ -172,6 +179,7 @@ export class MlxWhisperEngine implements STTEngine {
     for (const resolve of pending) {
       resolve({ error: 'Engine disposed' })
     }
+    this.initPromise = null
   }
 
   private sendCommand(cmd: Record<string, unknown>): Promise<any> {

--- a/src/engines/stt/MoonshineEngine.ts
+++ b/src/engines/stt/MoonshineEngine.ts
@@ -11,6 +11,7 @@ export class MoonshineEngine implements STTEngine {
   readonly isOffline = true
 
   private pipeline: any = null
+  private initPromise: Promise<void> | null = null
   private onProgress?: (message: string) => void
   private variant: MoonshineVariant
 
@@ -20,6 +21,12 @@ export class MoonshineEngine implements STTEngine {
   }
 
   async initialize(): Promise<void> {
+    if (this.initPromise) return this.initPromise
+    this.initPromise = this.doInitialize()
+    return this.initPromise
+  }
+
+  private async doInitialize(): Promise<void> {
     if (this.pipeline) return
 
     const config = MOONSHINE_VARIANTS[this.variant]
@@ -80,5 +87,6 @@ export class MoonshineEngine implements STTEngine {
   async dispose(): Promise<void> {
     console.log('[moonshine] Disposing resources')
     this.pipeline = null
+    this.initPromise = null
   }
 }

--- a/src/engines/stt/QwenASREngine.ts
+++ b/src/engines/stt/QwenASREngine.ts
@@ -50,6 +50,7 @@ export class QwenASREngine implements STTEngine {
   readonly isOffline = true
 
   private process: ChildProcess | null = null
+  private initPromise: Promise<void> | null = null
   private variant: QwenASRVariant
   private onProgress?: (message: string) => void
   private pendingRequests = new Map<number, (data: any) => void>()
@@ -68,6 +69,12 @@ export class QwenASREngine implements STTEngine {
   }
 
   async initialize(): Promise<void> {
+    if (this.initPromise) return this.initPromise
+    this.initPromise = this.doInitialize()
+    return this.initPromise
+  }
+
+  private async doInitialize(): Promise<void> {
     if (this.process) return
 
     const config = QWEN_ASR_VARIANTS[this.variant]
@@ -218,6 +225,7 @@ export class QwenASREngine implements STTEngine {
     for (const resolve of pending) {
       resolve({ error: 'Engine disposed' })
     }
+    this.initPromise = null
   }
 
   private sendCommand(cmd: Record<string, unknown>): Promise<any> {

--- a/src/engines/translator/ANETranslator.ts
+++ b/src/engines/translator/ANETranslator.ts
@@ -23,6 +23,7 @@ export class ANETranslator implements TranslatorEngine {
   readonly isOffline = true
 
   private process: ChildProcess | null = null
+  private initPromise: Promise<void> | null = null
   private onProgress?: (message: string) => void
   private model: string
   private pendingRequests = new Map<number, (data: Record<string, unknown>) => void>()
@@ -39,6 +40,12 @@ export class ANETranslator implements TranslatorEngine {
   }
 
   async initialize(): Promise<void> {
+    if (this.initPromise) return this.initPromise
+    this.initPromise = this.doInitialize()
+    return this.initPromise
+  }
+
+  private async doInitialize(): Promise<void> {
     if (this.process) return
 
     this.onProgress?.('Starting ANEMLL bridge...')
@@ -206,6 +213,7 @@ export class ANETranslator implements TranslatorEngine {
     for (const resolve of pending) {
       resolve({ error: 'Engine disposed' })
     }
+    this.initPromise = null
   }
 
   private sendCommand(cmd: Record<string, unknown>): Promise<Record<string, unknown>> {

--- a/src/engines/translator/CT2Madlad400Translator.ts
+++ b/src/engines/translator/CT2Madlad400Translator.ts
@@ -21,6 +21,7 @@ export class CT2Madlad400Translator implements TranslatorEngine {
   readonly isOffline = true
 
   private process: ChildProcess | null = null
+  private initPromise: Promise<void> | null = null
   private onProgress?: (message: string) => void
   private pendingRequests = new Map<number, (data: Record<string, unknown>) => void>()
   private nextRequestId = 0
@@ -32,6 +33,12 @@ export class CT2Madlad400Translator implements TranslatorEngine {
   }
 
   async initialize(): Promise<void> {
+    if (this.initPromise) return this.initPromise
+    this.initPromise = this.doInitialize()
+    return this.initPromise
+  }
+
+  private async doInitialize(): Promise<void> {
     if (this.process) return
 
     this.onProgress?.('Starting CTranslate2 Madlad-400 bridge...')
@@ -191,6 +198,7 @@ export class CT2Madlad400Translator implements TranslatorEngine {
     for (const resolve of pending) {
       resolve({ error: 'Engine disposed' })
     }
+    this.initPromise = null
   }
 
   private sendCommand(cmd: Record<string, unknown>): Promise<Record<string, unknown>> {

--- a/src/engines/translator/CT2OpusMTTranslator.ts
+++ b/src/engines/translator/CT2OpusMTTranslator.ts
@@ -21,6 +21,7 @@ export class CT2OpusMTTranslator implements TranslatorEngine {
   readonly isOffline = true
 
   private process: ChildProcess | null = null
+  private initPromise: Promise<void> | null = null
   private onProgress?: (message: string) => void
   private pendingRequests = new Map<number, (data: Record<string, unknown>) => void>()
   private nextRequestId = 0
@@ -32,6 +33,12 @@ export class CT2OpusMTTranslator implements TranslatorEngine {
   }
 
   async initialize(): Promise<void> {
+    if (this.initPromise) return this.initPromise
+    this.initPromise = this.doInitialize()
+    return this.initPromise
+  }
+
+  private async doInitialize(): Promise<void> {
     if (this.process) return
 
     this.onProgress?.('Starting CTranslate2 OPUS-MT bridge...')
@@ -196,6 +203,7 @@ export class CT2OpusMTTranslator implements TranslatorEngine {
     for (const resolve of pending) {
       resolve({ error: 'Engine disposed' })
     }
+    this.initPromise = null
   }
 
   private sendCommand(cmd: Record<string, unknown>): Promise<Record<string, unknown>> {

--- a/src/engines/translator/HunyuanMT15Translator.ts
+++ b/src/engines/translator/HunyuanMT15Translator.ts
@@ -25,6 +25,7 @@ export class HunyuanMT15Translator implements TranslatorEngine {
   private worker: Electron.UtilityProcess | null = null
   private pending = new Map<string, PendingRequest>()
   private nextId = 0
+  private initPromise: Promise<void> | null = null
   private onProgress?: (message: string) => void
   private variant: string
   private kvCacheQuant: boolean
@@ -36,6 +37,12 @@ export class HunyuanMT15Translator implements TranslatorEngine {
   }
 
   async initialize(): Promise<void> {
+    if (this.initPromise) return this.initPromise
+    this.initPromise = this.doInitialize()
+    return this.initPromise
+  }
+
+  private async doInitialize(): Promise<void> {
     if (this.worker) return
 
     // Download model if needed
@@ -199,5 +206,6 @@ export class HunyuanMT15Translator implements TranslatorEngine {
       req.reject(new Error('Translator disposed'))
     }
     this.pending.clear()
+    this.initPromise = null
   }
 }

--- a/src/engines/translator/HunyuanMTTranslator.ts
+++ b/src/engines/translator/HunyuanMTTranslator.ts
@@ -25,6 +25,7 @@ export class HunyuanMTTranslator implements TranslatorEngine {
   private worker: Electron.UtilityProcess | null = null
   private pending = new Map<string, PendingRequest>()
   private nextId = 0
+  private initPromise: Promise<void> | null = null
   private onProgress?: (message: string) => void
   private variant: string
   private kvCacheQuant: boolean
@@ -36,6 +37,12 @@ export class HunyuanMTTranslator implements TranslatorEngine {
   }
 
   async initialize(): Promise<void> {
+    if (this.initPromise) return this.initPromise
+    this.initPromise = this.doInitialize()
+    return this.initPromise
+  }
+
+  private async doInitialize(): Promise<void> {
     if (this.worker) return
 
     // Download model if needed
@@ -199,5 +206,6 @@ export class HunyuanMTTranslator implements TranslatorEngine {
       req.reject(new Error('Translator disposed'))
     }
     this.pending.clear()
+    this.initPromise = null
   }
 }

--- a/src/engines/translator/OpusMTTranslator.ts
+++ b/src/engines/translator/OpusMTTranslator.ts
@@ -12,7 +12,7 @@ export class OpusMTTranslator implements TranslatorEngine {
 
   private jaToEn: TranslationPipeline | null = null
   private enToJa: TranslationPipeline | null = null
-  private initializing = false
+  private initPromise: Promise<void> | null = null
   private onProgress?: (message: string) => void
 
   constructor(options?: { onProgress?: (message: string) => void }) {
@@ -20,9 +20,13 @@ export class OpusMTTranslator implements TranslatorEngine {
   }
 
   async initialize(): Promise<void> {
+    if (this.initPromise) return this.initPromise
+    this.initPromise = this.doInitialize()
+    return this.initPromise
+  }
+
+  private async doInitialize(): Promise<void> {
     if (this.jaToEn && this.enToJa) return
-    if (this.initializing) return
-    this.initializing = true
 
     const { pipeline, env } = await import('@huggingface/transformers')
     env.cacheDir = join(app.getPath('userData'), 'models', 'transformers')
@@ -46,9 +50,8 @@ export class OpusMTTranslator implements TranslatorEngine {
     } catch (err) {
       this.jaToEn = null
       this.enToJa = null
+      this.initPromise = null
       throw err
-    } finally {
-      this.initializing = false
     }
   }
 

--- a/src/engines/translator/SLMTranslator.ts
+++ b/src/engines/translator/SLMTranslator.ts
@@ -20,6 +20,7 @@ export class SLMTranslator implements TranslatorEngine {
   private worker: Electron.UtilityProcess | null = null
   private pending = new Map<string, PendingRequest>()
   private nextId = 0
+  private initPromise: Promise<void> | null = null
   private onProgress?: (message: string) => void
   private variant: string
   private modelSize: SLMModelSize
@@ -36,6 +37,12 @@ export class SLMTranslator implements TranslatorEngine {
   }
 
   async initialize(): Promise<void> {
+    if (this.initPromise) return this.initPromise
+    this.initPromise = this.doInitialize()
+    return this.initPromise
+  }
+
+  private async doInitialize(): Promise<void> {
     if (this.worker) return
 
     // Download model if needed
@@ -236,5 +243,6 @@ export class SLMTranslator implements TranslatorEngine {
       req.reject(new Error('Translator disposed'))
     }
     this.pending.clear()
+    this.initPromise = null
   }
 }


### PR DESCRIPTION
## Summary
- Add `initPromise` guard pattern to prevent duplicate worker/process spawning when `initialize()` is called concurrently
- Applied consistently to all 10 affected engine classes: SLMTranslator, HunyuanMTTranslator, HunyuanMT15Translator, OpusMTTranslator, MoonshineEngine, CT2OpusMTTranslator, CT2Madlad400Translator, ANETranslator, MlxWhisperEngine, QwenASREngine
- Reset `initPromise` in `dispose()` to allow re-initialization after disposal

## Test plan
- [x] `npm run typecheck` passes (pre-existing ws-audio-server errors only)
- [x] `npm test` — all 45 tests pass
- [ ] Manual: rapidly click start twice to verify no duplicate workers spawn

Closes #286