### PR TITLE
Deduplicate audio chunk minimum size validation

### DIFF
--- a/src/main/audio-handlers.ts
+++ b/src/main/audio-handlers.ts
@@ -2,6 +2,9 @@ import { ipcMain } from 'electron'
 import { sanitizeErrorMessage } from './error-utils'
 import type { AppContext } from './app-context'
 
+/** Minimum number of samples for a valid audio chunk (0.5s at 16kHz) */
+const MIN_AUDIO_CHUNK_SAMPLES = 8000
+
 /** Minimum amplitude to consider a chunk as non-silent */
 const SILENCE_THRESHOLD = 0.001
 
@@ -35,14 +38,24 @@ function toFloat32Array(audioData: unknown): Float32Array | null {
   return chunk
 }
 
+/**
+ * Validate and convert IPC audio data to Float32Array.
+ * Returns null if data is invalid, too short, or silent.
+ */
+function toValidAudioChunk(audioData: unknown): Float32Array | null {
+  const chunk = toFloat32Array(audioData)
+  if (!chunk || chunk.length < MIN_AUDIO_CHUNK_SAMPLES) return null
+  return chunk
+}
+
 /** Register audio processing IPC handlers */
 export function registerAudioHandlers(ctx: AppContext): void {
   // Process audio chunk from renderer
   ipcMain.handle('process-audio', async (_event, audioData: unknown) => {
     if (!ctx.pipeline?.running) return null
 
-    const chunk = toFloat32Array(audioData)
-    if (!chunk || chunk.length < 8000) return null
+    const chunk = toValidAudioChunk(audioData)
+    if (!chunk) return null
 
     try {
       return await ctx.pipeline.process(chunk, 16000)
@@ -59,8 +72,8 @@ export function registerAudioHandlers(ctx: AppContext): void {
   ipcMain.handle('process-audio-streaming', async (_event, audioData: unknown) => {
     if (!ctx.pipeline?.running) return null
 
-    const chunk = toFloat32Array(audioData)
-    if (!chunk || chunk.length < 8000) return null
+    const chunk = toValidAudioChunk(audioData)
+    if (!chunk) return null
 
     try {
       return await ctx.pipeline.processStreaming(chunk, 16000)
@@ -74,8 +87,8 @@ export function registerAudioHandlers(ctx: AppContext): void {
   ipcMain.handle('finalize-streaming', async (_event, audioData: unknown) => {
     if (!ctx.pipeline?.running) return null
 
-    const chunk = toFloat32Array(audioData)
-    if (!chunk || chunk.length < 8000) return null
+    const chunk = toValidAudioChunk(audioData)
+    if (!chunk) return null
 
     try {
       return await ctx.pipeline.finalizeStreaming(chunk, 16000)


### PR DESCRIPTION
## Summary
- Extract `MIN_AUDIO_CHUNK_SAMPLES` constant (8000 = 0.5s at 16kHz) to replace 3 hardcoded magic numbers
- Add `toValidAudioChunk()` helper that combines `toFloat32Array()` + minimum size check
- All 3 IPC handlers (`process-audio`, `process-audio-streaming`, `finalize-streaming`) now use the shared helper

Closes #289