### PR TITLE
Extract hardcoded WebSocket port 9876 to shared config

### DIFF
--- a/src/main/ipc-handlers.ts
+++ b/src/main/ipc-handlers.ts
@@ -239,7 +239,8 @@ export function registerIpcHandlers(ctx: AppContext): void {
       whisperVariant: store.get('whisperVariant'),
       moonshineVariant: store.get('moonshineVariant'),
       sourceLanguage: store.get('sourceLanguage'),
-      targetLanguage: store.get('targetLanguage')
+      targetLanguage: store.get('targetLanguage'),
+      wsAudioPort: store.get('wsAudioPort')
     }
   })
 
@@ -413,7 +414,7 @@ export function registerIpcHandlers(ctx: AppContext): void {
         return { error: 'WebSocket audio server is already running' }
       }
 
-      ctx.wsAudioServer = new WsAudioServer(port || DEFAULT_WS_PORT)
+      ctx.wsAudioServer = new WsAudioServer(port || store.get('wsAudioPort') || DEFAULT_WS_PORT)
 
       // Forward received audio to the pipeline
       ctx.wsAudioServer.on('audio', async (chunk: Float32Array) => {
@@ -465,7 +466,7 @@ export function registerIpcHandlers(ctx: AppContext): void {
     return {
       running: ctx.wsAudioServer?.running ?? false,
       connected: ctx.wsAudioServer?.hasClient ?? false,
-      port: ctx.wsAudioServer?.port ?? DEFAULT_WS_PORT
+      port: ctx.wsAudioServer?.port ?? store.get('wsAudioPort') ?? DEFAULT_WS_PORT
     }
   })
 }

--- a/src/main/store.ts
+++ b/src/main/store.ts
@@ -62,6 +62,8 @@ export interface AppSettings {
   sourceLanguage: SourceLanguage
   /** Target language for translation output */
   targetLanguage: Language
+  /** WebSocket port for Chrome extension audio server (default 9876) */
+  wsAudioPort: number
 }
 
 export const store = new Store<AppSettings>({
@@ -95,6 +97,7 @@ export const store = new Store<AppSettings>({
     whisperVariant: 'kotoba-v2.0',
     moonshineVariant: 'base',
     sourceLanguage: 'auto',
-    targetLanguage: 'en'
+    targetLanguage: 'en',
+    wsAudioPort: 9876
   }
 })


### PR DESCRIPTION
## Summary
- Add `wsAudioPort` to `AppSettings` in electron-store with default `9876`
- Update `ws-audio-start` and `ws-audio-get-status` IPC handlers to read port from store
- Expose `wsAudioPort` in `get-settings` IPC so renderer can display/configure it
- Chrome extension popup already supports custom port via UI input + localStorage

Closes #288