### PR TITLE
Guard streamingLockResolvers and centralize language name mappings

### DIFF
--- a/src/engines/language-names.ts
+++ b/src/engines/language-names.ts
@@ -1,0 +1,93 @@
+/**
+ * Centralized language name mappings.
+ *
+ * LANG_NAMES_EN covers all languages supported by SLM engines (TranslateGemma,
+ * Hunyuan-MT) — a superset of the `Language` type used by online engines.
+ *
+ * LANG_NAMES_ZH provides Chinese-localized names required by the HY-MT1.5
+ * prompt template.
+ */
+
+/** English language names keyed by ISO 639-1 / BCP-47 codes */
+export const LANG_NAMES_EN: Record<string, string> = {
+  ja: 'Japanese',
+  en: 'English',
+  zh: 'Chinese',
+  'zh-Hant': 'Traditional Chinese',
+  fr: 'French',
+  de: 'German',
+  es: 'Spanish',
+  pt: 'Portuguese',
+  ru: 'Russian',
+  ko: 'Korean',
+  ar: 'Arabic',
+  th: 'Thai',
+  vi: 'Vietnamese',
+  id: 'Indonesian',
+  ms: 'Malay',
+  tr: 'Turkish',
+  it: 'Italian',
+  pl: 'Polish',
+  nl: 'Dutch',
+  cs: 'Czech',
+  uk: 'Ukrainian',
+  hi: 'Hindi',
+  tl: 'Filipino',
+  km: 'Khmer',
+  my: 'Burmese',
+  fa: 'Persian',
+  gu: 'Gujarati',
+  ur: 'Urdu',
+  te: 'Telugu',
+  mr: 'Marathi',
+  he: 'Hebrew',
+  bn: 'Bengali',
+  ta: 'Tamil',
+  bo: 'Tibetan',
+  kk: 'Kazakh',
+  mn: 'Mongolian',
+  ug: 'Uyghur',
+  yue: 'Cantonese'
+}
+
+/** Chinese language names used by HY-MT1.5 prompt template */
+export const LANG_NAMES_ZH: Record<string, string> = {
+  ja: '日语',
+  en: '英语',
+  zh: '中文',
+  'zh-Hant': '繁体中文',
+  fr: '法语',
+  de: '德语',
+  es: '西班牙语',
+  pt: '葡萄牙语',
+  ru: '俄语',
+  ko: '韩语',
+  ar: '阿拉伯语',
+  th: '泰语',
+  vi: '越南语',
+  id: '印尼语',
+  ms: '马来语',
+  tr: '土耳其语',
+  it: '意大利语',
+  pl: '波兰语',
+  nl: '荷兰语',
+  cs: '捷克语',
+  uk: '乌克兰语',
+  hi: '印地语',
+  tl: '菲律宾语',
+  km: '高棉语',
+  my: '缅甸语',
+  fa: '波斯语',
+  gu: '古吉拉特语',
+  ur: '乌尔都语',
+  te: '泰卢固语',
+  mr: '马拉地语',
+  he: '希伯来语',
+  bn: '孟加拉语',
+  ta: '泰米尔语',
+  bo: '藏语',
+  kk: '哈萨克语',
+  mn: '蒙古语',
+  ug: '维吾尔语',
+  yue: '粤语'
+}

--- a/src/engines/translator/GeminiTranslator.ts
+++ b/src/engines/translator/GeminiTranslator.ts
@@ -1,27 +1,9 @@
 import type { TranslatorEngine, Language, TranslateContext } from '../types'
+import { LANG_NAMES_EN } from '../language-names'
 
 const GEMINI_API_URL =
   'https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent'
 const DEFAULT_TIMEOUT_MS = 15_000
-
-const LANG_NAMES: Record<Language, string> = {
-  ja: 'Japanese',
-  en: 'English',
-  zh: 'Chinese',
-  ko: 'Korean',
-  fr: 'French',
-  de: 'German',
-  es: 'Spanish',
-  pt: 'Portuguese',
-  ru: 'Russian',
-  it: 'Italian',
-  nl: 'Dutch',
-  pl: 'Polish',
-  ar: 'Arabic',
-  th: 'Thai',
-  vi: 'Vietnamese',
-  id: 'Indonesian'
-}
 
 export class GeminiTranslator implements TranslatorEngine {
   readonly id = 'gemini-translate'
@@ -67,7 +49,7 @@ export class GeminiTranslator implements TranslatorEngine {
     }
     const contextSection = contextParts.length > 0 ? contextParts.join('\n\n') + '\n\n' : ''
 
-    const prompt = `${contextSection}Translate the following ${LANG_NAMES[from]} text to ${LANG_NAMES[to]}. Output ONLY the translated text, nothing else.\n\n${text}`
+    const prompt = `${contextSection}Translate the following ${LANG_NAMES_EN[from]} text to ${LANG_NAMES_EN[to]}. Output ONLY the translated text, nothing else.\n\n${text}`
 
     const controller = new AbortController()
     const timeout = setTimeout(() => controller.abort(), this.timeoutMs)

--- a/src/main/slm-worker.ts
+++ b/src/main/slm-worker.ts
@@ -14,90 +14,9 @@
  *   Worker → Main: { type: 'error', id?: string, message: string }
  */
 
+import { LANG_NAMES_EN, LANG_NAMES_ZH } from '../engines/language-names'
+
 type ModelType = 'translategemma' | 'hunyuan-mt' | 'hunyuan-mt-15'
-
-const LANG_NAMES: Record<string, string> = {
-  ja: 'Japanese',
-  en: 'English',
-  zh: 'Chinese',
-  'zh-Hant': 'Traditional Chinese',
-  fr: 'French',
-  de: 'German',
-  es: 'Spanish',
-  pt: 'Portuguese',
-  ru: 'Russian',
-  ko: 'Korean',
-  ar: 'Arabic',
-  th: 'Thai',
-  vi: 'Vietnamese',
-  id: 'Indonesian',
-  ms: 'Malay',
-  tr: 'Turkish',
-  it: 'Italian',
-  pl: 'Polish',
-  nl: 'Dutch',
-  cs: 'Czech',
-  uk: 'Ukrainian',
-  hi: 'Hindi',
-  tl: 'Filipino',
-  km: 'Khmer',
-  my: 'Burmese',
-  fa: 'Persian',
-  gu: 'Gujarati',
-  ur: 'Urdu',
-  te: 'Telugu',
-  mr: 'Marathi',
-  he: 'Hebrew',
-  bn: 'Bengali',
-  ta: 'Tamil',
-  bo: 'Tibetan',
-  kk: 'Kazakh',
-  mn: 'Mongolian',
-  ug: 'Uyghur',
-  yue: 'Cantonese'
-}
-
-/** Chinese language names used by HY-MT1.5 prompt template */
-const LANG_NAMES_ZH: Record<string, string> = {
-  ja: '日语',
-  en: '英语',
-  zh: '中文',
-  'zh-Hant': '繁体中文',
-  fr: '法语',
-  de: '德语',
-  es: '西班牙语',
-  pt: '葡萄牙语',
-  ru: '俄语',
-  ko: '韩语',
-  ar: '阿拉伯语',
-  th: '泰语',
-  vi: '越南语',
-  id: '印尼语',
-  ms: '马来语',
-  tr: '土耳其语',
-  it: '意大利语',
-  pl: '波兰语',
-  nl: '荷兰语',
-  cs: '捷克语',
-  uk: '乌克兰语',
-  hi: '印地语',
-  tl: '菲律宾语',
-  km: '高棉语',
-  my: '缅甸语',
-  fa: '波斯语',
-  gu: '古吉拉特语',
-  ur: '乌尔都语',
-  te: '泰卢固语',
-  mr: '马拉地语',
-  he: '希伯来语',
-  bn: '孟加拉语',
-  ta: '泰米尔语',
-  bo: '藏语',
-  kk: '哈萨克语',
-  mn: '蒙古语',
-  ug: '维吾尔语',
-  yue: '粤语'
-}
 
 let llama: any = null
 let model: any = null
@@ -242,8 +161,8 @@ async function handleTranslate(
 
     const session = new LlamaChatSession({ contextSequence })
 
-    const fromLang = LANG_NAMES[from] ?? from
-    const toLang = LANG_NAMES[to] ?? to
+    const fromLang = LANG_NAMES_EN[from] ?? from
+    const toLang = LANG_NAMES_EN[to] ?? to
 
     // Build prompt based on model type
     let prompt: string
@@ -336,8 +255,8 @@ async function handleTranslateIncremental(
     const contextSequence = context.getSequence()
     const session = new LlamaChatSession({ contextSequence })
 
-    const fromLang = LANG_NAMES[from] ?? from
-    const toLang = LANG_NAMES[to] ?? to
+    const fromLang = LANG_NAMES_EN[from] ?? from
+    const toLang = LANG_NAMES_EN[to] ?? to
 
     const contextSection = buildContextPrompt(translateContext)
 

--- a/src/pipeline/TranslationPipeline.ts
+++ b/src/pipeline/TranslationPipeline.ts
@@ -47,6 +47,8 @@ export enum PipelineState {
 const MAX_CONSECUTIVE_ERRORS = 3
 const RECOVERY_DELAY_MS = 1000
 const ENGINE_INIT_TIMEOUT_MS = 5 * 60_000 // 5 minutes for model download
+const MAX_STREAMING_LOCK_RESOLVERS = 50
+const STREAMING_LOCK_TIMEOUT_MS = 10_000
 
 /**
  * Manages the STT → Translation pipeline.
@@ -196,6 +198,36 @@ export class TranslationPipeline extends EventEmitter {
     if (this.processingCount === 0) return
     return new Promise((resolve) => {
       this.processingDoneResolvers.push(resolve)
+    })
+  }
+
+  /**
+   * Wait for the streaming lock to be released with a timeout and backpressure cap.
+   * If more than MAX_STREAMING_LOCK_RESOLVERS are already waiting, the oldest
+   * resolvers are auto-resolved to prevent unbounded growth (#292).
+   */
+  private waitForStreamingLock(): Promise<void> {
+    return new Promise<void>((resolve) => {
+      // Evict oldest waiters when the queue is full
+      while (this.streamingLockResolvers.length >= MAX_STREAMING_LOCK_RESOLVERS) {
+        const oldest = this.streamingLockResolvers.shift()
+        if (oldest) oldest()
+      }
+
+      // Auto-resolve after timeout so callers never hang indefinitely
+      const timer = setTimeout(() => {
+        const idx = this.streamingLockResolvers.indexOf(resolve)
+        if (idx !== -1) {
+          this.streamingLockResolvers.splice(idx, 1)
+          console.warn('[pipeline] streamingLock wait timed out')
+          resolve()
+        }
+      }, STREAMING_LOCK_TIMEOUT_MS)
+
+      this.streamingLockResolvers.push(() => {
+        clearTimeout(timer)
+        resolve()
+      })
     })
   }
 
@@ -517,9 +549,7 @@ export class TranslationPipeline extends EventEmitter {
     if (this.config.mode !== 'cascade' || !this.sttEngine) return null
 
     if (this.streamingLock) {
-      await new Promise<void>((resolve) => {
-        this.streamingLockResolvers.push(resolve)
-      })
+      await this.waitForStreamingLock()
     }
     this.processingCount++
     this.streamingLock = true


### PR DESCRIPTION
## Summary
- **#292**: Added max resolver count (50) and timeout (10s) to `streamingLockResolvers` in `TranslationPipeline` to prevent unbounded growth when `finalizeStreaming()` is never called after `processStreaming()`. Oldest waiters are evicted when the cap is reached, and a timeout auto-resolves stale callbacks.
- **#293**: Extracted duplicated `LANG_NAMES` / `LANG_NAMES_ZH` mappings from `slm-worker.ts` into a shared `src/engines/language-names.ts` module. Updated both `slm-worker.ts` and `GeminiTranslator.ts` to import from the centralized source.

## Test plan
- [x] `npm run typecheck` passes (pre-existing errors in ws-audio-server.ts unrelated)
- [x] `npm test` — all 45 tests pass
- [ ] Manual: run streaming translation session and verify no memory leak in resolver array

Closes #292, Closes #293