### PR TITLE
Migrate ScriptProcessorNode to AudioWorkletNode in Chrome extension

### DIFF
--- a/chrome-extension/audio-processor.js
+++ b/chrome-extension/audio-processor.js
@@ -1,0 +1,85 @@
+/**
+ * AudioWorklet processor for capturing and downsampling audio.
+ *
+ * Runs off the main thread. Receives raw PCM from the audio graph,
+ * downsamples to 16 kHz mono via linear interpolation, and posts
+ * Float32Array chunks to the main thread through the MessagePort.
+ */
+
+class AudioCaptureProcessor extends AudioWorkletProcessor {
+  constructor(options) {
+    super()
+
+    const { sourceSampleRate = 48000, targetSampleRate = 16000 } =
+      options.processorOptions || {}
+
+    this._sourceSampleRate = sourceSampleRate
+    this._targetSampleRate = targetSampleRate
+    this._active = true
+
+    // Listen for stop signal from the main thread
+    this.port.onmessage = (event) => {
+      if (event.data && event.data.type === 'stop') {
+        this._active = false
+      }
+    }
+  }
+
+  /**
+   * Downsample audio from source sample rate to target sample rate
+   * using linear interpolation.
+   */
+  _downsample(buffer) {
+    const fromRate = this._sourceSampleRate
+    const toRate = this._targetSampleRate
+
+    if (fromRate === toRate) {
+      return buffer
+    }
+
+    const ratio = fromRate / toRate
+    const newLength = Math.round(buffer.length / ratio)
+    const result = new Float32Array(newLength)
+
+    for (let i = 0; i < newLength; i++) {
+      const srcIndex = i * ratio
+      const low = Math.floor(srcIndex)
+      const high = Math.min(low + 1, buffer.length - 1)
+      const frac = srcIndex - low
+      result[i] = buffer[low] * (1 - frac) + buffer[high] * frac
+    }
+
+    return result
+  }
+
+  /**
+   * Called by the Web Audio engine for each 128-sample render quantum.
+   * Returns true to keep the processor alive, false to stop.
+   */
+  process(inputs) {
+    if (!this._active) {
+      return false
+    }
+
+    const input = inputs[0]
+    if (!input || input.length === 0 || !input[0]) {
+      return true
+    }
+
+    // Take the first channel (mono)
+    const channelData = input[0]
+
+    // Downsample to target rate
+    const resampled = this._downsample(channelData)
+
+    // Transfer to main thread via MessagePort
+    this.port.postMessage(
+      { type: 'audio', samples: resampled.buffer },
+      [resampled.buffer]
+    )
+
+    return true
+  }
+}
+
+registerProcessor('audio-capture-processor', AudioCaptureProcessor)

--- a/chrome-extension/manifest.json
+++ b/chrome-extension/manifest.json
@@ -27,5 +27,11 @@
   "offscreen": {
     "reasons": ["USER_MEDIA"],
     "justification": "Capture tab audio via tabCapture API and stream PCM data to the Live Translate desktop app for real-time speech translation."
-  }
+  },
+  "web_accessible_resources": [
+    {
+      "resources": ["audio-processor.js"],
+      "matches": []
+    }
+  ]
 }

--- a/chrome-extension/offscreen.js
+++ b/chrome-extension/offscreen.js
@@ -2,8 +2,9 @@
  * Offscreen document for audio capture and WebSocket streaming.
  *
  * Receives a tab capture stream ID from the background service worker,
- * captures the audio via getUserMedia + AudioWorklet, resamples to 16kHz mono,
- * and streams raw Float32 PCM to the Electron app via WebSocket.
+ * captures the audio via AudioWorkletNode, resamples to 16kHz mono
+ * off the main thread, and streams raw Float32 PCM to the Electron
+ * app via WebSocket.
  */
 
 const TARGET_SAMPLE_RATE = 16000
@@ -15,7 +16,7 @@ const WS_MAX_RECONNECT_ATTEMPTS = 5
 let mediaStream = null
 let audioContext = null
 let sourceNode = null
-let processorNode = null
+let workletNode = null
 let ws = null
 let heartbeatTimer = null
 let audioBuffer = []
@@ -115,31 +116,10 @@ function flushAudioBuffer() {
 }
 
 /**
- * Downsample audio from source sample rate to target sample rate.
- * Uses simple linear interpolation.
- */
-function downsample(buffer, fromRate, toRate) {
-  if (fromRate === toRate) {
-    return buffer
-  }
-
-  const ratio = fromRate / toRate
-  const newLength = Math.round(buffer.length / ratio)
-  const result = new Float32Array(newLength)
-
-  for (let i = 0; i < newLength; i++) {
-    const srcIndex = i * ratio
-    const low = Math.floor(srcIndex)
-    const high = Math.min(low + 1, buffer.length - 1)
-    const frac = srcIndex - low
-    result[i] = buffer[low] * (1 - frac) + buffer[high] * frac
-  }
-
-  return result
-}
-
-/**
  * Start capturing audio from the given stream ID.
+ *
+ * Registers the AudioWorklet processor, connects the audio graph,
+ * and listens for downsampled audio chunks via MessagePort.
  */
 async function startCapture(streamId, port) {
   wsPort = port || 9876
@@ -163,17 +143,32 @@ async function startCapture(streamId, port) {
   audioContext = new AudioContext({ sampleRate })
   sourceNode = audioContext.createMediaStreamSource(mediaStream)
 
-  // Use ScriptProcessorNode for broad compatibility (AudioWorklet not available in offscreen)
-  const bufferSize = 4096
-  processorNode = audioContext.createScriptProcessor(bufferSize, 1, 1)
+  // Load the AudioWorklet processor module
+  // Use chrome.runtime.getURL() because addModule() cannot resolve relative
+  // paths inside Chrome extension contexts.
+  const processorUrl = chrome.runtime.getURL('audio-processor.js')
+  await audioContext.audioWorklet.addModule(processorUrl)
+
+  // Create the worklet node, passing sample rates so it can downsample
+  workletNode = new AudioWorkletNode(audioContext, 'audio-capture-processor', {
+    numberOfInputs: 1,
+    numberOfOutputs: 0,
+    channelCount: 1,
+    processorOptions: {
+      sourceSampleRate: sampleRate,
+      targetSampleRate: TARGET_SAMPLE_RATE
+    }
+  })
 
   const targetSamplesPerBuffer = Math.floor(TARGET_SAMPLE_RATE * (BUFFER_DURATION_MS / 1000))
 
-  processorNode.onaudioprocess = (event) => {
-    const inputData = event.inputBuffer.getChannelData(0)
+  // Receive downsampled audio chunks from the worklet via MessagePort
+  workletNode.port.onmessage = (event) => {
+    if (event.data.type !== 'audio') {
+      return
+    }
 
-    // Downsample to 16kHz
-    const resampled = downsample(inputData, sampleRate, TARGET_SAMPLE_RATE)
+    const resampled = new Float32Array(event.data.samples)
 
     audioBuffer.push(resampled)
     audioBufferLength += resampled.length
@@ -184,8 +179,7 @@ async function startCapture(streamId, port) {
     }
   }
 
-  sourceNode.connect(processorNode)
-  processorNode.connect(audioContext.destination)
+  sourceNode.connect(workletNode)
 
   // Detect when the tab's audio track ends (tab closed or navigated away)
   mediaStream.getAudioTracks()[0].addEventListener('ended', () => {
@@ -194,7 +188,7 @@ async function startCapture(streamId, port) {
     chrome.runtime.sendMessage({ type: 'capture-stopped' })
   })
 
-  console.log(`[offscreen] Capturing at ${sampleRate}Hz, resampling to ${TARGET_SAMPLE_RATE}Hz`)
+  console.log(`[offscreen] Capturing at ${sampleRate}Hz, resampling to ${TARGET_SAMPLE_RATE}Hz via AudioWorklet`)
 }
 
 /**
@@ -206,9 +200,11 @@ function stopCapture() {
   // Flush remaining audio
   flushAudioBuffer()
 
-  if (processorNode) {
-    processorNode.disconnect()
-    processorNode = null
+  if (workletNode) {
+    // Signal the worklet processor to stop, then disconnect
+    workletNode.port.postMessage({ type: 'stop' })
+    workletNode.disconnect()
+    workletNode = null
   }
 
   if (sourceNode) {


### PR DESCRIPTION
## Description

Replace the deprecated `ScriptProcessorNode` with `AudioWorkletNode` in the Chrome extension's offscreen document. Audio downsampling now runs off the main thread in a dedicated `AudioWorkletProcessor`, improving performance during tab audio capture.

### Changes
- **New file `chrome-extension/audio-processor.js`**: AudioWorklet processor that receives raw PCM, downsamples to 16 kHz via linear interpolation, and posts chunks back via MessagePort
- **Updated `chrome-extension/offscreen.js`**: Loads the worklet module via `audioContext.audioWorklet.addModule()`, receives audio data through `workletNode.port.onmessage`, sends stop signal on cleanup
- **Updated `chrome-extension/manifest.json`**: Added `web_accessible_resources` for the processor script (required for `addModule()` in extension contexts)

Closes #280