### PR TITLE
Add structured logging to main process and remove deprecated GGUF_VARIANTS

### DIFF
--- a/src/engines/model-downloader.ts
+++ b/src/engines/model-downloader.ts
@@ -217,9 +217,6 @@ export function getGGUFVariants(modelSize: SLMModelSize): Record<string, GGUFVar
   return modelSize === '12b' ? GGUF_VARIANTS_12B : GGUF_VARIANTS_4B
 }
 
-/** @deprecated Use getGGUFVariants() instead. Kept for backward compatibility. */
-export const GGUF_VARIANTS: Record<string, GGUFVariant> = GGUF_VARIANTS_4B
-
 // GGUF download lock uses shared activeDownloads map
 
 /** Get the GGUF models subdirectory */

--- a/src/main/audio-handlers.ts
+++ b/src/main/audio-handlers.ts
@@ -1,6 +1,9 @@
 import { ipcMain } from 'electron'
 import { sanitizeErrorMessage } from './error-utils'
+import { createLogger } from './logger'
 import type { AppContext } from './app-context'
+
+const log = createLogger('audio')
 
 /** Minimum number of samples for a valid audio chunk (0.5s at 16kHz) */
 const MIN_AUDIO_CHUNK_SAMPLES = 8000
@@ -20,7 +23,7 @@ function toFloat32Array(audioData: unknown): Float32Array | null {
       Buffer.isBuffer(audioData) ? audioData.buffer.slice(audioData.byteOffset, audioData.byteOffset + audioData.byteLength) : audioData
     )
   } else {
-    console.error('[audio] Unknown data type:', typeof audioData)
+    log.error('Unknown data type:', typeof audioData)
     return null
   }
 
@@ -60,7 +63,7 @@ export function registerAudioHandlers(ctx: AppContext): void {
     try {
       return await ctx.pipeline.process(chunk, 16000)
     } catch (err) {
-      console.error('[audio] Pipeline error:', err)
+      log.error('Pipeline error:', err)
       // #43: propagate error to renderer
       const message = sanitizeErrorMessage(err instanceof Error ? err.message : String(err))
       ctx.mainWindow?.webContents.send('status-update', `Processing error: ${message}`)
@@ -78,7 +81,7 @@ export function registerAudioHandlers(ctx: AppContext): void {
     try {
       return await ctx.pipeline.processStreaming(chunk, 16000)
     } catch (err) {
-      console.error('[audio] Streaming pipeline error:', err)
+      log.error('Streaming pipeline error:', err)
       return null
     }
   })
@@ -93,7 +96,7 @@ export function registerAudioHandlers(ctx: AppContext): void {
     try {
       return await ctx.pipeline.finalizeStreaming(chunk, 16000)
     } catch (err) {
-      console.error('[audio] Finalize streaming error:', err)
+      log.error('Finalize streaming error:', err)
       return null
     }
   })

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -17,9 +17,12 @@ import { sanitizeErrorMessage, getErrorHint } from './error-utils'
 import { createMainWindow, createSubtitleWindow, registerDisplayHandlers } from './window-manager'
 import { registerAudioHandlers } from './audio-handlers'
 import { registerIpcHandlers } from './ipc-handlers'
+import { createLogger } from './logger'
 import type { AppContext } from './app-context'
 import type { TranslationResult } from '../engines/types'
 import type { WhisperVariant, MoonshineVariant } from '../engines/model-downloader'
+
+const log = createLogger('main')
 
 // Shared mutable state
 const ctx: AppContext = {
@@ -102,7 +105,7 @@ function initPipeline(): void {
     } else if (manifest.engineType === 'e2e') {
       ctx.pipeline.registerE2E(manifest.engineId, factory as any)
     }
-    console.log(`[plugin] Registered ${manifest.engineType} plugin: ${manifest.name} (${manifest.engineId})`)
+    log.info(`Registered ${manifest.engineType} plugin: ${manifest.name} (${manifest.engineId})`)
   }
 
   // Forward results to subtitle window and logger
@@ -174,7 +177,7 @@ app.on('before-quit', (event) => {
         )
       ])
     } catch (err) {
-      console.error('[quit] Cleanup error:', err)
+      log.error('Cleanup error:', err)
     } finally {
       app.quit()
     }

--- a/src/main/ipc-handlers.ts
+++ b/src/main/ipc-handlers.ts
@@ -16,10 +16,13 @@ import * as SessionManager from '../logger/SessionManager'
 import { store } from './store'
 import type { AppSettings, SubtitleSettings } from './store'
 import { sanitizeErrorMessage } from './error-utils'
+import { createLogger } from './logger'
 import { getSubtitleHeight } from './window-manager'
 import { WsAudioServer } from './ws-audio-server'
 import type { AppContext } from './app-context'
 import type { EngineConfig } from '../engines/types'
+
+const log = createLogger('ipc')
 
 /** Monthly character limits for API rotation providers */
 const QUOTA_LIMITS = {
@@ -119,7 +122,7 @@ export function registerIpcHandlers(ctx: AppContext): void {
         // Dispose leaked rotation provider instances on switchEngine failure
         if (rotationProviders) {
           for (const p of rotationProviders) {
-            p.engine.dispose().catch((e) => console.warn('[ipc] Failed to dispose rotation provider:', e))
+            p.engine.dispose().catch((e) => log.warn('Failed to dispose rotation provider:', e))
           }
         }
         throw err
@@ -197,7 +200,7 @@ export function registerIpcHandlers(ctx: AppContext): void {
   ipcMain.on('move-subtitle-to-display', (_event, displayId: number) => {
     const display = screen.getAllDisplays().find((d) => d.id === displayId)
     if (!display) {
-      console.warn(`[display] Display ${displayId} not found, ignoring move request`)
+      log.warn(`Display ${displayId} not found, ignoring move request`)
       return
     }
     if (ctx.subtitleWindow) {
@@ -275,7 +278,7 @@ export function registerIpcHandlers(ctx: AppContext): void {
       if (config && typeof config === 'object' && config.mode) {
         return session
       }
-      console.warn('[crash-recovery] Invalid session config, discarding:', config)
+      log.warn('Invalid session config, discarding:', config)
     }
     return null
   })
@@ -423,7 +426,7 @@ export function registerIpcHandlers(ctx: AppContext): void {
         try {
           await ctx.pipeline.process(chunk, 16000)
         } catch (err) {
-          console.error('[ws-audio] Pipeline processing error:', err)
+          log.error('Pipeline processing error (ws-audio):', err)
         }
       })
 

--- a/src/main/logger.ts
+++ b/src/main/logger.ts
@@ -1,0 +1,62 @@
+/**
+ * Lightweight structured logger for the main process.
+ *
+ * Provides log levels and module prefixes without external dependencies.
+ * Renderer process should continue using console.log (goes to DevTools).
+ */
+
+export type LogLevel = 'debug' | 'info' | 'warn' | 'error'
+
+const LOG_LEVEL_ORDER: Record<LogLevel, number> = {
+  debug: 0,
+  info: 1,
+  warn: 2,
+  error: 3
+}
+
+let globalLevel: LogLevel = 'info'
+
+/** Set the minimum log level for all loggers */
+export function setLogLevel(level: LogLevel): void {
+  globalLevel = level
+}
+
+/** Get the current global log level */
+export function getLogLevel(): LogLevel {
+  return globalLevel
+}
+
+/**
+ * Create a logger with a module prefix.
+ *
+ * Usage:
+ * ```ts
+ * const log = createLogger('ws-audio')
+ * log.info('Server started on port', port)
+ * log.error('Connection failed:', err)
+ * ```
+ */
+export function createLogger(module: string) {
+  const prefix = `[${module}]`
+
+  function shouldLog(level: LogLevel): boolean {
+    return LOG_LEVEL_ORDER[level] >= LOG_LEVEL_ORDER[globalLevel]
+  }
+
+  return {
+    debug(...args: unknown[]): void {
+      if (shouldLog('debug')) console.debug(prefix, ...args)
+    },
+    info(...args: unknown[]): void {
+      if (shouldLog('info')) console.log(prefix, ...args)
+    },
+    warn(...args: unknown[]): void {
+      if (shouldLog('warn')) console.warn(prefix, ...args)
+    },
+    error(...args: unknown[]): void {
+      if (shouldLog('error')) console.error(prefix, ...args)
+    }
+  }
+}
+
+export type Logger = ReturnType<typeof createLogger>

--- a/src/main/ws-audio-server.ts
+++ b/src/main/ws-audio-server.ts
@@ -16,6 +16,9 @@
 import { createServer, type Server, type IncomingMessage } from 'http'
 import { WebSocketServer, WebSocket } from 'ws'
 import { EventEmitter } from 'events'
+import { createLogger } from './logger'
+
+const log = createLogger('ws-audio')
 
 export interface WsAudioServerEvents {
   /** Emitted when a valid audio chunk is received */
@@ -70,19 +73,19 @@ export class WsAudioServer extends EventEmitter {
         // Only allow connections from localhost
         const remoteAddr = req.socket.remoteAddress
         if (remoteAddr !== '127.0.0.1' && remoteAddr !== '::1' && remoteAddr !== '::ffff:127.0.0.1') {
-          console.warn(`[ws-audio] Rejected connection from non-localhost: ${remoteAddr}`)
+          log.warn(`Rejected connection from non-localhost: ${remoteAddr}`)
           ws.close(1008, 'Only localhost connections allowed')
           return
         }
 
         // Only allow one client at a time
         if (this.client && this.client.readyState === WebSocket.OPEN) {
-          console.warn('[ws-audio] Rejecting second client — only one extension connection allowed')
+          log.warn('Rejecting second client — only one extension connection allowed')
           ws.close(1013, 'Only one client allowed')
           return
         }
 
-        console.log('[ws-audio] Chrome extension connected')
+        log.info('Chrome extension connected')
         this.client = ws
         this.emit('connected')
 
@@ -95,7 +98,7 @@ export class WsAudioServer extends EventEmitter {
         })
 
         ws.on('close', () => {
-          console.log('[ws-audio] Chrome extension disconnected')
+          log.info('Chrome extension disconnected')
           if (this.client === ws) {
             this.client = null
           }
@@ -103,13 +106,13 @@ export class WsAudioServer extends EventEmitter {
         })
 
         ws.on('error', (err) => {
-          console.error('[ws-audio] Client error:', err)
+          log.error('Client error:', err)
           this.emit('error', err)
         })
       })
 
       this.wss.on('error', (err) => {
-        console.error('[ws-audio] Server error:', err)
+        log.error('Server error:', err)
         this.emit('error', err)
       })
 
@@ -123,7 +126,7 @@ export class WsAudioServer extends EventEmitter {
 
       this.httpServer.listen(this._port, '127.0.0.1', () => {
         this._running = true
-        console.log(`[ws-audio] Server listening on ws://127.0.0.1:${this._port}`)
+        log.info(`Server listening on ws://127.0.0.1:${this._port}`)
         resolve()
       })
     })
@@ -154,7 +157,7 @@ export class WsAudioServer extends EventEmitter {
       if (this.httpServer) {
         this.httpServer.close(() => {
           this.httpServer = null
-          console.log('[ws-audio] Server stopped')
+          log.info('Server stopped')
           resolve()
         })
       } else {
@@ -195,7 +198,7 @@ export class WsAudioServer extends EventEmitter {
       }
     }
     if (hasInvalid) {
-      console.warn('[ws-audio] Received audio data with invalid samples, discarding')
+      log.warn('Received audio data with invalid samples, discarding')
       return
     }
 
@@ -211,7 +214,7 @@ export class WsAudioServer extends EventEmitter {
 
       switch (msg.type) {
         case 'hello':
-          console.log(`[ws-audio] Client identified: ${msg.source}`)
+          log.info(`Client identified: ${msg.source}`)
           ws.send(JSON.stringify({ type: 'welcome', sampleRate: SAMPLE_RATE }))
           break
 
@@ -220,10 +223,10 @@ export class WsAudioServer extends EventEmitter {
           break
 
         default:
-          console.log(`[ws-audio] Unknown message type: ${msg.type}`)
+          log.warn(`Unknown message type: ${msg.type}`)
       }
     } catch {
-      console.warn('[ws-audio] Failed to parse text message')
+      log.warn('Failed to parse text message')
     }
   }
 }


### PR DESCRIPTION
## Description

### #302: Structured logging for main process
- Created `src/main/logger.ts` with log levels (debug, info, warn, error) and module prefixes
- Migrated all `console.log/error/warn` calls in `src/main/` to use `createLogger()`:
  - `audio-handlers.ts` — 4 instances
  - `ipc-handlers.ts` — 4 instances
  - `ws-audio-server.ts` — 11 instances
  - `index.ts` — 2 instances
- Renderer process console.log left untouched (goes to DevTools)

### #303: Remove deprecated GGUF_VARIANTS export
- Removed `GGUF_VARIANTS` (deprecated alias for `GGUF_VARIANTS_4B`) from `model-downloader.ts`
- Confirmed zero consumers — all code already uses `getGGUFVariants()`

Closes #302, Closes #303