### PR TITLE
Add error logging to silent catch blocks

### DIFF
--- a/src/engines/SubprocessBridge.ts
+++ b/src/engines/SubprocessBridge.ts
@@ -98,8 +98,8 @@ export abstract class SubprocessBridge {
       console.error(`${prefix} Initialization timed out`)
       try {
         this.process?.kill()
-      } catch {
-        /* ignore */
+      } catch (e) {
+        console.warn(`${prefix} Failed to kill timed-out process:`, e)
       }
       this.process = null
     }, initTimeout)
@@ -175,8 +175,8 @@ export abstract class SubprocessBridge {
       if (this.process) {
         try {
           this.process.kill()
-        } catch {
-          /* ignore */
+        } catch (e) {
+          console.warn(`${prefix} Failed to kill process after init error:`, e)
         }
         this.process = null
       }
@@ -235,15 +235,17 @@ export abstract class SubprocessBridge {
     console.log(`${prefix} Disposing resources`)
     if (this.process) {
       try {
-        this.sendCommand({ action: 'dispose' }).catch(() => {})
+        this.sendCommand({ action: 'dispose' }).catch((e) =>
+          console.warn(`${prefix} Failed to send dispose command:`, e)
+        )
         await new Promise((resolve) => setTimeout(resolve, 500))
-      } catch {
-        /* ignore */
+      } catch (e) {
+        console.warn(`${prefix} Error during dispose handshake:`, e)
       }
       try {
         this.process.kill()
-      } catch {
-        /* ignore */
+      } catch (e) {
+        console.warn(`${prefix} Failed to kill process during dispose:`, e)
       }
       this.process = null
     }

--- a/src/engines/model-downloader.ts
+++ b/src/engines/model-downloader.ts
@@ -304,7 +304,7 @@ async function doDownloadWithResume(
       // If server doesn't support Range, start over
       if (response.status === 200 && existingSize > 0) {
         existingSize = 0
-        try { unlinkSync(partialPath) } catch { /* ignore */ }
+        try { unlinkSync(partialPath) } catch (e) { console.warn('[model-downloader] Failed to delete partial file for restart:', e) }
       }
 
       if (!response.ok && response.status !== 206) {
@@ -370,7 +370,7 @@ async function doDownloadWithResume(
 
     } catch (err) {
       if (attempt >= MAX_RETRIES) {
-        try { if (existsSync(partialPath)) unlinkSync(partialPath) } catch { /* ignore */ }
+        try { if (existsSync(partialPath)) unlinkSync(partialPath) } catch (e) { console.warn('[model-downloader] Failed to clean up partial file after max retries:', e) }
         throw err
       }
       const delay = RETRY_DELAYS[attempt]

--- a/src/engines/stt/MlxWhisperEngine.ts
+++ b/src/engines/stt/MlxWhisperEngine.ts
@@ -96,7 +96,7 @@ export class MlxWhisperEngine extends SubprocessBridge implements STTEngine {
         timestamp: Date.now()
       }
     } finally {
-      try { unlinkSync(tempPath) } catch { /* ignore */ }
+      try { unlinkSync(tempPath) } catch (e) { console.warn('[mlx-whisper] Failed to delete temp WAV file:', e) }
     }
   }
 }

--- a/src/engines/stt/QwenASREngine.ts
+++ b/src/engines/stt/QwenASREngine.ts
@@ -142,7 +142,7 @@ export class QwenASREngine extends SubprocessBridge implements STTEngine {
         timestamp: Date.now()
       }
     } finally {
-      try { unlinkSync(tempPath) } catch { /* ignore */ }
+      try { unlinkSync(tempPath) } catch (e) { console.warn('[qwen-asr] Failed to delete temp WAV file:', e) }
     }
   }
 }

--- a/src/engines/translator/HunyuanMT15Translator.ts
+++ b/src/engines/translator/HunyuanMT15Translator.ts
@@ -71,7 +71,7 @@ export class HunyuanMT15Translator implements TranslatorEngine {
     await new Promise<void>((resolve, reject) => {
       const timeout = setTimeout(() => {
         this.worker?.removeListener('message', initHandler)
-        try { this.worker?.kill() } catch { /* ignore */ }
+        try { this.worker?.kill() } catch (e) { console.warn('[hunyuan-mt-15] Failed to kill timed-out worker:', e) }
         this.worker = null
         reject(new Error('HY-MT1.5 initialization timed out'))
       }, 5 * 60_000)
@@ -192,13 +192,13 @@ export class HunyuanMT15Translator implements TranslatorEngine {
       try {
         this.worker.postMessage({ type: 'dispose' })
         await new Promise((resolve) => setTimeout(resolve, 1000))
-      } catch {
-        // Ignore errors during disposal
+      } catch (e) {
+        console.warn('[hunyuan-mt-15] Error sending dispose to worker:', e)
       }
       try {
         this.worker.kill()
-      } catch {
-        // Already exited
+      } catch (e) {
+        console.warn('[hunyuan-mt-15] Failed to kill worker (may have already exited):', e)
       }
       this.worker = null
     }

--- a/src/engines/translator/HunyuanMTTranslator.ts
+++ b/src/engines/translator/HunyuanMTTranslator.ts
@@ -71,7 +71,7 @@ export class HunyuanMTTranslator implements TranslatorEngine {
     await new Promise<void>((resolve, reject) => {
       const timeout = setTimeout(() => {
         this.worker?.removeListener('message', initHandler)
-        try { this.worker?.kill() } catch { /* ignore */ }
+        try { this.worker?.kill() } catch (e) { console.warn('[hunyuan-mt] Failed to kill timed-out worker:', e) }
         this.worker = null
         reject(new Error('Hunyuan-MT initialization timed out'))
       }, 5 * 60_000)
@@ -192,13 +192,13 @@ export class HunyuanMTTranslator implements TranslatorEngine {
       try {
         this.worker.postMessage({ type: 'dispose' })
         await new Promise((resolve) => setTimeout(resolve, 1000))
-      } catch {
-        // Ignore errors during disposal
+      } catch (e) {
+        console.warn('[hunyuan-mt] Error sending dispose to worker:', e)
       }
       try {
         this.worker.kill()
-      } catch {
-        // Already exited
+      } catch (e) {
+        console.warn('[hunyuan-mt] Failed to kill worker (may have already exited):', e)
       }
       this.worker = null
     }

--- a/src/engines/translator/SLMTranslator.ts
+++ b/src/engines/translator/SLMTranslator.ts
@@ -85,7 +85,7 @@ export class SLMTranslator implements TranslatorEngine {
       const timeout = setTimeout(() => {
         this.worker?.removeListener('message', initHandler)
         // Kill orphaned worker on timeout
-        try { this.worker?.kill() } catch { /* ignore */ }
+        try { this.worker?.kill() } catch (e) { console.warn('[slm-translator] Failed to kill timed-out worker:', e) }
         this.worker = null
         reject(new Error('TranslateGemma initialization timed out'))
       }, 5 * 60_000)
@@ -229,13 +229,13 @@ export class SLMTranslator implements TranslatorEngine {
         this.worker.postMessage({ type: 'dispose' })
         // Give worker time to clean up
         await new Promise((resolve) => setTimeout(resolve, 1000))
-      } catch {
-        // Ignore errors during disposal
+      } catch (e) {
+        console.warn('[slm-translator] Error sending dispose to worker:', e)
       }
       try {
         this.worker.kill()
-      } catch {
-        // Already exited
+      } catch (e) {
+        console.warn('[slm-translator] Failed to kill worker (may have already exited):', e)
       }
       this.worker = null
     }

--- a/src/logger/SessionManager.ts
+++ b/src/logger/SessionManager.ts
@@ -120,7 +120,8 @@ export function listSessions(): SessionMetadata[] {
     try {
       const data: SessionData = JSON.parse(readFileSync(join(dir, f), 'utf-8'))
       return data.metadata
-    } catch {
+    } catch (e) {
+      console.warn(`[session] Failed to parse session file ${f}:`, e)
       return null
     }
   }).filter(Boolean) as SessionMetadata[]
@@ -132,7 +133,8 @@ export function loadSession(sessionId: string): SessionData | null {
   if (!existsSync(path)) return null
   try {
     return JSON.parse(readFileSync(path, 'utf-8'))
-  } catch {
+  } catch (e) {
+    console.warn(`[session] Failed to load session ${sessionId}:`, e)
     return null
   }
 }
@@ -158,7 +160,7 @@ export function searchSessions(query: string): Array<{ sessionId: string; matche
         results.push({ sessionId: data.metadata.id, matches })
         totalMatches += matches.length
       }
-    } catch { /* skip corrupted files */ }
+    } catch (e) { console.warn(`[session] Skipping corrupted session file ${f}:`, e) }
   }
 
   return results

--- a/src/main/ipc-handlers.ts
+++ b/src/main/ipc-handlers.ts
@@ -119,7 +119,7 @@ export function registerIpcHandlers(ctx: AppContext): void {
         // Dispose leaked rotation provider instances on switchEngine failure
         if (rotationProviders) {
           for (const p of rotationProviders) {
-            p.engine.dispose().catch(() => {})
+            p.engine.dispose().catch((e) => console.warn('[ipc] Failed to dispose rotation provider:', e))
           }
         }
         throw err

--- a/src/renderer/components/SettingsPanel.tsx
+++ b/src/renderer/components/SettingsPanel.tsx
@@ -154,7 +154,7 @@ function SettingsPanel(): React.JSX.Element {
           setSttEngine('mlx-whisper')
         }
       })
-    }).catch(() => {})
+    }).catch((e) => console.warn('[settings] Failed to load platform/STT defaults:', e))
 
     // Check for crashed session
     window.api.getCrashedSession().then((session) => {
@@ -167,7 +167,7 @@ function SettingsPanel(): React.JSX.Element {
 
   // Load session history
   useEffect(() => {
-    window.api.listSessions().then(setSessions).catch(() => {})
+    window.api.listSessions().then(setSessions).catch((e) => console.warn('[settings] Failed to load sessions:', e))
   }, [isRunning])
 
   // Detect GPU — fall back to OPUS-MT if no GPU
@@ -182,12 +182,18 @@ function SettingsPanel(): React.JSX.Element {
           }
         })
       }
-    }).catch(() => setGpuInfo({ hasGpu: false, gpuNames: [] }))
+    }).catch((e) => {
+      console.warn('[settings] GPU detection failed, falling back to no-GPU:', e)
+      setGpuInfo({ hasGpu: false, gpuNames: [] })
+    })
   }, [])
 
   // Check if 4B draft model is available for speculative decoding
   useEffect(() => {
-    window.api.isDraftModelAvailable().then(setDraftModelAvailable).catch(() => setDraftModelAvailable(false))
+    window.api.isDraftModelAvailable().then(setDraftModelAvailable).catch((e) => {
+      console.warn('[settings] Failed to check draft model availability:', e)
+      setDraftModelAvailable(false)
+    })
   }, [slmModelSize])
 
   // Load displays and listen for display changes


### PR DESCRIPTION
## Summary
- Replace silent `catch {}` / `.catch(() => {})` blocks with `console.warn` logging across 10 files
- Covers SubprocessBridge, SLMTranslator, HunyuanMT variants, model-downloader, MlxWhisper, QwenASR, SettingsPanel, ipc-handlers, and SessionManager
- Python detection probe catches (expected control flow) left as silent catches with clarified comments

## Test plan
- [x] `npm test` — all 45 tests pass
- [x] `npm run typecheck` — no new errors (3 pre-existing in ws-audio-server.ts)

Closes #291