### PR TITLE
Replace any types with proper types in plugin loader and slm-worker

### DIFF
--- a/src/engines/translator/HunyuanMT15Translator.ts
+++ b/src/engines/translator/HunyuanMT15Translator.ts
@@ -5,6 +5,14 @@ import { getGGUFDir, downloadGGUF, getHunyuanMT15Variants } from '../model-downl
 
 const TRANSLATE_TIMEOUT_MS = 30_000
 
+/** IPC message from slm-worker to main process */
+interface WorkerMessage {
+  type: 'ready' | 'result' | 'error'
+  id?: string
+  text?: string
+  message?: string
+}
+
 interface PendingRequest {
   resolve: (text: string) => void
   reject: (err: Error) => void
@@ -76,7 +84,7 @@ export class HunyuanMT15Translator implements TranslatorEngine {
         reject(new Error('HY-MT1.5 initialization timed out'))
       }, 5 * 60_000)
 
-      const initHandler = (msg: any): void => {
+      const initHandler = (msg: WorkerMessage): void => {
         if (!this.worker) return
 
         if (msg.type === 'ready') {
@@ -87,7 +95,7 @@ export class HunyuanMT15Translator implements TranslatorEngine {
         } else if (msg.type === 'error') {
           clearTimeout(timeout)
           this.worker?.removeListener('message', initHandler)
-          reject(new Error(msg.message))
+          reject(new Error(msg.message ?? 'Unknown worker error'))
         }
       }
 
@@ -106,13 +114,13 @@ export class HunyuanMT15Translator implements TranslatorEngine {
 
     // Clear any leftover listeners before registering to prevent duplicates
     this.worker.removeAllListeners('message')
-    this.worker.on('message', (msg: any) => {
+    this.worker.on('message', (msg: WorkerMessage) => {
       if (msg.type === 'result' && msg.id) {
         const req = this.pending.get(msg.id)
         if (req) {
           clearTimeout(req.timer)
           this.pending.delete(msg.id)
-          req.resolve(msg.text)
+          req.resolve(msg.text ?? '')
         }
         return
       }
@@ -121,7 +129,7 @@ export class HunyuanMT15Translator implements TranslatorEngine {
         if (req) {
           clearTimeout(req.timer)
           this.pending.delete(msg.id)
-          req.reject(new Error(msg.message))
+          req.reject(new Error(msg.message ?? 'Unknown worker error'))
         }
         return
       }

--- a/src/engines/translator/HunyuanMTTranslator.ts
+++ b/src/engines/translator/HunyuanMTTranslator.ts
@@ -5,6 +5,14 @@ import { getGGUFDir, downloadGGUF, getHunyuanMTVariants } from '../model-downloa
 
 const TRANSLATE_TIMEOUT_MS = 30_000
 
+/** IPC message from slm-worker to main process */
+interface WorkerMessage {
+  type: 'ready' | 'result' | 'error'
+  id?: string
+  text?: string
+  message?: string
+}
+
 interface PendingRequest {
   resolve: (text: string) => void
   reject: (err: Error) => void
@@ -76,7 +84,7 @@ export class HunyuanMTTranslator implements TranslatorEngine {
         reject(new Error('Hunyuan-MT initialization timed out'))
       }, 5 * 60_000)
 
-      const initHandler = (msg: any): void => {
+      const initHandler = (msg: WorkerMessage): void => {
         if (!this.worker) return
 
         if (msg.type === 'ready') {
@@ -87,7 +95,7 @@ export class HunyuanMTTranslator implements TranslatorEngine {
         } else if (msg.type === 'error') {
           clearTimeout(timeout)
           this.worker?.removeListener('message', initHandler)
-          reject(new Error(msg.message))
+          reject(new Error(msg.message ?? 'Unknown worker error'))
         }
       }
 
@@ -106,13 +114,13 @@ export class HunyuanMTTranslator implements TranslatorEngine {
 
     // Clear any leftover listeners before registering to prevent duplicates
     this.worker.removeAllListeners('message')
-    this.worker.on('message', (msg: any) => {
+    this.worker.on('message', (msg: WorkerMessage) => {
       if (msg.type === 'result' && msg.id) {
         const req = this.pending.get(msg.id)
         if (req) {
           clearTimeout(req.timer)
           this.pending.delete(msg.id)
-          req.resolve(msg.text)
+          req.resolve(msg.text ?? '')
         }
         return
       }
@@ -121,7 +129,7 @@ export class HunyuanMTTranslator implements TranslatorEngine {
         if (req) {
           clearTimeout(req.timer)
           this.pending.delete(msg.id)
-          req.reject(new Error(msg.message))
+          req.reject(new Error(msg.message ?? 'Unknown worker error'))
         }
         return
       }

--- a/src/engines/translator/SLMTranslator.ts
+++ b/src/engines/translator/SLMTranslator.ts
@@ -6,6 +6,14 @@ import type { SLMModelSize } from '../model-downloader'
 
 const TRANSLATE_TIMEOUT_MS = 30_000
 
+/** IPC message from slm-worker to main process */
+interface WorkerMessage {
+  type: 'ready' | 'result' | 'error'
+  id?: string
+  text?: string
+  message?: string
+}
+
 interface PendingRequest {
   resolve: (text: string) => void
   reject: (err: Error) => void
@@ -90,7 +98,7 @@ export class SLMTranslator implements TranslatorEngine {
         reject(new Error('TranslateGemma initialization timed out'))
       }, 5 * 60_000)
 
-      const initHandler = (msg: any): void => {
+      const initHandler = (msg: WorkerMessage): void => {
         // Guard: ignore messages if worker was killed during timeout (#205)
         if (!this.worker) return
 
@@ -103,7 +111,7 @@ export class SLMTranslator implements TranslatorEngine {
         } else if (msg.type === 'error') {
           clearTimeout(timeout)
           this.worker?.removeListener('message', initHandler)
-          reject(new Error(msg.message))
+          reject(new Error(msg.message ?? 'Unknown worker error'))
         }
       }
 
@@ -123,13 +131,13 @@ export class SLMTranslator implements TranslatorEngine {
 
     // Clear any leftover listeners before registering to prevent duplicates (#206)
     this.worker.removeAllListeners('message')
-    this.worker.on('message', (msg: any) => {
+    this.worker.on('message', (msg: WorkerMessage) => {
       if (msg.type === 'result' && msg.id) {
         const req = this.pending.get(msg.id)
         if (req) {
           clearTimeout(req.timer)
           this.pending.delete(msg.id)
-          req.resolve(msg.text)
+          req.resolve(msg.text ?? '')
         }
         return
       }
@@ -138,7 +146,7 @@ export class SLMTranslator implements TranslatorEngine {
         if (req) {
           clearTimeout(req.timer)
           this.pending.delete(msg.id)
-          req.reject(new Error(msg.message))
+          req.reject(new Error(msg.message ?? 'Unknown worker error'))
         }
         return
       }

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -18,7 +18,7 @@ import { createMainWindow, createSubtitleWindow, registerDisplayHandlers } from 
 import { registerAudioHandlers } from './audio-handlers'
 import { registerIpcHandlers } from './ipc-handlers'
 import type { AppContext } from './app-context'
-import type { TranslationResult } from '../engines/types'
+import type { TranslationResult, STTEngine, TranslatorEngine, E2ETranslationEngine } from '../engines/types'
 import type { WhisperVariant, MoonshineVariant } from '../engines/model-downloader'
 
 // Shared mutable state
@@ -92,15 +92,16 @@ function initPipeline(): void {
     })
   ))
   // Auto-register discovered plugins (#145)
+  // Plugin factories are async (loadPluginEngine returns Promise), but the pipeline
+  // handles this via `await Promise.resolve(factory())` in switchEngine().
   for (const plugin of discoverPlugins()) {
     const { manifest } = plugin
-    const factory = () => loadPluginEngine(plugin)
     if (manifest.engineType === 'stt') {
-      ctx.pipeline.registerSTT(manifest.engineId, factory as any)
+      ctx.pipeline.registerSTT(manifest.engineId, (() => loadPluginEngine(plugin)) as unknown as () => STTEngine)
     } else if (manifest.engineType === 'translator') {
-      ctx.pipeline.registerTranslator(manifest.engineId, factory as any)
+      ctx.pipeline.registerTranslator(manifest.engineId, (() => loadPluginEngine(plugin)) as unknown as () => TranslatorEngine)
     } else if (manifest.engineType === 'e2e') {
-      ctx.pipeline.registerE2E(manifest.engineId, factory as any)
+      ctx.pipeline.registerE2E(manifest.engineId, (() => loadPluginEngine(plugin)) as unknown as () => E2ETranslationEngine)
     }
     console.log(`[plugin] Registered ${manifest.engineType} plugin: ${manifest.name} (${manifest.engineId})`)
   }

--- a/src/main/slm-worker.ts
+++ b/src/main/slm-worker.ts
@@ -14,7 +14,29 @@
  *   Worker → Main: { type: 'error', id?: string, message: string }
  */
 
+import type { Llama, LlamaModel, LlamaContext, LlamaContextSequence } from 'node-llama-cpp'
+
 type ModelType = 'translategemma' | 'hunyuan-mt' | 'hunyuan-mt-15'
+
+/** IPC message from main process to worker */
+interface WorkerIncomingMessage {
+  type: 'init' | 'translate' | 'translate-incremental' | 'summarize' | 'dispose'
+  id?: string
+  modelPath?: string
+  kvCacheQuant?: boolean
+  modelType?: ModelType
+  draftModelPath?: string
+  text?: string
+  from?: string
+  to?: string
+  previousOutput?: string
+  transcript?: string
+  context?: {
+    previousSegments?: Array<{ source: string; translated: string; speakerId?: string }>
+    glossary?: Array<{ source: string; target: string }>
+    speakerId?: string
+  }
+}
 
 const LANG_NAMES: Record<string, string> = {
   ja: 'Japanese',
@@ -99,11 +121,11 @@ const LANG_NAMES_ZH: Record<string, string> = {
   yue: '粤语'
 }
 
-let llama: any = null
-let model: any = null
-let context: any = null
-let draftModel: any = null
-let draftContext: any = null
+let llama: Llama | null = null
+let model: LlamaModel | null = null
+let context: LlamaContext | null = null
+let draftModel: LlamaModel | null = null
+let draftContext: LlamaContext | null = null
 let speculativeEnabled = false
 let requestQueue: Promise<void> = Promise.resolve()
 let activeModelType: ModelType = 'translategemma'
@@ -226,7 +248,7 @@ async function handleTranslate(
     const { LlamaChatSession, DraftSequenceTokenPredictor } = await import('node-llama-cpp')
 
     // Create context sequence, optionally with speculative decoding
-    let contextSequence: any
+    let contextSequence: LlamaContextSequence
     if (speculativeEnabled && draftContext) {
       const draftSequence = draftContext.getSequence()
       contextSequence = context.getSequence({
@@ -469,23 +491,23 @@ async function handleDispose(): Promise<void> {
 
 // Listen for messages from main process
 // Serialize translate/summarize requests to prevent concurrent context access
-process.parentPort!.on('message', (e: { data: any }) => {
+process.parentPort!.on('message', (e: { data: WorkerIncomingMessage }) => {
   const msg = e.data
 
   const handleMessage = async (): Promise<void> => {
     try {
       switch (msg.type) {
         case 'init':
-          await handleInit(msg.modelPath, msg.kvCacheQuant, msg.modelType, msg.draftModelPath)
+          await handleInit(msg.modelPath!, msg.kvCacheQuant, msg.modelType, msg.draftModelPath)
           break
         case 'translate':
-          await handleTranslate(msg.id, msg.text, msg.from, msg.to, msg.context)
+          await handleTranslate(msg.id!, msg.text!, msg.from!, msg.to!, msg.context)
           break
         case 'translate-incremental':
-          await handleTranslateIncremental(msg.id, msg.text, msg.previousOutput, msg.from, msg.to, msg.context)
+          await handleTranslateIncremental(msg.id!, msg.text!, msg.previousOutput!, msg.from!, msg.to!, msg.context)
           break
         case 'summarize':
-          await handleSummarize(msg.id, msg.transcript)
+          await handleSummarize(msg.id!, msg.transcript!)
           break
         case 'dispose':
           await handleDispose()


### PR DESCRIPTION
## Summary
- Replace `any` types in `slm-worker.ts` with `Llama`, `LlamaModel`, `LlamaContext`, `LlamaContextSequence` from node-llama-cpp
- Add `WorkerMessage` interface to `SLMTranslator`, `HunyuanMTTranslator`, and `HunyuanMT15Translator` for typed IPC messages
- Add `WorkerIncomingMessage` interface to `slm-worker.ts` for typed message handler
- Replace `factory as any` in plugin registration (`index.ts`) with explicit `as unknown as () => T` casts with explanatory comment

## Test plan
- [x] `npm run typecheck` passes
- [x] `npm test` passes (45/45)

Closes #290