### PR TITLE
Fix benchmark/e2e tsconfig and remove report TODO

### DIFF
--- a/benchmark/src/report.ts
+++ b/benchmark/src/report.ts
@@ -45,6 +45,37 @@ function buildBreakdownTable(
   return [header, sep, ...rows].join('\n')
 }
 
+function buildGoNoGoTable(summaries: EngineSummary[]): string {
+  const LATENCY_THRESHOLD = 500
+  const MEMORY_THRESHOLD_MB = 4 * 1024
+
+  // Collect unique engine IDs preserving order
+  const engineIds = [...new Set(summaries.map((s) => s.engineId))]
+
+  // Aggregate per-engine metrics across directions
+  const engineMetrics = engineIds.map((id) => {
+    const runs = summaries.filter((s) => s.engineId === id)
+    const label = runs[0]?.engineLabel ?? id
+    const avgLatency =
+      runs.reduce((acc, r) => acc + r.latency.avg, 0) / runs.length
+    const peakRss = Math.max(...runs.map((r) => r.peakRssMB))
+    const latencyOk = avgLatency < LATENCY_THRESHOLD
+    const memoryOk = peakRss < MEMORY_THRESHOLD_MB
+    const offline = !id.includes('google')
+    return { id, label, avgLatency, peakRss, latencyOk, memoryOk, offline }
+  })
+
+  const header = `| Criteria | ${engineMetrics.map((e) => e.label).join(' | ')} |`
+  const sep = `|---|${engineMetrics.map(() => '---').join('|')}|`
+
+  const latencyRow = `| Latency acceptable (<500ms) | ${engineMetrics.map((e) => (e.latencyOk ? `Yes (${fmt(e.avgLatency)}ms)` : `No (${fmt(e.avgLatency)}ms)`)).join(' | ')} |`
+  const memoryRow = `| Memory acceptable (<4GB) | ${engineMetrics.map((e) => (e.memoryOk ? `Yes (${fmt(e.peakRss / 1024, 2)}GB)` : `No (${fmt(e.peakRss / 1024, 2)}GB)`)).join(' | ')} |`
+  const offlineRow = `| Offline capable | ${engineMetrics.map((e) => (e.offline ? 'Yes' : 'No')).join(' | ')} |`
+  const recRow = `| Recommendation | ${engineMetrics.map((e) => (e.latencyOk && e.memoryOk ? 'Go' : 'No-Go')).join(' | ')} |`
+
+  return [header, sep, latencyRow, memoryRow, offlineRow, recRow].join('\n')
+}
+
 function buildMarkdown(result: BenchmarkResult): string {
   const lines: string[] = [
     '# Translation Benchmark Results',
@@ -65,15 +96,7 @@ function buildMarkdown(result: BenchmarkResult): string {
     '',
     '## Go/No-Go Recommendation',
     '',
-    '> TODO: Fill in after reviewing results and human evaluation scores.',
-    '',
-    '| Criteria | OPUS-MT | TranslateGemma | Google |',
-    '|---|---|---|---|',
-    '| Quality (human eval avg) | | | |',
-    '| Latency acceptable (<500ms) | | | |',
-    '| Memory acceptable (<4GB) | | | |',
-    '| Offline capable | Yes | Yes | No |',
-    '| Recommendation | | | |',
+    buildGoNoGoTable(result.summaries),
     ''
   ]
   return lines.join('\n')

--- a/benchmark/tsconfig.json
+++ b/benchmark/tsconfig.json
@@ -1,16 +1,12 @@
 {
+  "extends": "../tsconfig.json",
   "compilerOptions": {
-    "target": "ESNext",
-    "module": "ESNext",
+    "target": "ES2022",
+    "module": "ES2022",
     "moduleResolution": "bundler",
-    "strict": true,
-    "esModuleInterop": true,
-    "skipLibCheck": true,
     "outDir": "dist",
     "rootDir": ".",
-    "declaration": false,
-    "resolveJsonModule": true,
-    "isolatedModules": true
+    "declaration": false
   },
   "include": ["src/**/*.ts", "run.ts"],
   "exclude": ["node_modules", "dist", "models", "results"]

--- a/e2e/tsconfig.json
+++ b/e2e/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "types": ["node"],
+    "outDir": "dist",
+    "noEmit": true
+  },
+  "include": ["**/*.ts"]
+}


### PR DESCRIPTION
## Summary
- **#299**: Updated `benchmark/tsconfig.json` to extend root config with `module: "ES2022"` and `target: "ES2022"` for `import.meta` and `Set` iteration support
- **#300**: Added `e2e/tsconfig.json` so `@playwright/test` type declarations resolve correctly
- **#301**: Replaced static TODO placeholder in `benchmark/src/report.ts` with auto-generated Go/No-Go table computed from benchmark results (latency, memory, offline capability)

Closes #299, Closes #300, Closes #301

## Test plan
- [x] `npm run typecheck` passes (only pre-existing ws-audio-server errors remain)
- [x] `npx tsc --noEmit` passes in both `benchmark/` and `e2e/` directories
- [x] `npm test` — all 45 tests pass