### PR TITLE
Migrate chrome extension audio capture to AudioWorkletNode

### DIFF
--- a/chrome-extension/audio-processor.js
+++ b/chrome-extension/audio-processor.js
@@ -1,0 +1,52 @@
+/**
+ * AudioWorkletProcessor that collects mono audio samples and posts them
+ * to the main thread in batches.
+ *
+ * Each `process()` call receives 128 frames. We accumulate them and
+ * post a message once we have collected enough for one processing chunk
+ * (4096 samples, matching the previous ScriptProcessorNode buffer size).
+ */
+class AudioCaptureProcessor extends AudioWorkletProcessor {
+  constructor() {
+    super()
+    this._buffer = new Float32Array(4096)
+    this._offset = 0
+  }
+
+  /**
+   * Called by the audio rendering thread for every 128-frame quantum.
+   * @param {Float32Array[][]} inputs  - input audio data
+   * @returns {boolean} true to keep the processor alive
+   */
+  process(inputs) {
+    const input = inputs[0]
+    if (!input || input.length === 0) {
+      return true
+    }
+
+    const channelData = input[0]
+    if (!channelData) {
+      return true
+    }
+
+    let srcOffset = 0
+    while (srcOffset < channelData.length) {
+      const remaining = this._buffer.length - this._offset
+      const toCopy = Math.min(remaining, channelData.length - srcOffset)
+
+      this._buffer.set(channelData.subarray(srcOffset, srcOffset + toCopy), this._offset)
+      this._offset += toCopy
+      srcOffset += toCopy
+
+      if (this._offset >= this._buffer.length) {
+        // Post a copy of the filled buffer to the main thread
+        this.port.postMessage({ audioData: Array.from(this._buffer) })
+        this._offset = 0
+      }
+    }
+
+    return true
+  }
+}
+
+registerProcessor('audio-capture-processor', AudioCaptureProcessor)

--- a/chrome-extension/manifest.json
+++ b/chrome-extension/manifest.json
@@ -27,5 +27,11 @@
   "offscreen": {
     "reasons": ["USER_MEDIA"],
     "justification": "Capture tab audio via tabCapture API and stream PCM data to the Live Translate desktop app for real-time speech translation."
-  }
+  },
+  "web_accessible_resources": [
+    {
+      "resources": ["audio-processor.js"],
+      "matches": []
+    }
+  ]
 }

--- a/chrome-extension/offscreen.js
+++ b/chrome-extension/offscreen.js
@@ -2,8 +2,8 @@
  * Offscreen document for audio capture and WebSocket streaming.
  *
  * Receives a tab capture stream ID from the background service worker,
- * captures the audio via getUserMedia + AudioWorklet, resamples to 16kHz mono,
- * and streams raw Float32 PCM to the Electron app via WebSocket.
+ * captures the audio via getUserMedia + AudioWorkletNode, resamples to 16kHz
+ * mono, and streams raw Float32 PCM to the Electron app via WebSocket.
  */
 
 const TARGET_SAMPLE_RATE = 16000
@@ -158,19 +158,23 @@ async function startCapture(streamId, port) {
     }
   })
 
-  // Set up AudioContext and processing
+  // Set up AudioContext and AudioWorklet processing
   const sampleRate = mediaStream.getAudioTracks()[0].getSettings().sampleRate || 48000
   audioContext = new AudioContext({ sampleRate })
+
+  // Load the AudioWorkletProcessor module
+  const processorUrl = chrome.runtime.getURL('audio-processor.js')
+  await audioContext.audioWorklet.addModule(processorUrl)
+
   sourceNode = audioContext.createMediaStreamSource(mediaStream)
 
-  // Use ScriptProcessorNode for broad compatibility (AudioWorklet not available in offscreen)
-  const bufferSize = 4096
-  processorNode = audioContext.createScriptProcessor(bufferSize, 1, 1)
+  // Use AudioWorkletNode (replaces deprecated ScriptProcessorNode)
+  processorNode = new AudioWorkletNode(audioContext, 'audio-capture-processor')
 
   const targetSamplesPerBuffer = Math.floor(TARGET_SAMPLE_RATE * (BUFFER_DURATION_MS / 1000))
 
-  processorNode.onaudioprocess = (event) => {
-    const inputData = event.inputBuffer.getChannelData(0)
+  processorNode.port.onmessage = (event) => {
+    const inputData = new Float32Array(event.data.audioData)
 
     // Downsample to 16kHz
     const resampled = downsample(inputData, sampleRate, TARGET_SAMPLE_RATE)


### PR DESCRIPTION
## Summary
- Replace deprecated `ScriptProcessorNode` with `AudioWorkletNode` in the chrome extension's offscreen document
- Add `audio-processor.js` as an `AudioWorkletProcessor` that buffers 4096 samples before posting to the main thread
- Update `manifest.json` to include `audio-processor.js` in `web_accessible_resources` so it can be loaded as a worklet module

Closes #280