### PR TITLE
Add error logging to silent catch blocks

### DIFF
--- a/src/engines/SubprocessBridge.ts
+++ b/src/engines/SubprocessBridge.ts
@@ -98,8 +98,8 @@ export abstract class SubprocessBridge {
       console.error(`${prefix} Initialization timed out`)
       try {
         this.process?.kill()
-      } catch {
-        /* ignore */
+      } catch (e) {
+        console.warn(`${prefix} Failed to kill process on timeout:`, e)
       }
       this.process = null
     }, initTimeout)
@@ -175,8 +175,8 @@ export abstract class SubprocessBridge {
       if (this.process) {
         try {
           this.process.kill()
-        } catch {
-          /* ignore */
+        } catch (e) {
+          console.warn(`${prefix} Failed to kill process during init cleanup:`, e)
         }
         this.process = null
       }
@@ -235,15 +235,17 @@ export abstract class SubprocessBridge {
     console.log(`${prefix} Disposing resources`)
     if (this.process) {
       try {
-        this.sendCommand({ action: 'dispose' }).catch(() => {})
+        this.sendCommand({ action: 'dispose' }).catch((e) => {
+          console.warn(`${prefix} Failed to send dispose command:`, e)
+        })
         await new Promise((resolve) => setTimeout(resolve, 500))
-      } catch {
-        /* ignore */
+      } catch (e) {
+        console.warn(`${prefix} Error during dispose command:`, e)
       }
       try {
         this.process.kill()
-      } catch {
-        /* ignore */
+      } catch (e) {
+        console.warn(`${prefix} Failed to kill process during dispose:`, e)
       }
       this.process = null
     }

--- a/src/engines/model-downloader.ts
+++ b/src/engines/model-downloader.ts
@@ -304,7 +304,7 @@ async function doDownloadWithResume(
       // If server doesn't support Range, start over
       if (response.status === 200 && existingSize > 0) {
         existingSize = 0
-        try { unlinkSync(partialPath) } catch { /* ignore */ }
+        try { unlinkSync(partialPath) } catch (e) { console.warn('[model-downloader] Failed to remove partial file for restart:', e) }
       }
 
       if (!response.ok && response.status !== 206) {
@@ -370,7 +370,7 @@ async function doDownloadWithResume(
 
     } catch (err) {
       if (attempt >= MAX_RETRIES) {
-        try { if (existsSync(partialPath)) unlinkSync(partialPath) } catch { /* ignore */ }
+        try { if (existsSync(partialPath)) unlinkSync(partialPath) } catch (e) { console.warn('[model-downloader] Failed to clean up partial file after max retries:', e) }
         throw err
       }
       const delay = RETRY_DELAYS[attempt]

--- a/src/engines/stt/MlxWhisperEngine.ts
+++ b/src/engines/stt/MlxWhisperEngine.ts
@@ -96,7 +96,7 @@ export class MlxWhisperEngine extends SubprocessBridge implements STTEngine {
         timestamp: Date.now()
       }
     } finally {
-      try { unlinkSync(tempPath) } catch { /* ignore */ }
+      try { unlinkSync(tempPath) } catch (e) { console.warn('[mlx-whisper] Failed to delete temp file:', e) }
     }
   }
 }

--- a/src/engines/stt/QwenASREngine.ts
+++ b/src/engines/stt/QwenASREngine.ts
@@ -142,7 +142,7 @@ export class QwenASREngine extends SubprocessBridge implements STTEngine {
         timestamp: Date.now()
       }
     } finally {
-      try { unlinkSync(tempPath) } catch { /* ignore */ }
+      try { unlinkSync(tempPath) } catch (e) { console.warn('[qwen-asr] Failed to delete temp file:', e) }
     }
   }
 }

--- a/src/engines/translator/HunyuanMT15Translator.ts
+++ b/src/engines/translator/HunyuanMT15Translator.ts
@@ -71,7 +71,7 @@ export class HunyuanMT15Translator implements TranslatorEngine {
     await new Promise<void>((resolve, reject) => {
       const timeout = setTimeout(() => {
         this.worker?.removeListener('message', initHandler)
-        try { this.worker?.kill() } catch { /* ignore */ }
+        try { this.worker?.kill() } catch (e) { console.warn('[hy-mt1.5] Failed to kill worker on timeout:', e) }
         this.worker = null
         reject(new Error('HY-MT1.5 initialization timed out'))
       }, 5 * 60_000)

--- a/src/engines/translator/HunyuanMTTranslator.ts
+++ b/src/engines/translator/HunyuanMTTranslator.ts
@@ -71,7 +71,7 @@ export class HunyuanMTTranslator implements TranslatorEngine {
     await new Promise<void>((resolve, reject) => {
       const timeout = setTimeout(() => {
         this.worker?.removeListener('message', initHandler)
-        try { this.worker?.kill() } catch { /* ignore */ }
+        try { this.worker?.kill() } catch (e) { console.warn('[hunyuan-mt] Failed to kill worker on timeout:', e) }
         this.worker = null
         reject(new Error('Hunyuan-MT initialization timed out'))
       }, 5 * 60_000)

--- a/src/engines/translator/SLMTranslator.ts
+++ b/src/engines/translator/SLMTranslator.ts
@@ -85,7 +85,7 @@ export class SLMTranslator implements TranslatorEngine {
       const timeout = setTimeout(() => {
         this.worker?.removeListener('message', initHandler)
         // Kill orphaned worker on timeout
-        try { this.worker?.kill() } catch { /* ignore */ }
+        try { this.worker?.kill() } catch (e) { console.warn('[slm] Failed to kill worker on timeout:', e) }
         this.worker = null
         reject(new Error('TranslateGemma initialization timed out'))
       }, 5 * 60_000)

--- a/src/main/ipc-handlers.ts
+++ b/src/main/ipc-handlers.ts
@@ -119,7 +119,7 @@ export function registerIpcHandlers(ctx: AppContext): void {
         // Dispose leaked rotation provider instances on switchEngine failure
         if (rotationProviders) {
           for (const p of rotationProviders) {
-            p.engine.dispose().catch(() => {})
+            p.engine.dispose().catch((e) => console.warn('[ipc] Failed to dispose rotation provider:', e))
           }
         }
         throw err

--- a/src/renderer/components/SettingsPanel.tsx
+++ b/src/renderer/components/SettingsPanel.tsx
@@ -154,7 +154,7 @@ function SettingsPanel(): React.JSX.Element {
           setSttEngine('mlx-whisper')
         }
       })
-    }).catch(() => {})
+    }).catch((e) => console.warn('[settings] Failed to load platform/settings:', e))
 
     // Check for crashed session
     window.api.getCrashedSession().then((session) => {
@@ -167,7 +167,7 @@ function SettingsPanel(): React.JSX.Element {
 
   // Load session history
   useEffect(() => {
-    window.api.listSessions().then(setSessions).catch(() => {})
+    window.api.listSessions().then(setSessions).catch((e) => console.warn('[settings] Failed to load sessions:', e))
   }, [isRunning])
 
   // Detect GPU — fall back to OPUS-MT if no GPU


### PR DESCRIPTION
## Description

Replace silent catch blocks (`catch { /* ignore */ }` and `.catch(() => {})`) with `console.warn` logging across 9 files to aid debugging.

### Changes:
- **SubprocessBridge.ts**: 5 catch blocks — process kill and dispose operations
- **SLMTranslator.ts**: worker kill on timeout
- **HunyuanMTTranslator.ts**: worker kill on timeout
- **HunyuanMT15Translator.ts**: worker kill on timeout
- **model-downloader.ts**: 2 catch blocks — partial file cleanup
- **MlxWhisperEngine.ts**: temp file cleanup
- **QwenASREngine.ts**: temp file cleanup
- **SettingsPanel.tsx**: 2 catch blocks — settings/session loading
- **ipc-handlers.ts**: rotation provider disposal

Python detection probes (execSync import checks) are intentionally left as-is since those are expected control flow.

Closes #291