### PR TITLE
Replace any types with proper types in plugin loader and slm-worker

### DIFF
--- a/src/engines/stt/MoonshineEngine.ts
+++ b/src/engines/stt/MoonshineEngine.ts
@@ -3,6 +3,12 @@ import type { STTEngine, STTResult, Language } from '../types'
 import { getModelsDir, MOONSHINE_VARIANTS } from '../model-downloader'
 import type { MoonshineVariant } from '../model-downloader'
 
+/** Callable ASR pipeline from @huggingface/transformers */
+interface ASRPipeline {
+  (audio: Float32Array, options?: { sampling_rate?: number }): Promise<{ text: string }>
+  dispose(): Promise<void>
+}
+
 const MODELS_SUBDIR = 'moonshine'
 
 export class MoonshineEngine implements STTEngine {
@@ -10,7 +16,7 @@ export class MoonshineEngine implements STTEngine {
   readonly name = 'Moonshine AI (Fast)'
   readonly isOffline = true
 
-  private pipeline: any = null
+  private pipeline: ASRPipeline | null = null
   private initPromise: Promise<void> | null = null
   private onProgress?: (message: string) => void
   private variant: MoonshineVariant
@@ -39,7 +45,7 @@ export class MoonshineEngine implements STTEngine {
       'automatic-speech-recognition',
       config.modelId,
       { dtype: 'q8' }
-    )
+    ) as unknown as ASRPipeline
 
     this.onProgress?.(`Moonshine ${config.label} model loaded`)
   }

--- a/src/engines/translator/HunyuanMT15Translator.ts
+++ b/src/engines/translator/HunyuanMT15Translator.ts
@@ -5,6 +5,12 @@ import { getGGUFDir, downloadGGUF, getHunyuanMT15Variants } from '../model-downl
 
 const TRANSLATE_TIMEOUT_MS = 30_000
 
+/** IPC messages sent from the slm-worker back to the main process */
+type WorkerMessage =
+  | { type: 'ready' }
+  | { type: 'result'; id: string; text: string }
+  | { type: 'error'; id?: string; message: string }
+
 interface PendingRequest {
   resolve: (text: string) => void
   reject: (err: Error) => void
@@ -76,7 +82,7 @@ export class HunyuanMT15Translator implements TranslatorEngine {
         reject(new Error('HY-MT1.5 initialization timed out'))
       }, 5 * 60_000)
 
-      const initHandler = (msg: any): void => {
+      const initHandler = (msg: WorkerMessage): void => {
         if (!this.worker) return
 
         if (msg.type === 'ready') {
@@ -106,7 +112,7 @@ export class HunyuanMT15Translator implements TranslatorEngine {
 
     // Clear any leftover listeners before registering to prevent duplicates
     this.worker.removeAllListeners('message')
-    this.worker.on('message', (msg: any) => {
+    this.worker.on('message', (msg: WorkerMessage) => {
       if (msg.type === 'result' && msg.id) {
         const req = this.pending.get(msg.id)
         if (req) {

--- a/src/engines/translator/HunyuanMTTranslator.ts
+++ b/src/engines/translator/HunyuanMTTranslator.ts
@@ -5,6 +5,12 @@ import { getGGUFDir, downloadGGUF, getHunyuanMTVariants } from '../model-downloa
 
 const TRANSLATE_TIMEOUT_MS = 30_000
 
+/** IPC messages sent from the slm-worker back to the main process */
+type WorkerMessage =
+  | { type: 'ready' }
+  | { type: 'result'; id: string; text: string }
+  | { type: 'error'; id?: string; message: string }
+
 interface PendingRequest {
   resolve: (text: string) => void
   reject: (err: Error) => void
@@ -76,7 +82,7 @@ export class HunyuanMTTranslator implements TranslatorEngine {
         reject(new Error('Hunyuan-MT initialization timed out'))
       }, 5 * 60_000)
 
-      const initHandler = (msg: any): void => {
+      const initHandler = (msg: WorkerMessage): void => {
         if (!this.worker) return
 
         if (msg.type === 'ready') {
@@ -106,7 +112,7 @@ export class HunyuanMTTranslator implements TranslatorEngine {
 
     // Clear any leftover listeners before registering to prevent duplicates
     this.worker.removeAllListeners('message')
-    this.worker.on('message', (msg: any) => {
+    this.worker.on('message', (msg: WorkerMessage) => {
       if (msg.type === 'result' && msg.id) {
         const req = this.pending.get(msg.id)
         if (req) {

--- a/src/engines/translator/SLMTranslator.ts
+++ b/src/engines/translator/SLMTranslator.ts
@@ -6,6 +6,12 @@ import type { SLMModelSize } from '../model-downloader'
 
 const TRANSLATE_TIMEOUT_MS = 30_000
 
+/** IPC messages sent from the slm-worker back to the main process */
+type WorkerMessage =
+  | { type: 'ready' }
+  | { type: 'result'; id: string; text: string }
+  | { type: 'error'; id?: string; message: string }
+
 interface PendingRequest {
   resolve: (text: string) => void
   reject: (err: Error) => void
@@ -90,7 +96,7 @@ export class SLMTranslator implements TranslatorEngine {
         reject(new Error('TranslateGemma initialization timed out'))
       }, 5 * 60_000)
 
-      const initHandler = (msg: any): void => {
+      const initHandler = (msg: WorkerMessage): void => {
         // Guard: ignore messages if worker was killed during timeout (#205)
         if (!this.worker) return
 
@@ -123,7 +129,7 @@ export class SLMTranslator implements TranslatorEngine {
 
     // Clear any leftover listeners before registering to prevent duplicates (#206)
     this.worker.removeAllListeners('message')
-    this.worker.on('message', (msg: any) => {
+    this.worker.on('message', (msg: WorkerMessage) => {
       if (msg.type === 'result' && msg.id) {
         const req = this.pending.get(msg.id)
         if (req) {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -18,7 +18,7 @@ import { createMainWindow, createSubtitleWindow, registerDisplayHandlers } from 
 import { registerAudioHandlers } from './audio-handlers'
 import { registerIpcHandlers } from './ipc-handlers'
 import type { AppContext } from './app-context'
-import type { TranslationResult } from '../engines/types'
+import type { TranslationResult, STTEngine, TranslatorEngine, E2ETranslationEngine } from '../engines/types'
 import type { WhisperVariant, MoonshineVariant } from '../engines/model-downloader'
 
 // Shared mutable state
@@ -92,15 +92,19 @@ function initPipeline(): void {
     })
   ))
   // Auto-register discovered plugins (#145)
+  // Plugin factories are async (return Promise<Engine>) — the pipeline handles this
+  // via `await Promise.resolve(factory())`, so the cast to sync factory is safe at runtime.
   for (const plugin of discoverPlugins()) {
     const { manifest } = plugin
-    const factory = () => loadPluginEngine(plugin)
     if (manifest.engineType === 'stt') {
-      ctx.pipeline.registerSTT(manifest.engineId, factory as any)
+      const factory = (() => loadPluginEngine(plugin)) as unknown as () => STTEngine
+      ctx.pipeline.registerSTT(manifest.engineId, factory)
     } else if (manifest.engineType === 'translator') {
-      ctx.pipeline.registerTranslator(manifest.engineId, factory as any)
+      const factory = (() => loadPluginEngine(plugin)) as unknown as () => TranslatorEngine
+      ctx.pipeline.registerTranslator(manifest.engineId, factory)
     } else if (manifest.engineType === 'e2e') {
-      ctx.pipeline.registerE2E(manifest.engineId, factory as any)
+      const factory = (() => loadPluginEngine(plugin)) as unknown as () => E2ETranslationEngine
+      ctx.pipeline.registerE2E(manifest.engineId, factory)
     }
     console.log(`[plugin] Registered ${manifest.engineType} plugin: ${manifest.name} (${manifest.engineId})`)
   }

--- a/src/main/slm-worker.ts
+++ b/src/main/slm-worker.ts
@@ -14,15 +14,30 @@
  *   Worker → Main: { type: 'error', id?: string, message: string }
  */
 
+import type { Llama, LlamaModel, LlamaContext } from 'node-llama-cpp'
 import { LANG_NAMES_EN, LANG_NAMES_ZH } from '../engines/language-names'
 
 type ModelType = 'translategemma' | 'hunyuan-mt' | 'hunyuan-mt-15'
 
-let llama: any = null
-let model: any = null
-let context: any = null
-let draftModel: any = null
-let draftContext: any = null
+/** IPC messages sent from the main process to this worker */
+type WorkerIncomingMessage =
+  | { type: 'init'; modelPath: string; kvCacheQuant?: boolean; modelType?: ModelType; draftModelPath?: string }
+  | { type: 'translate'; id: string; text: string; from: string; to: string; context?: TranslateContextPayload }
+  | { type: 'translate-incremental'; id: string; text: string; previousOutput: string; from: string; to: string; context?: TranslateContextPayload }
+  | { type: 'summarize'; id: string; transcript: string }
+  | { type: 'dispose' }
+
+interface TranslateContextPayload {
+  previousSegments?: Array<{ source: string; translated: string; speakerId?: string }>
+  glossary?: Array<{ source: string; target: string }>
+  speakerId?: string
+}
+
+let llama: Llama | null = null
+let model: LlamaModel | null = null
+let context: LlamaContext | null = null
+let draftModel: LlamaModel | null = null
+let draftContext: LlamaContext | null = null
 let speculativeEnabled = false
 let requestQueue: Promise<void> = Promise.resolve()
 let activeModelType: ModelType = 'translategemma'
@@ -145,7 +160,7 @@ async function handleTranslate(
     const { LlamaChatSession, DraftSequenceTokenPredictor } = await import('node-llama-cpp')
 
     // Create context sequence, optionally with speculative decoding
-    let contextSequence: any
+    let contextSequence: ReturnType<LlamaContext['getSequence']>
     if (speculativeEnabled && draftContext) {
       const draftSequence = draftContext.getSequence()
       contextSequence = context.getSequence({
@@ -388,7 +403,7 @@ async function handleDispose(): Promise<void> {
 
 // Listen for messages from main process
 // Serialize translate/summarize requests to prevent concurrent context access
-process.parentPort!.on('message', (e: { data: any }) => {
+process.parentPort!.on('message', (e: { data: WorkerIncomingMessage }) => {
   const msg = e.data
 
   const handleMessage = async (): Promise<void> => {
@@ -413,7 +428,7 @@ process.parentPort!.on('message', (e: { data: any }) => {
     } catch (err) {
       process.parentPort!.postMessage({
         type: 'error',
-        id: msg.id,
+        id: 'id' in msg ? msg.id : undefined,
         message: err instanceof Error ? err.message : String(err)
       })
     }


### PR DESCRIPTION
## Summary
- Replace `any` types in `slm-worker.ts` with proper `Llama`, `LlamaModel`, `LlamaContext` imports from `node-llama-cpp` and a `WorkerIncomingMessage` discriminated union for IPC messages
- Replace `msg: any` in `SLMTranslator`, `HunyuanMTTranslator`, `HunyuanMT15Translator` init/message handlers with a `WorkerMessage` discriminated union type
- Replace `pipeline: any` in `MoonshineEngine` with a typed `ASRPipeline` interface
- Replace `factory as any` plugin casts in `index.ts` with narrowed engine type casts

## Test plan
- [x] `npm run typecheck` passes
- [x] `npm test` passes (45/45)

Closes #290