### PR TITLE
Modularize main/index.ts into focused modules

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,7 +40,12 @@ npm install          # Install deps (postinstall fixes whisper-node-addon)
 live-translate/
 ├── src/
 │   ├── main/
-│   │   ├── index.ts             # App entry, IPC handlers, pipeline wiring
+│   │   ├── index.ts             # App entry, pipeline init, lifecycle orchestration
+│   │   ├── app-context.ts       # Shared mutable state interface (AppContext)
+│   │   ├── window-manager.ts    # Window creation, display handlers
+│   │   ├── ipc-handlers.ts      # IPC handlers (pipeline, settings, sessions, ws-audio)
+│   │   ├── audio-handlers.ts    # Audio processing IPC (process, streaming, finalize)
+│   │   ├── error-utils.ts       # Error sanitization and hint mapping
 │   │   ├── store.ts             # electron-store (encrypted, settings, quota)
 │   │   └── slm-worker.ts        # UtilityProcess: TranslateGemma + summarization
 │   ├── preload/                 # Context bridge (renderer ↔ main IPC)

--- a/src/main/app-context.ts
+++ b/src/main/app-context.ts
@@ -1,0 +1,16 @@
+import type { BrowserWindow } from 'electron'
+import type { TranslationPipeline } from '../pipeline/TranslationPipeline'
+import type { TranscriptLogger } from '../logger/TranscriptLogger'
+import type { WsAudioServer } from './ws-audio-server'
+
+/**
+ * Shared mutable state accessed by all main-process modules.
+ * Passed by reference so mutations are visible across modules.
+ */
+export interface AppContext {
+  mainWindow: BrowserWindow | null
+  subtitleWindow: BrowserWindow | null
+  pipeline: TranslationPipeline | null
+  logger: TranscriptLogger | null
+  wsAudioServer: WsAudioServer | null
+}

--- a/src/main/audio-handlers.ts
+++ b/src/main/audio-handlers.ts
@@ -1,0 +1,87 @@
+import { ipcMain } from 'electron'
+import { sanitizeErrorMessage } from './error-utils'
+import type { AppContext } from './app-context'
+
+/** Minimum amplitude to consider a chunk as non-silent */
+const SILENCE_THRESHOLD = 0.001
+
+/** Convert IPC audio data to Float32Array, returning null for silence */
+function toFloat32Array(audioData: unknown): Float32Array | null {
+  let chunk: Float32Array
+  if (audioData instanceof Float32Array) {
+    chunk = audioData
+  } else if (Array.isArray(audioData)) {
+    chunk = new Float32Array(audioData)
+  } else if (audioData instanceof ArrayBuffer || Buffer.isBuffer(audioData)) {
+    chunk = new Float32Array(
+      Buffer.isBuffer(audioData) ? audioData.buffer.slice(audioData.byteOffset, audioData.byteOffset + audioData.byteLength) : audioData
+    )
+  } else {
+    console.error('[audio] Unknown data type:', typeof audioData)
+    return null
+  }
+
+  // Scan for max amplitude (used for silence detection)
+  let maxAmp = 0
+  for (let i = 0; i < chunk.length; i++) {
+    const abs = Math.abs(chunk[i])
+    if (abs > maxAmp) maxAmp = abs
+  }
+
+  if (maxAmp < SILENCE_THRESHOLD) {
+    return null
+  }
+
+  return chunk
+}
+
+/** Register audio processing IPC handlers */
+export function registerAudioHandlers(ctx: AppContext): void {
+  // Process audio chunk from renderer
+  ipcMain.handle('process-audio', async (_event, audioData: unknown) => {
+    if (!ctx.pipeline?.running) return null
+
+    const chunk = toFloat32Array(audioData)
+    if (!chunk || chunk.length < 8000) return null
+
+    try {
+      return await ctx.pipeline.process(chunk, 16000)
+    } catch (err) {
+      console.error('[audio] Pipeline error:', err)
+      // #43: propagate error to renderer
+      const message = sanitizeErrorMessage(err instanceof Error ? err.message : String(err))
+      ctx.mainWindow?.webContents.send('status-update', `Processing error: ${message}`)
+      return null
+    }
+  })
+
+  // Process streaming audio (rolling buffer during speech)
+  ipcMain.handle('process-audio-streaming', async (_event, audioData: unknown) => {
+    if (!ctx.pipeline?.running) return null
+
+    const chunk = toFloat32Array(audioData)
+    if (!chunk || chunk.length < 8000) return null
+
+    try {
+      return await ctx.pipeline.processStreaming(chunk, 16000)
+    } catch (err) {
+      console.error('[audio] Streaming pipeline error:', err)
+      return null
+    }
+  })
+
+  // Finalize streaming (speech segment ended)
+  ipcMain.handle('finalize-streaming', async (_event, audioData: unknown) => {
+    if (!ctx.pipeline?.running) return null
+
+    const chunk = toFloat32Array(audioData)
+    if (!chunk || chunk.length < 8000) return null
+
+    try {
+      return await ctx.pipeline.finalizeStreaming(chunk, 16000)
+    } catch (err) {
+      console.error('[audio] Finalize streaming error:', err)
+      return null
+    }
+  })
+}

--- a/src/main/error-utils.ts
+++ b/src/main/error-utils.ts
@@ -1,0 +1,41 @@
+import { store } from './store'
+
+/** Scrub API keys from error messages before sending to renderer (#209) */
+export function sanitizeErrorMessage(message: string): string {
+  const settings = store.store as unknown as Record<string, unknown>
+  const secrets = [
+    settings.googleApiKey,
+    settings.deeplApiKey,
+    settings.geminiApiKey,
+    settings.microsoftApiKey
+  ].filter((s): s is string => typeof s === 'string' && s.length > 8)
+
+  let sanitized = message
+  for (const secret of secrets) {
+    sanitized = sanitized.split(secret).join('***')
+  }
+  // Also scrub common API key patterns that may leak from HTTP responses
+  sanitized = sanitized.replace(/AIza[0-9A-Za-z\-_]{35}/g, '***')
+  return sanitized
+}
+
+/** Map error patterns to actionable hints */
+export function getErrorHint(message: string): string {
+  const lower = message.toLowerCase()
+  if (lower.includes('api key') || lower.includes('401') || lower.includes('403')) {
+    return ' — Check your API key in settings'
+  }
+  if (lower.includes('rate limit') || lower.includes('429') || lower.includes('quota')) {
+    return ' — API quota exceeded, try a different provider'
+  }
+  if (lower.includes('timed out') || lower.includes('timeout')) {
+    return ' — Check your internet connection'
+  }
+  if (lower.includes('network') || lower.includes('fetch')) {
+    return ' — Check your internet connection'
+  }
+  if (lower.includes('model') || lower.includes('download')) {
+    return ' — Model download issue, try restarting'
+  }
+  return ''
+}

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1,200 +1,91 @@
-import { app, BrowserWindow, screen, ipcMain } from 'electron'
-import { join } from 'path'
-import { is } from '@electron-toolkit/utils'
+import { app } from 'electron'
 import { TranslationPipeline } from '../pipeline/TranslationPipeline'
-import { WsAudioServer } from './ws-audio-server'
 import { WhisperLocalEngine } from '../engines/stt/WhisperLocalEngine'
 import { MlxWhisperEngine } from '../engines/stt/MlxWhisperEngine'
 import { MoonshineEngine } from '../engines/stt/MoonshineEngine'
-import { GoogleTranslator } from '../engines/translator/GoogleTranslator'
-import { DeepLTranslator } from '../engines/translator/DeepLTranslator'
-import { GeminiTranslator } from '../engines/translator/GeminiTranslator'
-import { MicrosoftTranslator } from '../engines/translator/MicrosoftTranslator'
 import { OpusMTTranslator } from '../engines/translator/OpusMTTranslator'
 import { CT2OpusMTTranslator } from '../engines/translator/CT2OpusMTTranslator'
 import { CT2Madlad400Translator } from '../engines/translator/CT2Madlad400Translator'
-import { ApiRotationController } from '../engines/translator/ApiRotationController'
-import type { ProviderConfig, QuotaStore } from '../engines/translator/ApiRotationController'
 import { SLMTranslator } from '../engines/translator/SLMTranslator'
 import { HunyuanMTTranslator } from '../engines/translator/HunyuanMTTranslator'
 import { HunyuanMT15Translator } from '../engines/translator/HunyuanMT15Translator'
 import { ANETranslator } from '../engines/translator/ANETranslator'
 import { HybridTranslator } from '../engines/translator/HybridTranslator'
-import { detectGpu } from '../engines/gpu-detector'
-import { isGGUFDownloaded, getGGUFVariants, getHunyuanMTVariants, getHunyuanMT15Variants, getWhisperVariants, getMoonshineVariants, isModelDownloaded as isWhisperModelDownloaded } from '../engines/model-downloader'
-import type { SLMModelSize, WhisperVariant, MoonshineVariant } from '../engines/model-downloader'
-import { listPlugins, discoverPlugins, loadPluginEngine } from '../engines/plugin-loader'
-import { TranscriptLogger } from '../logger/TranscriptLogger'
-import * as SessionManager from '../logger/SessionManager'
+import { discoverPlugins, loadPluginEngine } from '../engines/plugin-loader'
 import { store } from './store'
-import type { EngineConfig, TranslationResult } from '../engines/types'
+import { sanitizeErrorMessage, getErrorHint } from './error-utils'
+import { createMainWindow, createSubtitleWindow, registerDisplayHandlers } from './window-manager'
+import { registerAudioHandlers } from './audio-handlers'
+import { registerIpcHandlers } from './ipc-handlers'
+import type { AppContext } from './app-context'
+import type { TranslationResult } from '../engines/types'
+import type { WhisperVariant, MoonshineVariant } from '../engines/model-downloader'
 
-/** Scrub API keys from error messages before sending to renderer (#209) */
-function sanitizeErrorMessage(message: string): string {
-  const settings = store.store as unknown as Record<string, unknown>
-  const secrets = [
-    settings.googleApiKey,
-    settings.deeplApiKey,
-    settings.geminiApiKey,
-    settings.microsoftApiKey
-  ].filter((s): s is string => typeof s === 'string' && s.length > 8)
-
-  let sanitized = message
-  for (const secret of secrets) {
-    sanitized = sanitized.split(secret).join('***')
-  }
-  // Also scrub common API key patterns that may leak from HTTP responses
-  sanitized = sanitized.replace(/AIza[0-9A-Za-z\-_]{35}/g, '***')
-  return sanitized
-}
-
-/** Minimum amplitude to consider a chunk as non-silent */
-const SILENCE_THRESHOLD = 0.001
-
-/** Calculate subtitle window height based on display scale factor */
-function getSubtitleHeight(display: Electron.Display): number {
-  // Base height for 3 subtitle lines at default font size (30px)
-  const baseHeight = 200
-  const scaleFactor = display.scaleFactor ?? 1
-  // Scale for HiDPI displays but cap at 2x to avoid excessively tall windows
-  return Math.round(baseHeight * Math.min(scaleFactor, 2))
-}
-
-/** Monthly character limits for API rotation providers */
-const QUOTA_LIMITS = {
-  microsoft: 2_000_000,
-  google: 480_000,
-  deepl: 500_000,
-  gemini: 1_000_000
-} as const
-
-let mainWindow: BrowserWindow | null = null
-let subtitleWindow: BrowserWindow | null = null
-let pipeline: TranslationPipeline | null = null
-let logger: TranscriptLogger | null = null
-let wsAudioServer: WsAudioServer | null = null
-
-function createMainWindow(): void {
-  mainWindow = new BrowserWindow({
-    width: 520,
-    height: 720,
-    minWidth: 480,
-    minHeight: 600,
-    resizable: true,
-    webPreferences: {
-      preload: join(__dirname, '../preload/index.js'),
-      contextIsolation: true,
-      nodeIntegration: false
-    }
-  })
-
-  if (is.dev && process.env['ELECTRON_RENDERER_URL']) {
-    mainWindow.loadURL(process.env['ELECTRON_RENDERER_URL'])
-  } else {
-    mainWindow.loadFile(join(__dirname, '../renderer/index.html'))
-  }
-
-  mainWindow.on('closed', () => {
-    mainWindow = null
-    subtitleWindow?.close()
-  })
-}
-
-function createSubtitleWindow(): void {
-  const displays = screen.getAllDisplays()
-  const savedDisplayId = store.get('selectedDisplay')
-  const savedDisplay = savedDisplayId ? displays.find((d) => d.id === savedDisplayId) : null
-  const primaryId = screen.getPrimaryDisplay().id
-  const externalDisplay = displays.find((d) => d.id !== primaryId)
-  const targetDisplay = savedDisplay || externalDisplay || displays[0]
-
-  const subtitleHeight = getSubtitleHeight(targetDisplay)
-  subtitleWindow = new BrowserWindow({
-    x: targetDisplay.bounds.x,
-    y: targetDisplay.bounds.y + targetDisplay.bounds.height - subtitleHeight,
-    width: targetDisplay.bounds.width,
-    height: subtitleHeight,
-    transparent: true,
-    frame: false,
-    alwaysOnTop: true,
-    skipTaskbar: true,
-    hasShadow: false,
-    webPreferences: {
-      preload: join(__dirname, '../preload/index.js'),
-      contextIsolation: true,
-      nodeIntegration: false
-    }
-  })
-
-  subtitleWindow.setIgnoreMouseEvents(true, { forward: true })
-
-  if (is.dev && process.env['ELECTRON_RENDERER_URL']) {
-    subtitleWindow.loadURL(`${process.env['ELECTRON_RENDERER_URL']}#/subtitle`)
-  } else {
-    subtitleWindow.loadFile(join(__dirname, '../renderer/index.html'), { hash: '/subtitle' })
-  }
-
-  subtitleWindow.on('closed', () => {
-    subtitleWindow = null
-  })
+// Shared mutable state
+const ctx: AppContext = {
+  mainWindow: null,
+  subtitleWindow: null,
+  pipeline: null,
+  logger: null,
+  wsAudioServer: null
 }
 
 function initPipeline(): void {
-  pipeline = new TranslationPipeline()
+  ctx.pipeline = new TranslationPipeline()
 
   // Register STT engines
-  pipeline.registerSTT('whisper-local', () => new WhisperLocalEngine({
-    onProgress: (msg) => mainWindow?.webContents.send('status-update', msg),
+  ctx.pipeline.registerSTT('whisper-local', () => new WhisperLocalEngine({
+    onProgress: (msg) => ctx.mainWindow?.webContents.send('status-update', msg),
     modelVariant: (store.get('whisperVariant') as WhisperVariant) || undefined
   }))
   // mlx-whisper is Apple Silicon only — skip registration on other platforms
   if (process.platform === 'darwin') {
-    pipeline.registerSTT('mlx-whisper', () => new MlxWhisperEngine({
-      onProgress: (msg) => mainWindow?.webContents.send('status-update', msg)
+    ctx.pipeline.registerSTT('mlx-whisper', () => new MlxWhisperEngine({
+      onProgress: (msg) => ctx.mainWindow?.webContents.send('status-update', msg)
     }))
   }
-  pipeline.registerSTT('moonshine', () => new MoonshineEngine({
-    onProgress: (msg) => mainWindow?.webContents.send('status-update', msg),
+  ctx.pipeline.registerSTT('moonshine', () => new MoonshineEngine({
+    onProgress: (msg) => ctx.mainWindow?.webContents.send('status-update', msg),
     variant: (store.get('moonshineVariant') as MoonshineVariant) || undefined
   }))
 
   // Register translator engines
-  pipeline.registerTranslator('opus-mt', () => new OpusMTTranslator({
-    onProgress: (msg) => mainWindow?.webContents.send('status-update', msg)
+  ctx.pipeline.registerTranslator('opus-mt', () => new OpusMTTranslator({
+    onProgress: (msg) => ctx.mainWindow?.webContents.send('status-update', msg)
   }))
-  pipeline.registerTranslator('ct2-opus-mt', () => new CT2OpusMTTranslator({
-    onProgress: (msg) => mainWindow?.webContents.send('status-update', msg)
+  ctx.pipeline.registerTranslator('ct2-opus-mt', () => new CT2OpusMTTranslator({
+    onProgress: (msg) => ctx.mainWindow?.webContents.send('status-update', msg)
   }))
-  pipeline.registerTranslator('ct2-madlad-400', () => new CT2Madlad400Translator({
-    onProgress: (msg) => mainWindow?.webContents.send('status-update', msg)
+  ctx.pipeline.registerTranslator('ct2-madlad-400', () => new CT2Madlad400Translator({
+    onProgress: (msg) => ctx.mainWindow?.webContents.send('status-update', msg)
   }))
-  pipeline.registerTranslator('slm-translate', () => new SLMTranslator({
-    onProgress: (msg) => mainWindow?.webContents.send('status-update', msg),
+  ctx.pipeline.registerTranslator('slm-translate', () => new SLMTranslator({
+    onProgress: (msg) => ctx.mainWindow?.webContents.send('status-update', msg),
     kvCacheQuant: store.get('slmKvCacheQuant'),
     modelSize: store.get('slmModelSize'),
     speculativeDecoding: store.get('slmSpeculativeDecoding')
   }))
-  pipeline.registerTranslator('hunyuan-mt', () => new HunyuanMTTranslator({
-    onProgress: (msg) => mainWindow?.webContents.send('status-update', msg),
+  ctx.pipeline.registerTranslator('hunyuan-mt', () => new HunyuanMTTranslator({
+    onProgress: (msg) => ctx.mainWindow?.webContents.send('status-update', msg),
     kvCacheQuant: store.get('slmKvCacheQuant')
   }))
-  pipeline.registerTranslator('hunyuan-mt-15', () => new HunyuanMT15Translator({
-    onProgress: (msg) => mainWindow?.webContents.send('status-update', msg),
+  ctx.pipeline.registerTranslator('hunyuan-mt-15', () => new HunyuanMT15Translator({
+    onProgress: (msg) => ctx.mainWindow?.webContents.send('status-update', msg),
     kvCacheQuant: store.get('slmKvCacheQuant')
   }))
   // ANEMLL Apple Neural Engine translator — macOS Apple Silicon only (#241)
   if (process.platform === 'darwin') {
-    pipeline.registerTranslator('ane-translate', () => new ANETranslator({
-      onProgress: (msg) => mainWindow?.webContents.send('status-update', msg)
+    ctx.pipeline.registerTranslator('ane-translate', () => new ANETranslator({
+      onProgress: (msg) => ctx.mainWindow?.webContents.send('status-update', msg)
     }))
   }
   // Hybrid translator: OPUS-MT instant draft + TranslateGemma refinement (#235)
-  pipeline.registerTranslator('hybrid', () => new HybridTranslator(
+  ctx.pipeline.registerTranslator('hybrid', () => new HybridTranslator(
     new OpusMTTranslator({
-      onProgress: (msg) => mainWindow?.webContents.send('status-update', msg)
+      onProgress: (msg) => ctx.mainWindow?.webContents.send('status-update', msg)
     }),
     new SLMTranslator({
-      onProgress: (msg) => mainWindow?.webContents.send('status-update', msg),
+      onProgress: (msg) => ctx.mainWindow?.webContents.send('status-update', msg),
       kvCacheQuant: store.get('slmKvCacheQuant'),
       modelSize: store.get('slmModelSize'),
       speculativeDecoding: store.get('slmSpeculativeDecoding')
@@ -205,627 +96,60 @@ function initPipeline(): void {
     const { manifest } = plugin
     const factory = () => loadPluginEngine(plugin)
     if (manifest.engineType === 'stt') {
-      pipeline.registerSTT(manifest.engineId, factory as any)
+      ctx.pipeline.registerSTT(manifest.engineId, factory as any)
     } else if (manifest.engineType === 'translator') {
-      pipeline.registerTranslator(manifest.engineId, factory as any)
+      ctx.pipeline.registerTranslator(manifest.engineId, factory as any)
     } else if (manifest.engineType === 'e2e') {
-      pipeline.registerE2E(manifest.engineId, factory as any)
+      ctx.pipeline.registerE2E(manifest.engineId, factory as any)
     }
     console.log(`[plugin] Registered ${manifest.engineType} plugin: ${manifest.name} (${manifest.engineId})`)
   }
-  // GoogleTranslator needs API key — registered dynamically when user provides one
 
   // Forward results to subtitle window and logger
-  pipeline.on('result', (result: TranslationResult) => {
-    subtitleWindow?.webContents.send('translation-result', result)
-    mainWindow?.webContents.send('translation-result', result)
-    logger?.log(result)
+  ctx.pipeline.on('result', (result: TranslationResult) => {
+    ctx.subtitleWindow?.webContents.send('translation-result', result)
+    ctx.mainWindow?.webContents.send('translation-result', result)
+    ctx.logger?.log(result)
   })
 
   // Forward interim (streaming) results to subtitle window
-  pipeline.on('interim-result', (result: TranslationResult) => {
-    subtitleWindow?.webContents.send('interim-result', result)
-    mainWindow?.webContents.send('interim-result', result)
+  ctx.pipeline.on('interim-result', (result: TranslationResult) => {
+    ctx.subtitleWindow?.webContents.send('interim-result', result)
+    ctx.mainWindow?.webContents.send('interim-result', result)
   })
 
   // Forward draft results from hybrid translation (#235)
-  pipeline.on('draft-result', (result: TranslationResult) => {
-    subtitleWindow?.webContents.send('draft-result', result)
-    mainWindow?.webContents.send('draft-result', result)
+  ctx.pipeline.on('draft-result', (result: TranslationResult) => {
+    ctx.subtitleWindow?.webContents.send('draft-result', result)
+    ctx.mainWindow?.webContents.send('draft-result', result)
   })
 
-  pipeline.on('error', (err: Error) => {
+  ctx.pipeline.on('error', (err: Error) => {
     const msg = sanitizeErrorMessage(err.message)
     const hint = getErrorHint(msg)
-    mainWindow?.webContents.send('status-update', `Error: ${msg}${hint}`)
+    ctx.mainWindow?.webContents.send('status-update', `Error: ${msg}${hint}`)
   })
 
-  pipeline.on('engine-loading', (msg: string) => {
-    mainWindow?.webContents.send('status-update', msg)
+  ctx.pipeline.on('engine-loading', (msg: string) => {
+    ctx.mainWindow?.webContents.send('status-update', msg)
   })
 
-  pipeline.on('engine-ready', () => {
-    mainWindow?.webContents.send('status-update', 'Engine ready')
+  ctx.pipeline.on('engine-ready', () => {
+    ctx.mainWindow?.webContents.send('status-update', 'Engine ready')
   })
 }
 
-// --- IPC Handlers ---
-
-// Start pipeline with given config
-interface PipelineStartConfig extends EngineConfig {
-  apiKey?: string
-  deeplApiKey?: string
-  geminiApiKey?: string
-  microsoftApiKey?: string
-  microsoftRegion?: string
-}
-
-ipcMain.handle('pipeline-start', async (_event, config: PipelineStartConfig) => {
-  if (!pipeline) return { error: 'Pipeline not initialized' }
-  if (pipeline.active) return { error: 'Pipeline already running' } // #30
-
-  try {
-    // Register online translators with provided API keys
-    if (config.apiKey) {
-      pipeline.registerTranslator('google-translate', () => new GoogleTranslator(config.apiKey!))
-    }
-    if (config.deeplApiKey) {
-      pipeline.registerTranslator('deepl-translate', () => new DeepLTranslator(config.deeplApiKey!))
-    }
-    if (config.geminiApiKey) {
-      pipeline.registerTranslator('gemini-translate', () => new GeminiTranslator(config.geminiApiKey!))
-    }
-    if (config.microsoftApiKey && config.microsoftRegion) {
-      pipeline.registerTranslator('microsoft-translate', () =>
-        new MicrosoftTranslator(config.microsoftApiKey!, config.microsoftRegion!)
-      )
-    }
-
-    // Build rotation controller when rotation mode is selected
-    let rotationProviders: ProviderConfig[] | null = null
-    if (config.translatorEngineId === 'rotation-controller') {
-      rotationProviders = []
-      const statusFn = (msg: string): void => {
-        mainWindow?.webContents.send('status-update', msg)
-      }
-
-      // Order: Azure (2M) → Google (480K safe cap) → DeepL (500K)
-      if (config.microsoftApiKey && config.microsoftRegion) {
-        rotationProviders.push({
-          engine: new MicrosoftTranslator(config.microsoftApiKey, config.microsoftRegion),
-          monthlyCharLimit: QUOTA_LIMITS.microsoft
-        })
-      }
-      if (config.apiKey) {
-        rotationProviders.push({
-          engine: new GoogleTranslator(config.apiKey),
-          monthlyCharLimit: QUOTA_LIMITS.google
-        })
-      }
-      if (config.deeplApiKey) {
-        rotationProviders.push({
-          engine: new DeepLTranslator(config.deeplApiKey),
-          monthlyCharLimit: QUOTA_LIMITS.deepl
-        })
-      }
-      if (config.geminiApiKey) {
-        rotationProviders.push({
-          engine: new GeminiTranslator(config.geminiApiKey),
-          monthlyCharLimit: QUOTA_LIMITS.gemini
-        })
-      }
-
-      if (rotationProviders.length === 0) {
-        return { error: 'Rotation mode requires at least one API key' }
-      }
-
-      const persistence = {
-        load: (): QuotaStore => store.get('quotaTracking') as QuotaStore,
-        save: (quota: QuotaStore): void => { store.set('quotaTracking', quota) }
-      }
-
-      pipeline.registerTranslator('rotation-controller', () =>
-        new ApiRotationController(rotationProviders!, persistence, statusFn)
-      )
-    }
-
-    try {
-      await pipeline.switchEngine(config)
-    } catch (err) {
-      // Dispose leaked rotation provider instances on switchEngine failure
-      if (rotationProviders) {
-        for (const p of rotationProviders) {
-          p.engine.dispose().catch(() => {})
-        }
-      }
-      throw err
-    }
-
-    // Load glossary terms from store
-    const glossaryTerms = store.get('glossaryTerms') || []
-    pipeline!.setGlossary(glossaryTerms)
-
-    // Configure language settings (#263)
-    pipeline!.setLanguageConfig(store.get('sourceLanguage'), store.get('targetLanguage'))
-
-    // Configure SimulMT (#239)
-    pipeline!.setSimulMt(store.get('simulMtEnabled'), store.get('simulMtWaitK'))
-
-    // Start logger
-    logger = new TranscriptLogger((msg) => mainWindow?.webContents.send('status-update', msg))
-    const sessionLabel = config.mode === 'e2e'
-      ? 'Offline (Whisper Translate)'
-      : `Cascade (Whisper + ${config.translatorEngineId})`
-    logger.startSession(sessionLabel)
-
-    // #62: persist session BEFORE start to avoid crash window
-    store.set('activeSession', { config, startedAt: Date.now() })
-
-    pipeline.start()
-
-    return { success: true }
-  } catch (err) {
-    return { error: sanitizeErrorMessage(String(err)) }
-  }
-})
-
-// Stop pipeline
-ipcMain.handle('pipeline-stop', async () => {
-  // #116: log session usage
-  const activeSession = store.get('activeSession')
-  if (activeSession) {
-    const now = Date.now()
-    const logs = store.get('sessionLogs') || []
-    logs.push({
-      startedAt: activeSession.startedAt,
-      endedAt: now,
-      engineMode: String(activeSession.config?.translatorEngineId || activeSession.config?.e2eEngineId || 'unknown'),
-      durationMs: now - activeSession.startedAt,
-      errorCount: 0
-    })
-    // Keep last 100 session logs
-    store.set('sessionLogs', logs.slice(-100))
-  }
-
-  await pipeline?.stop()
-  logger?.endSession()
-  const logPath = logger?.getLogPath()
-  logger = null
-  // #54: clear session on clean stop
-  store.set('activeSession', null)
-  return { logPath }
-})
-
-// Get session start time
-ipcMain.handle('get-session-start-time', () => {
-  return pipeline?.sessionStartTime ?? null
-})
-
-/** Map error patterns to actionable hints */
-function getErrorHint(message: string): string {
-  const lower = message.toLowerCase()
-  if (lower.includes('api key') || lower.includes('401') || lower.includes('403')) {
-    return ' — Check your API key in settings'
-  }
-  if (lower.includes('rate limit') || lower.includes('429') || lower.includes('quota')) {
-    return ' — API quota exceeded, try a different provider'
-  }
-  if (lower.includes('timed out') || lower.includes('timeout')) {
-    return ' — Check your internet connection'
-  }
-  if (lower.includes('network') || lower.includes('fetch')) {
-    return ' — Check your internet connection'
-  }
-  if (lower.includes('model') || lower.includes('download')) {
-    return ' — Model download issue, try restarting'
-  }
-  return ''
-}
-
-/** Convert IPC audio data to Float32Array */
-function toFloat32Array(audioData: unknown): Float32Array | null {
-  let chunk: Float32Array
-  if (audioData instanceof Float32Array) {
-    chunk = audioData
-  } else if (Array.isArray(audioData)) {
-    chunk = new Float32Array(audioData)
-  } else if (audioData instanceof ArrayBuffer || Buffer.isBuffer(audioData)) {
-    chunk = new Float32Array(
-      Buffer.isBuffer(audioData) ? audioData.buffer.slice(audioData.byteOffset, audioData.byteOffset + audioData.byteLength) : audioData
-    )
-  } else {
-    console.error('[audio] Unknown data type:', typeof audioData)
-    return null
-  }
-
-  // Scan for max amplitude (used for silence detection)
-  let maxAmp = 0
-  for (let i = 0; i < chunk.length; i++) {
-    const abs = Math.abs(chunk[i])
-    if (abs > maxAmp) maxAmp = abs
-  }
-
-  if (maxAmp < SILENCE_THRESHOLD) {
-    return null
-  }
-
-  return chunk
-}
-
-// Process audio chunk from renderer
-ipcMain.handle('process-audio', async (_event, audioData: unknown) => {
-  if (!pipeline?.running) return null
-
-  const chunk = toFloat32Array(audioData)
-  if (!chunk || chunk.length < 8000) return null
-
-  try {
-    return await pipeline.process(chunk, 16000)
-  } catch (err) {
-    console.error('[audio] Pipeline error:', err)
-    // #43: propagate error to renderer
-    const message = sanitizeErrorMessage(err instanceof Error ? err.message : String(err))
-    mainWindow?.webContents.send('status-update', `Processing error: ${message}`)
-    return null
-  }
-})
-
-// Process streaming audio (rolling buffer during speech)
-ipcMain.handle('process-audio-streaming', async (_event, audioData: unknown) => {
-  if (!pipeline?.running) return null
-
-  const chunk = toFloat32Array(audioData)
-  if (!chunk || chunk.length < 8000) return null
-
-  try {
-    return await pipeline.processStreaming(chunk, 16000)
-  } catch (err) {
-    console.error('[audio] Streaming pipeline error:', err)
-    return null
-  }
-})
-
-// Finalize streaming (speech segment ended)
-ipcMain.handle('finalize-streaming', async (_event, audioData: unknown) => {
-  if (!pipeline?.running) return null
-
-  const chunk = toFloat32Array(audioData)
-  if (!chunk || chunk.length < 8000) return null
-
-  try {
-    return await pipeline.finalizeStreaming(chunk, 16000)
-  } catch (err) {
-    console.error('[audio] Finalize streaming error:', err)
-    return null
-  }
-})
-
-// Get available displays
-ipcMain.handle('get-displays', () => {
-  const primary = screen.getPrimaryDisplay()
-  return screen.getAllDisplays().map((d, i) => ({
-    id: d.id,
-    label: d.id === primary.id ? `Display ${i + 1} (Main)` : `Display ${i + 1} (External)`,
-    bounds: d.bounds
-  }))
-})
-
-// Move subtitle window to target display
-ipcMain.on('move-subtitle-to-display', (_event, displayId: number) => {
-  const display = screen.getAllDisplays().find((d) => d.id === displayId)
-  if (!display) {
-    console.warn(`[display] Display ${displayId} not found, ignoring move request`)
-    return
-  }
-  if (subtitleWindow) {
-    const h = getSubtitleHeight(display)
-    subtitleWindow.setBounds({
-      x: display.bounds.x,
-      y: display.bounds.y + display.bounds.height - h,
-      width: display.bounds.width,
-      height: h
-    })
-  }
-})
-
-// Forward translation result to subtitle window (from renderer)
-ipcMain.on('translation-result', (_event, data) => {
-  subtitleWindow?.webContents.send('translation-result', data)
-})
-
-// Settings persistence via electron-store (#49)
-ipcMain.handle('get-settings', () => {
-  return {
-    translationEngine: store.get('translationEngine'),
-    googleApiKey: store.get('googleApiKey'),
-    deeplApiKey: store.get('deeplApiKey'),
-    geminiApiKey: store.get('geminiApiKey'),
-    microsoftApiKey: store.get('microsoftApiKey'),
-    microsoftRegion: store.get('microsoftRegion'),
-    sttEngine: store.get('sttEngine'),
-    selectedMicrophone: store.get('selectedMicrophone'),
-    selectedDisplay: store.get('selectedDisplay'),
-    subtitleSettings: store.get('subtitleSettings'),
-    slmKvCacheQuant: store.get('slmKvCacheQuant'),
-    slmModelSize: store.get('slmModelSize'),
-    slmSpeculativeDecoding: store.get('slmSpeculativeDecoding'),
-    glossaryTerms: store.get('glossaryTerms') || [],
-    simulMtEnabled: store.get('simulMtEnabled'),
-    simulMtWaitK: store.get('simulMtWaitK'),
-    whisperVariant: store.get('whisperVariant'),
-    moonshineVariant: store.get('moonshineVariant'),
-    sourceLanguage: store.get('sourceLanguage'),
-    targetLanguage: store.get('targetLanguage')
-  }
-})
-
-// Subtitle settings — push changes to subtitle window in real-time
-ipcMain.handle('save-subtitle-settings', (_event, settings: Record<string, unknown>) => {
-  store.set('subtitleSettings', settings as unknown as import('./store').SubtitleSettings)
-  subtitleWindow?.webContents.send('subtitle-settings-changed', settings)
-})
-
-ipcMain.handle('save-settings', (_event, settings: Record<string, unknown>) => {
-  for (const [key, value] of Object.entries(settings)) {
-    store.set(key as keyof import('./store').AppSettings, value as never)
-  }
-})
-
-// Glossary terms persistence (#240)
-ipcMain.handle('save-glossary', (_event, terms: Array<{ source: string; target: string }>) => {
-  store.set('glossaryTerms', terms)
-  // Update running pipeline glossary in real-time
-  if (pipeline) {
-    pipeline.setGlossary(terms)
-  }
-})
-
-// #54: crash recovery — check if previous session ended uncleanly
-ipcMain.handle('get-crashed-session', () => {
-  const session = store.get('activeSession')
-  if (session) {
-    // Clear it so we don't keep detecting the same crash
-    store.set('activeSession', null)
-    // Validate config has required fields
-    const config = session.config
-    if (config && typeof config === 'object' && config.mode) {
-      return session
-    }
-    console.warn('[crash-recovery] Invalid session config, discarding:', config)
-  }
-  return null
-})
-
-// #124: Generate meeting summary from transcript
-ipcMain.handle('generate-summary', async (_event, transcriptPath: string) => {
-  try {
-    // #150: Validate path is within expected logs directory
-    const { resolve } = await import('path')
-    const { readFileSync } = await import('fs')
-    const logsDir = join(app.getPath('documents'), 'live-translate')
-    const resolved = resolve(transcriptPath)
-    if (!resolved.startsWith(logsDir)) {
-      return { error: 'Invalid transcript path' }
-    }
-    const transcript = readFileSync(resolved, 'utf-8')
-
-    if (!transcript.trim()) {
-      return { error: 'Transcript is empty' }
-    }
-
-    // Use SLM translator for summarization
-    const slm = new SLMTranslator({
-      onProgress: (msg) => mainWindow?.webContents.send('status-update', msg),
-      kvCacheQuant: store.get('slmKvCacheQuant'),
-      modelSize: store.get('slmModelSize')
-    })
-
-    try {
-      await slm.initialize()
-      const summary = await slm.summarize(transcript)
-      return { summary }
-    } finally {
-      await slm.dispose()
-    }
-  } catch (err) {
-    return { error: sanitizeErrorMessage(err instanceof Error ? err.message : String(err)) }
-  }
-})
-
-// #121: Session management
-ipcMain.handle('list-sessions', () => SessionManager.listSessions())
-ipcMain.handle('load-session', (_event, id: string) => SessionManager.loadSession(id))
-ipcMain.handle('search-sessions', (_event, query: string) => SessionManager.searchSessions(query))
-ipcMain.handle('delete-session', (_event, id: string) => {
-  SessionManager.deleteSession(id)
-  return { success: true }
-})
-ipcMain.handle('export-session', (_event, id: string, format: 'text' | 'srt' | 'markdown') => {
-  const data = SessionManager.loadSession(id)
-  if (!data) return { error: 'Session not found' }
-  switch (format) {
-    case 'srt': return { content: SessionManager.exportAsSRT(data), ext: '.srt' }
-    case 'markdown': return { content: SessionManager.exportAsMarkdown(data), ext: '.md' }
-    default: return { content: SessionManager.exportAsText(data), ext: '.txt' }
-  }
-})
-
-// #133: GGUF model status
-ipcMain.handle('get-gguf-variants', (_event, modelSize?: SLMModelSize) => {
-  const variants = getGGUFVariants(modelSize ?? store.get('slmModelSize'))
-  return Object.entries(variants).map(([key, v]) => ({
-    key,
-    label: v.label,
-    filename: v.filename,
-    sizeMB: v.sizeMB,
-    downloaded: isGGUFDownloaded(v.filename)
-  }))
-})
-
-// #238: Check if draft model (4B) is available for speculative decoding
-ipcMain.handle('is-draft-model-available', () => {
-  const draftVariants = getGGUFVariants('4b')
-  const draftVariantConfig = draftVariants['Q4_K_M']
-  return draftVariantConfig ? isGGUFDownloaded(draftVariantConfig.filename) : false
-})
-
-// #234: Hunyuan-MT GGUF model status
-ipcMain.handle('get-hunyuan-mt-variants', () => {
-  const variants = getHunyuanMTVariants()
-  return Object.entries(variants).map(([key, v]) => ({
-    key,
-    label: v.label,
-    filename: v.filename,
-    sizeMB: v.sizeMB,
-    downloaded: isGGUFDownloaded(v.filename)
-  }))
-})
-
-// #259: HY-MT1.5-1.8B GGUF model status
-ipcMain.handle('get-hunyuan-mt-15-variants', () => {
-  const variants = getHunyuanMT15Variants()
-  return Object.entries(variants).map(([key, v]) => ({
-    key,
-    label: v.label,
-    filename: v.filename,
-    sizeMB: v.sizeMB,
-    downloaded: isGGUFDownloaded(v.filename)
-  }))
-})
-
-// #261: Whisper model variant status
-ipcMain.handle('get-whisper-variants', () => {
-  const variants = getWhisperVariants()
-  return Object.entries(variants).map(([key, v]) => ({
-    key,
-    label: v.label,
-    description: v.description,
-    filename: v.filename,
-    sizeMB: v.sizeMB,
-    downloaded: isWhisperModelDownloaded(key as WhisperVariant)
-  }))
-})
-
-// #260: Moonshine model variant info
-ipcMain.handle('get-moonshine-variants', () => {
-  const variants = getMoonshineVariants()
-  return Object.entries(variants).map(([key, v]) => ({
-    key,
-    label: v.label,
-    description: v.description,
-    modelId: v.modelId,
-    sizeMB: v.sizeMB,
-    params: v.params
-  }))
-})
-
-// #127: List installed engine plugins
-ipcMain.handle('list-plugins', () => listPlugins())
-
-// #132: GPU detection for engine auto-selection
-ipcMain.handle('detect-gpu', async () => {
-  return detectGpu()
-})
-
-// #243: Platform info for renderer to hide platform-specific options
-ipcMain.handle('get-platform', () => process.platform)
-
-// #116: Get session usage logs for feedback collection
-ipcMain.handle('get-session-logs', () => {
-  return store.get('sessionLogs') || []
-})
-
-// --- WebSocket Audio Server for Chrome Extension (#264) ---
-
-const DEFAULT_WS_PORT = 9876
-
-ipcMain.handle('ws-audio-start', async (_event, port?: number) => {
-  try {
-    if (wsAudioServer?.running) {
-      return { error: 'WebSocket audio server is already running' }
-    }
-
-    wsAudioServer = new WsAudioServer(port || DEFAULT_WS_PORT)
-
-    // Forward received audio to the pipeline
-    wsAudioServer.on('audio', async (chunk: Float32Array) => {
-      if (!pipeline?.running) return
-
-      try {
-        await pipeline.process(chunk, 16000)
-      } catch (err) {
-        console.error('[ws-audio] Pipeline processing error:', err)
-      }
-    })
-
-    wsAudioServer.on('connected', () => {
-      mainWindow?.webContents.send('status-update', 'Chrome extension connected')
-      mainWindow?.webContents.send('ws-audio-status', { connected: true, running: true, port: wsAudioServer?.port })
-    })
-
-    wsAudioServer.on('disconnected', () => {
-      mainWindow?.webContents.send('status-update', 'Chrome extension disconnected')
-      mainWindow?.webContents.send('ws-audio-status', { connected: false, running: wsAudioServer?.running ?? false, port: wsAudioServer?.port })
-    })
-
-    wsAudioServer.on('error', (err: Error) => {
-      mainWindow?.webContents.send('status-update', `WebSocket error: ${sanitizeErrorMessage(err.message)}`)
-    })
-
-    await wsAudioServer.start()
-    mainWindow?.webContents.send('ws-audio-status', { connected: false, running: true, port: wsAudioServer.port })
-    return { success: true, port: wsAudioServer.port }
-  } catch (err) {
-    return { error: sanitizeErrorMessage(err instanceof Error ? err.message : String(err)) }
-  }
-})
-
-ipcMain.handle('ws-audio-stop', async () => {
-  try {
-    if (wsAudioServer) {
-      await wsAudioServer.stop()
-      wsAudioServer = null
-    }
-    mainWindow?.webContents.send('ws-audio-status', { connected: false, running: false, port: null })
-    return { success: true }
-  } catch (err) {
-    return { error: sanitizeErrorMessage(err instanceof Error ? err.message : String(err)) }
-  }
-})
-
-ipcMain.handle('ws-audio-get-status', () => {
-  return {
-    running: wsAudioServer?.running ?? false,
-    connected: wsAudioServer?.hasClient ?? false,
-    port: wsAudioServer?.port ?? DEFAULT_WS_PORT
-  }
-})
+// --- Register all IPC handlers ---
+registerAudioHandlers(ctx)
+registerIpcHandlers(ctx)
 
 // --- App Lifecycle ---
 
 app.whenReady().then(() => {
   initPipeline()
-  createMainWindow()
-  createSubtitleWindow()
-
-  // #46: reposition subtitle window when external display is disconnected
-  screen.on('display-removed', () => {
-    if (!subtitleWindow) return
-    const primaryDisplay = screen.getPrimaryDisplay()
-    const h = getSubtitleHeight(primaryDisplay)
-    subtitleWindow.setBounds({
-      x: primaryDisplay.bounds.x,
-      y: primaryDisplay.bounds.y + primaryDisplay.bounds.height - h,
-      width: primaryDisplay.bounds.width,
-      height: h
-    })
-    // #64: notify renderer to refresh display list
-    mainWindow?.webContents.send('displays-changed')
-  })
-
-  screen.on('display-added', () => {
-    mainWindow?.webContents.send('displays-changed')
-  })
+  createMainWindow(ctx)
+  createSubtitleWindow(ctx)
+  registerDisplayHandlers(ctx)
 })
 
 let isQuitting = false
@@ -837,13 +161,13 @@ app.on('before-quit', (event) => {
   // Async cleanup before quit — timeout after 5s to prevent hanging (#222)
   ;(async () => {
     try {
-      logger?.endSession()
-      logger = null
+      ctx.logger?.endSession()
+      ctx.logger = null
       store.set('activeSession', null)
       await Promise.race([
         Promise.all([
-          pipeline?.dispose() ?? Promise.resolve(),
-          wsAudioServer?.stop() ?? Promise.resolve()
+          ctx.pipeline?.dispose() ?? Promise.resolve(),
+          ctx.wsAudioServer?.stop() ?? Promise.resolve()
         ]),
         new Promise((_resolve, reject) =>
           setTimeout(() => reject(new Error('Cleanup timed out')), 5000)
@@ -860,4 +184,3 @@ app.on('before-quit', (event) => {
 app.on('window-all-closed', () => {
   app.quit()
 })
-

--- a/src/main/ipc-handlers.ts
+++ b/src/main/ipc-handlers.ts
@@ -1,0 +1,471 @@
+import { app, screen, ipcMain } from 'electron'
+import { join } from 'path'
+import { GoogleTranslator } from '../engines/translator/GoogleTranslator'
+import { DeepLTranslator } from '../engines/translator/DeepLTranslator'
+import { GeminiTranslator } from '../engines/translator/GeminiTranslator'
+import { MicrosoftTranslator } from '../engines/translator/MicrosoftTranslator'
+import { ApiRotationController } from '../engines/translator/ApiRotationController'
+import type { ProviderConfig, QuotaStore } from '../engines/translator/ApiRotationController'
+import { SLMTranslator } from '../engines/translator/SLMTranslator'
+import { detectGpu } from '../engines/gpu-detector'
+import { isGGUFDownloaded, getGGUFVariants, getHunyuanMTVariants, getHunyuanMT15Variants, getWhisperVariants, getMoonshineVariants, isModelDownloaded as isWhisperModelDownloaded } from '../engines/model-downloader'
+import type { SLMModelSize, WhisperVariant } from '../engines/model-downloader'
+import { listPlugins } from '../engines/plugin-loader'
+import { TranscriptLogger } from '../logger/TranscriptLogger'
+import * as SessionManager from '../logger/SessionManager'
+import { store } from './store'
+import type { AppSettings, SubtitleSettings } from './store'
+import { sanitizeErrorMessage } from './error-utils'
+import { getSubtitleHeight } from './window-manager'
+import { WsAudioServer } from './ws-audio-server'
+import type { AppContext } from './app-context'
+import type { EngineConfig } from '../engines/types'
+
+/** Monthly character limits for API rotation providers */
+const QUOTA_LIMITS = {
+  microsoft: 2_000_000,
+  google: 480_000,
+  deepl: 500_000,
+  gemini: 1_000_000
+} as const
+
+/** Pipeline start config with API keys */
+interface PipelineStartConfig extends EngineConfig {
+  apiKey?: string
+  deeplApiKey?: string
+  geminiApiKey?: string
+  microsoftApiKey?: string
+  microsoftRegion?: string
+}
+
+const DEFAULT_WS_PORT = 9876
+
+/** Register all IPC handlers (pipeline, settings, session, display, ws-audio) */
+export function registerIpcHandlers(ctx: AppContext): void {
+  // --- Pipeline control ---
+
+  ipcMain.handle('pipeline-start', async (_event, config: PipelineStartConfig) => {
+    if (!ctx.pipeline) return { error: 'Pipeline not initialized' }
+    if (ctx.pipeline.active) return { error: 'Pipeline already running' } // #30
+
+    try {
+      // Register online translators with provided API keys
+      if (config.apiKey) {
+        ctx.pipeline.registerTranslator('google-translate', () => new GoogleTranslator(config.apiKey!))
+      }
+      if (config.deeplApiKey) {
+        ctx.pipeline.registerTranslator('deepl-translate', () => new DeepLTranslator(config.deeplApiKey!))
+      }
+      if (config.geminiApiKey) {
+        ctx.pipeline.registerTranslator('gemini-translate', () => new GeminiTranslator(config.geminiApiKey!))
+      }
+      if (config.microsoftApiKey && config.microsoftRegion) {
+        ctx.pipeline.registerTranslator('microsoft-translate', () =>
+          new MicrosoftTranslator(config.microsoftApiKey!, config.microsoftRegion!)
+        )
+      }
+
+      // Build rotation controller when rotation mode is selected
+      let rotationProviders: ProviderConfig[] | null = null
+      if (config.translatorEngineId === 'rotation-controller') {
+        rotationProviders = []
+        const statusFn = (msg: string): void => {
+          ctx.mainWindow?.webContents.send('status-update', msg)
+        }
+
+        // Order: Azure (2M) → Google (480K safe cap) → DeepL (500K)
+        if (config.microsoftApiKey && config.microsoftRegion) {
+          rotationProviders.push({
+            engine: new MicrosoftTranslator(config.microsoftApiKey, config.microsoftRegion),
+            monthlyCharLimit: QUOTA_LIMITS.microsoft
+          })
+        }
+        if (config.apiKey) {
+          rotationProviders.push({
+            engine: new GoogleTranslator(config.apiKey),
+            monthlyCharLimit: QUOTA_LIMITS.google
+          })
+        }
+        if (config.deeplApiKey) {
+          rotationProviders.push({
+            engine: new DeepLTranslator(config.deeplApiKey),
+            monthlyCharLimit: QUOTA_LIMITS.deepl
+          })
+        }
+        if (config.geminiApiKey) {
+          rotationProviders.push({
+            engine: new GeminiTranslator(config.geminiApiKey),
+            monthlyCharLimit: QUOTA_LIMITS.gemini
+          })
+        }
+
+        if (rotationProviders.length === 0) {
+          return { error: 'Rotation mode requires at least one API key' }
+        }
+
+        const persistence = {
+          load: (): QuotaStore => store.get('quotaTracking') as QuotaStore,
+          save: (quota: QuotaStore): void => { store.set('quotaTracking', quota) }
+        }
+
+        ctx.pipeline.registerTranslator('rotation-controller', () =>
+          new ApiRotationController(rotationProviders!, persistence, statusFn)
+        )
+      }
+
+      try {
+        await ctx.pipeline.switchEngine(config)
+      } catch (err) {
+        // Dispose leaked rotation provider instances on switchEngine failure
+        if (rotationProviders) {
+          for (const p of rotationProviders) {
+            p.engine.dispose().catch(() => {})
+          }
+        }
+        throw err
+      }
+
+      // Load glossary terms from store
+      const glossaryTerms = store.get('glossaryTerms') || []
+      ctx.pipeline!.setGlossary(glossaryTerms)
+
+      // Configure language settings (#263)
+      ctx.pipeline!.setLanguageConfig(store.get('sourceLanguage'), store.get('targetLanguage'))
+
+      // Configure SimulMT (#239)
+      ctx.pipeline!.setSimulMt(store.get('simulMtEnabled'), store.get('simulMtWaitK'))
+
+      // Start logger
+      ctx.logger = new TranscriptLogger((msg) => ctx.mainWindow?.webContents.send('status-update', msg))
+      const sessionLabel = config.mode === 'e2e'
+        ? 'Offline (Whisper Translate)'
+        : `Cascade (Whisper + ${config.translatorEngineId})`
+      ctx.logger.startSession(sessionLabel)
+
+      // #62: persist session BEFORE start to avoid crash window
+      store.set('activeSession', { config, startedAt: Date.now() })
+
+      ctx.pipeline.start()
+
+      return { success: true }
+    } catch (err) {
+      return { error: sanitizeErrorMessage(String(err)) }
+    }
+  })
+
+  ipcMain.handle('pipeline-stop', async () => {
+    // #116: log session usage
+    const activeSession = store.get('activeSession')
+    if (activeSession) {
+      const now = Date.now()
+      const logs = store.get('sessionLogs') || []
+      logs.push({
+        startedAt: activeSession.startedAt,
+        endedAt: now,
+        engineMode: String(activeSession.config?.translatorEngineId || activeSession.config?.e2eEngineId || 'unknown'),
+        durationMs: now - activeSession.startedAt,
+        errorCount: 0
+      })
+      // Keep last 100 session logs
+      store.set('sessionLogs', logs.slice(-100))
+    }
+
+    await ctx.pipeline?.stop()
+    ctx.logger?.endSession()
+    const logPath = ctx.logger?.getLogPath()
+    ctx.logger = null
+    // #54: clear session on clean stop
+    store.set('activeSession', null)
+    return { logPath }
+  })
+
+  ipcMain.handle('get-session-start-time', () => {
+    return ctx.pipeline?.sessionStartTime ?? null
+  })
+
+  // --- Display management ---
+
+  ipcMain.handle('get-displays', () => {
+    const primary = screen.getPrimaryDisplay()
+    return screen.getAllDisplays().map((d, i) => ({
+      id: d.id,
+      label: d.id === primary.id ? `Display ${i + 1} (Main)` : `Display ${i + 1} (External)`,
+      bounds: d.bounds
+    }))
+  })
+
+  ipcMain.on('move-subtitle-to-display', (_event, displayId: number) => {
+    const display = screen.getAllDisplays().find((d) => d.id === displayId)
+    if (!display) {
+      console.warn(`[display] Display ${displayId} not found, ignoring move request`)
+      return
+    }
+    if (ctx.subtitleWindow) {
+      const h = getSubtitleHeight(display)
+      ctx.subtitleWindow.setBounds({
+        x: display.bounds.x,
+        y: display.bounds.y + display.bounds.height - h,
+        width: display.bounds.width,
+        height: h
+      })
+    }
+  })
+
+  // Forward translation result to subtitle window (from renderer)
+  ipcMain.on('translation-result', (_event, data) => {
+    ctx.subtitleWindow?.webContents.send('translation-result', data)
+  })
+
+  // --- Settings persistence via electron-store (#49) ---
+
+  ipcMain.handle('get-settings', () => {
+    return {
+      translationEngine: store.get('translationEngine'),
+      googleApiKey: store.get('googleApiKey'),
+      deeplApiKey: store.get('deeplApiKey'),
+      geminiApiKey: store.get('geminiApiKey'),
+      microsoftApiKey: store.get('microsoftApiKey'),
+      microsoftRegion: store.get('microsoftRegion'),
+      sttEngine: store.get('sttEngine'),
+      selectedMicrophone: store.get('selectedMicrophone'),
+      selectedDisplay: store.get('selectedDisplay'),
+      subtitleSettings: store.get('subtitleSettings'),
+      slmKvCacheQuant: store.get('slmKvCacheQuant'),
+      slmModelSize: store.get('slmModelSize'),
+      slmSpeculativeDecoding: store.get('slmSpeculativeDecoding'),
+      glossaryTerms: store.get('glossaryTerms') || [],
+      simulMtEnabled: store.get('simulMtEnabled'),
+      simulMtWaitK: store.get('simulMtWaitK'),
+      whisperVariant: store.get('whisperVariant'),
+      moonshineVariant: store.get('moonshineVariant'),
+      sourceLanguage: store.get('sourceLanguage'),
+      targetLanguage: store.get('targetLanguage')
+    }
+  })
+
+  ipcMain.handle('save-subtitle-settings', (_event, settings: Record<string, unknown>) => {
+    store.set('subtitleSettings', settings as unknown as SubtitleSettings)
+    ctx.subtitleWindow?.webContents.send('subtitle-settings-changed', settings)
+  })
+
+  ipcMain.handle('save-settings', (_event, settings: Record<string, unknown>) => {
+    for (const [key, value] of Object.entries(settings)) {
+      store.set(key as keyof AppSettings, value as never)
+    }
+  })
+
+  // Glossary terms persistence (#240)
+  ipcMain.handle('save-glossary', (_event, terms: Array<{ source: string; target: string }>) => {
+    store.set('glossaryTerms', terms)
+    // Update running pipeline glossary in real-time
+    if (ctx.pipeline) {
+      ctx.pipeline.setGlossary(terms)
+    }
+  })
+
+  // #54: crash recovery — check if previous session ended uncleanly
+  ipcMain.handle('get-crashed-session', () => {
+    const session = store.get('activeSession')
+    if (session) {
+      // Clear it so we don't keep detecting the same crash
+      store.set('activeSession', null)
+      // Validate config has required fields
+      const config = session.config
+      if (config && typeof config === 'object' && config.mode) {
+        return session
+      }
+      console.warn('[crash-recovery] Invalid session config, discarding:', config)
+    }
+    return null
+  })
+
+  // #124: Generate meeting summary from transcript
+  ipcMain.handle('generate-summary', async (_event, transcriptPath: string) => {
+    try {
+      // #150: Validate path is within expected logs directory
+      const { resolve } = await import('path')
+      const { readFileSync } = await import('fs')
+      const logsDir = join(app.getPath('documents'), 'live-translate')
+      const resolved = resolve(transcriptPath)
+      if (!resolved.startsWith(logsDir)) {
+        return { error: 'Invalid transcript path' }
+      }
+      const transcript = readFileSync(resolved, 'utf-8')
+
+      if (!transcript.trim()) {
+        return { error: 'Transcript is empty' }
+      }
+
+      // Use SLM translator for summarization
+      const slm = new SLMTranslator({
+        onProgress: (msg) => ctx.mainWindow?.webContents.send('status-update', msg),
+        kvCacheQuant: store.get('slmKvCacheQuant'),
+        modelSize: store.get('slmModelSize')
+      })
+
+      try {
+        await slm.initialize()
+        const summary = await slm.summarize(transcript)
+        return { summary }
+      } finally {
+        await slm.dispose()
+      }
+    } catch (err) {
+      return { error: sanitizeErrorMessage(err instanceof Error ? err.message : String(err)) }
+    }
+  })
+
+  // #121: Session management
+  ipcMain.handle('list-sessions', () => SessionManager.listSessions())
+  ipcMain.handle('load-session', (_event, id: string) => SessionManager.loadSession(id))
+  ipcMain.handle('search-sessions', (_event, query: string) => SessionManager.searchSessions(query))
+  ipcMain.handle('delete-session', (_event, id: string) => {
+    SessionManager.deleteSession(id)
+    return { success: true }
+  })
+  ipcMain.handle('export-session', (_event, id: string, format: 'text' | 'srt' | 'markdown') => {
+    const data = SessionManager.loadSession(id)
+    if (!data) return { error: 'Session not found' }
+    switch (format) {
+      case 'srt': return { content: SessionManager.exportAsSRT(data), ext: '.srt' }
+      case 'markdown': return { content: SessionManager.exportAsMarkdown(data), ext: '.md' }
+      default: return { content: SessionManager.exportAsText(data), ext: '.txt' }
+    }
+  })
+
+  // --- Model status queries ---
+
+  ipcMain.handle('get-gguf-variants', (_event, modelSize?: SLMModelSize) => {
+    const variants = getGGUFVariants(modelSize ?? store.get('slmModelSize'))
+    return Object.entries(variants).map(([key, v]) => ({
+      key,
+      label: v.label,
+      filename: v.filename,
+      sizeMB: v.sizeMB,
+      downloaded: isGGUFDownloaded(v.filename)
+    }))
+  })
+
+  ipcMain.handle('is-draft-model-available', () => {
+    const draftVariants = getGGUFVariants('4b')
+    const draftVariantConfig = draftVariants['Q4_K_M']
+    return draftVariantConfig ? isGGUFDownloaded(draftVariantConfig.filename) : false
+  })
+
+  ipcMain.handle('get-hunyuan-mt-variants', () => {
+    const variants = getHunyuanMTVariants()
+    return Object.entries(variants).map(([key, v]) => ({
+      key,
+      label: v.label,
+      filename: v.filename,
+      sizeMB: v.sizeMB,
+      downloaded: isGGUFDownloaded(v.filename)
+    }))
+  })
+
+  ipcMain.handle('get-hunyuan-mt-15-variants', () => {
+    const variants = getHunyuanMT15Variants()
+    return Object.entries(variants).map(([key, v]) => ({
+      key,
+      label: v.label,
+      filename: v.filename,
+      sizeMB: v.sizeMB,
+      downloaded: isGGUFDownloaded(v.filename)
+    }))
+  })
+
+  ipcMain.handle('get-whisper-variants', () => {
+    const variants = getWhisperVariants()
+    return Object.entries(variants).map(([key, v]) => ({
+      key,
+      label: v.label,
+      description: v.description,
+      filename: v.filename,
+      sizeMB: v.sizeMB,
+      downloaded: isWhisperModelDownloaded(key as WhisperVariant)
+    }))
+  })
+
+  ipcMain.handle('get-moonshine-variants', () => {
+    const variants = getMoonshineVariants()
+    return Object.entries(variants).map(([key, v]) => ({
+      key,
+      label: v.label,
+      description: v.description,
+      modelId: v.modelId,
+      sizeMB: v.sizeMB,
+      params: v.params
+    }))
+  })
+
+  // --- Misc ---
+
+  ipcMain.handle('list-plugins', () => listPlugins())
+  ipcMain.handle('detect-gpu', async () => detectGpu())
+  ipcMain.handle('get-platform', () => process.platform)
+  ipcMain.handle('get-session-logs', () => store.get('sessionLogs') || [])
+
+  // --- WebSocket Audio Server for Chrome Extension (#264) ---
+
+  ipcMain.handle('ws-audio-start', async (_event, port?: number) => {
+    try {
+      if (ctx.wsAudioServer?.running) {
+        return { error: 'WebSocket audio server is already running' }
+      }
+
+      ctx.wsAudioServer = new WsAudioServer(port || DEFAULT_WS_PORT)
+
+      // Forward received audio to the pipeline
+      ctx.wsAudioServer.on('audio', async (chunk: Float32Array) => {
+        if (!ctx.pipeline?.running) return
+
+        try {
+          await ctx.pipeline.process(chunk, 16000)
+        } catch (err) {
+          console.error('[ws-audio] Pipeline processing error:', err)
+        }
+      })
+
+      ctx.wsAudioServer.on('connected', () => {
+        ctx.mainWindow?.webContents.send('status-update', 'Chrome extension connected')
+        ctx.mainWindow?.webContents.send('ws-audio-status', { connected: true, running: true, port: ctx.wsAudioServer?.port })
+      })
+
+      ctx.wsAudioServer.on('disconnected', () => {
+        ctx.mainWindow?.webContents.send('status-update', 'Chrome extension disconnected')
+        ctx.mainWindow?.webContents.send('ws-audio-status', { connected: false, running: ctx.wsAudioServer?.running ?? false, port: ctx.wsAudioServer?.port })
+      })
+
+      ctx.wsAudioServer.on('error', (err: Error) => {
+        ctx.mainWindow?.webContents.send('status-update', `WebSocket error: ${sanitizeErrorMessage(err.message)}`)
+      })
+
+      await ctx.wsAudioServer.start()
+      ctx.mainWindow?.webContents.send('ws-audio-status', { connected: false, running: true, port: ctx.wsAudioServer.port })
+      return { success: true, port: ctx.wsAudioServer.port }
+    } catch (err) {
+      return { error: sanitizeErrorMessage(err instanceof Error ? err.message : String(err)) }
+    }
+  })
+
+  ipcMain.handle('ws-audio-stop', async () => {
+    try {
+      if (ctx.wsAudioServer) {
+        await ctx.wsAudioServer.stop()
+        ctx.wsAudioServer = null
+      }
+      ctx.mainWindow?.webContents.send('ws-audio-status', { connected: false, running: false, port: null })
+      return { success: true }
+    } catch (err) {
+      return { error: sanitizeErrorMessage(err instanceof Error ? err.message : String(err)) }
+    }
+  })
+
+  ipcMain.handle('ws-audio-get-status', () => {
+    return {
+      running: ctx.wsAudioServer?.running ?? false,
+      connected: ctx.wsAudioServer?.hasClient ?? false,
+      port: ctx.wsAudioServer?.port ?? DEFAULT_WS_PORT
+    }
+  })
+}

--- a/src/main/window-manager.ts
+++ b/src/main/window-manager.ts
@@ -1,0 +1,101 @@
+import { BrowserWindow, screen } from 'electron'
+import { join } from 'path'
+import { is } from '@electron-toolkit/utils'
+import { store } from './store'
+import type { AppContext } from './app-context'
+
+/** Calculate subtitle window height based on display scale factor */
+export function getSubtitleHeight(display: Electron.Display): number {
+  // Base height for 3 subtitle lines at default font size (30px)
+  const baseHeight = 200
+  const scaleFactor = display.scaleFactor ?? 1
+  // Scale for HiDPI displays but cap at 2x to avoid excessively tall windows
+  return Math.round(baseHeight * Math.min(scaleFactor, 2))
+}
+
+export function createMainWindow(ctx: AppContext): void {
+  ctx.mainWindow = new BrowserWindow({
+    width: 520,
+    height: 720,
+    minWidth: 480,
+    minHeight: 600,
+    resizable: true,
+    webPreferences: {
+      preload: join(__dirname, '../preload/index.js'),
+      contextIsolation: true,
+      nodeIntegration: false
+    }
+  })
+
+  if (is.dev && process.env['ELECTRON_RENDERER_URL']) {
+    ctx.mainWindow.loadURL(process.env['ELECTRON_RENDERER_URL'])
+  } else {
+    ctx.mainWindow.loadFile(join(__dirname, '../renderer/index.html'))
+  }
+
+  ctx.mainWindow.on('closed', () => {
+    ctx.mainWindow = null
+    ctx.subtitleWindow?.close()
+  })
+}
+
+export function createSubtitleWindow(ctx: AppContext): void {
+  const displays = screen.getAllDisplays()
+  const savedDisplayId = store.get('selectedDisplay')
+  const savedDisplay = savedDisplayId ? displays.find((d) => d.id === savedDisplayId) : null
+  const primaryId = screen.getPrimaryDisplay().id
+  const externalDisplay = displays.find((d) => d.id !== primaryId)
+  const targetDisplay = savedDisplay || externalDisplay || displays[0]
+
+  const subtitleHeight = getSubtitleHeight(targetDisplay)
+  ctx.subtitleWindow = new BrowserWindow({
+    x: targetDisplay.bounds.x,
+    y: targetDisplay.bounds.y + targetDisplay.bounds.height - subtitleHeight,
+    width: targetDisplay.bounds.width,
+    height: subtitleHeight,
+    transparent: true,
+    frame: false,
+    alwaysOnTop: true,
+    skipTaskbar: true,
+    hasShadow: false,
+    webPreferences: {
+      preload: join(__dirname, '../preload/index.js'),
+      contextIsolation: true,
+      nodeIntegration: false
+    }
+  })
+
+  ctx.subtitleWindow.setIgnoreMouseEvents(true, { forward: true })
+
+  if (is.dev && process.env['ELECTRON_RENDERER_URL']) {
+    ctx.subtitleWindow.loadURL(`${process.env['ELECTRON_RENDERER_URL']}#/subtitle`)
+  } else {
+    ctx.subtitleWindow.loadFile(join(__dirname, '../renderer/index.html'), { hash: '/subtitle' })
+  }
+
+  ctx.subtitleWindow.on('closed', () => {
+    ctx.subtitleWindow = null
+  })
+}
+
+/** Register display-change event handlers */
+export function registerDisplayHandlers(ctx: AppContext): void {
+  // #46: reposition subtitle window when external display is disconnected
+  screen.on('display-removed', () => {
+    if (!ctx.subtitleWindow) return
+    const primaryDisplay = screen.getPrimaryDisplay()
+    const h = getSubtitleHeight(primaryDisplay)
+    ctx.subtitleWindow.setBounds({
+      x: primaryDisplay.bounds.x,
+      y: primaryDisplay.bounds.y + primaryDisplay.bounds.height - h,
+      width: primaryDisplay.bounds.width,
+      height: h
+    })
+    // #64: notify renderer to refresh display list
+    ctx.mainWindow?.webContents.send('displays-changed')
+  })
+
+  screen.on('display-added', () => {
+    ctx.mainWindow?.webContents.send('displays-changed')
+  })
+}


### PR DESCRIPTION
## Summary
- Extract `src/main/index.ts` (863 lines) into 5 focused modules while keeping index.ts as the orchestrator
- `app-context.ts` — Shared mutable state interface (`AppContext`) passed to all modules
- `window-manager.ts` — Window creation/lifecycle and display event handlers
- `audio-handlers.ts` — Audio processing IPC (process-audio, streaming, finalize)
- `ipc-handlers.ts` — All other IPC handlers (pipeline control, settings, sessions, model queries, ws-audio)
- `error-utils.ts` — Error sanitization and hint mapping utilities
- `index.ts` reduced to ~140 lines: pipeline init, handler registration, app lifecycle
- No behavioral changes — all IPC channel names and runtime behavior preserved

## Test plan
- [x] `npm run typecheck` — no new errors (pre-existing ws-audio-server.ts errors unchanged)
- [x] `npm test` — all 45 tests pass
- [ ] Manual smoke test: start pipeline, verify subtitles, stop pipeline

Closes #282