### PR TITLE
Extract constants, bound pending maps, fix worker lifecycle, standardize log naming

### DIFF
--- a/src/engines/SubprocessBridge.ts
+++ b/src/engines/SubprocessBridge.ts
@@ -1,4 +1,11 @@
 import { spawn, type ChildProcess } from 'child_process'
+import {
+  BRIDGE_DISPOSE_GRACE_MS,
+  BRIDGE_STDERR_MAX_LINES,
+  BRIDGE_STDERR_WINDOW_MS,
+  BRIDGE_MAX_PENDING_REQUESTS,
+  BRIDGE_PENDING_TIMEOUT_MS
+} from './constants'
 
 /**
  * Spawn configuration returned by subclasses to define how the Python bridge
@@ -36,7 +43,7 @@ export type InitResult = Record<string, unknown>
 export abstract class SubprocessBridge {
   protected process: ChildProcess | null = null
   private initPromise: Promise<void> | null = null
-  private pendingRequests = new Map<number, (data: Record<string, unknown>) => void>()
+  private pendingRequests = new Map<number, { resolve: (data: Record<string, unknown>) => void; timer: ReturnType<typeof setTimeout> }>()
   private nextRequestId = 0
   private buffer = ''
   private stderrRateLimit = { count: 0, lastReset: Date.now() }
@@ -95,11 +102,11 @@ export abstract class SubprocessBridge {
     }
 
     const timer = setTimeout(() => {
-      console.error(`${prefix} Initialization timed out`)
+      console.error(`${prefix} bridge initialization timed out`)
       try {
         this.process?.kill()
       } catch (e) {
-        console.warn(`${prefix} Failed to kill process on timeout:`, e)
+        console.warn(`${prefix} bridge: failed to kill process on timeout:`, e)
       }
       this.process = null
     }, initTimeout)
@@ -115,7 +122,7 @@ export abstract class SubprocessBridge {
 
     this.process.on('error', (err) => {
       clearTimeout(timer)
-      console.error(`${prefix} Failed to start Python bridge:`, err.message)
+      console.error(`${prefix} bridge failed to start:`, err.message)
       this.process = null
     })
 
@@ -136,28 +143,30 @@ export abstract class SubprocessBridge {
 
           const reqId = msg._reqId as number | undefined
           if (reqId !== undefined && this.pendingRequests.has(reqId)) {
-            this.pendingRequests.get(reqId)!(msg)
+            const pending = this.pendingRequests.get(reqId)!
             this.pendingRequests.delete(reqId)
+            clearTimeout(pending.timer)
+            pending.resolve(msg)
           }
         } catch {
-          console.warn(`${prefix} Invalid JSON from bridge:`, line)
+          console.warn(`${prefix} bridge invalid JSON:`, line)
         }
       }
     })
 
     this.process.stderr!.on('data', (data: Buffer) => {
       const now = Date.now()
-      if (now - this.stderrRateLimit.lastReset > 5000) {
+      if (now - this.stderrRateLimit.lastReset > BRIDGE_STDERR_WINDOW_MS) {
         this.stderrRateLimit = { count: 0, lastReset: now }
       }
-      if (this.stderrRateLimit.count < 10) {
+      if (this.stderrRateLimit.count < BRIDGE_STDERR_MAX_LINES) {
         this.stderrRateLimit.count++
-        console.warn(`${prefix} stderr:`, data.toString().trim())
+        console.warn(`${prefix} bridge stderr:`, data.toString().trim())
       }
     })
 
     this.process.on('exit', (code) => {
-      console.log(`${prefix} Bridge exited with code ${code}`)
+      console.log(`${prefix} bridge exited with code ${code}`)
       this.process = null
     })
 
@@ -176,7 +185,7 @@ export abstract class SubprocessBridge {
         try {
           this.process.kill()
         } catch (e) {
-          console.warn(`${prefix} Failed to kill process during init cleanup:`, e)
+          console.warn(`${prefix} bridge: failed to kill process during init cleanup:`, e)
         }
         this.process = null
       }
@@ -188,6 +197,8 @@ export abstract class SubprocessBridge {
 
   /**
    * Send a JSON command to the bridge and wait for a response.
+   * Enforces a max pending request limit — if exceeded, the oldest request
+   * is rejected to prevent unbounded memory growth.
    * @param cmd - The command object (action + data)
    * @param timeout - Optional timeout override in ms
    */
@@ -201,6 +212,15 @@ export abstract class SubprocessBridge {
         return
       }
 
+      // Evict the oldest pending request if at capacity
+      if (this.pendingRequests.size >= BRIDGE_MAX_PENDING_REQUESTS) {
+        const oldestKey = this.pendingRequests.keys().next().value!
+        const oldest = this.pendingRequests.get(oldestKey)!
+        this.pendingRequests.delete(oldestKey)
+        clearTimeout(oldest.timer)
+        oldest.resolve({ error: 'Evicted: pending request limit exceeded' })
+      }
+
       const reqId = this.nextRequestId++ % 0xffffff
 
       const timeoutMs = timeout ?? this.getCommandTimeout()
@@ -209,10 +229,10 @@ export abstract class SubprocessBridge {
         reject(new Error('Bridge command timed out'))
       }, timeoutMs)
 
-      this.pendingRequests.set(reqId, (data) => {
+      this.pendingRequests.set(reqId, { resolve: (data) => {
         clearTimeout(timer)
         resolve(data)
-      })
+      }, timer })
 
       const written = this.process.stdin.write(
         JSON.stringify({ ...cmd, _reqId: reqId }) + '\n'
@@ -232,28 +252,29 @@ export abstract class SubprocessBridge {
 
   async dispose(): Promise<void> {
     const prefix = this.getLogPrefix()
-    console.log(`${prefix} Disposing resources`)
+    console.log(`${prefix} bridge disposing resources`)
     if (this.process) {
       try {
         this.sendCommand({ action: 'dispose' }).catch((e) => {
-          console.warn(`${prefix} Failed to send dispose command:`, e)
+          console.warn(`${prefix} bridge: failed to send dispose command:`, e)
         })
         await new Promise((resolve) => setTimeout(resolve, 500))
       } catch (e) {
-        console.warn(`${prefix} Error during dispose command:`, e)
+        console.warn(`${prefix} bridge: error during dispose command:`, e)
       }
       try {
         this.process.kill()
       } catch (e) {
-        console.warn(`${prefix} Failed to kill process during dispose:`, e)
+        console.warn(`${prefix} bridge: failed to kill process during dispose:`, e)
       }
       this.process = null
     }
     // Snapshot pending requests to avoid concurrent modification
     const pending = Array.from(this.pendingRequests.values())
     this.pendingRequests.clear()
-    for (const resolve of pending) {
-      resolve({ error: 'Engine disposed' })
+    for (const entry of pending) {
+      clearTimeout(entry.timer)
+      entry.resolve({ error: 'Engine disposed' })
     }
     this.initPromise = null
   }

--- a/src/engines/constants.ts
+++ b/src/engines/constants.ts
@@ -1,0 +1,86 @@
+/**
+ * Shared timeout and limit constants for engine subsystems.
+ *
+ * Centralizes magic numbers previously scattered across SubprocessBridge,
+ * SLM translators, and STT engines so they can be tuned in one place.
+ */
+
+// ---------------------------------------------------------------------------
+// SubprocessBridge (Python bridge processes)
+// ---------------------------------------------------------------------------
+
+/** How long to wait for the dispose command before force-killing the bridge (ms) */
+export const BRIDGE_DISPOSE_GRACE_MS = 500
+
+/** Max stderr lines forwarded per rate-limit window */
+export const BRIDGE_STDERR_MAX_LINES = 10
+
+/** Rate-limit window for stderr forwarding (ms) */
+export const BRIDGE_STDERR_WINDOW_MS = 5_000
+
+/** Upper bound on pending requests in SubprocessBridge before oldest is evicted */
+export const BRIDGE_MAX_PENDING_REQUESTS = 100
+
+/** Auto-timeout for orphaned pending requests in SubprocessBridge (ms) */
+export const BRIDGE_PENDING_TIMEOUT_MS = 120_000
+
+// ---------------------------------------------------------------------------
+// UtilityProcess workers (SLM / Hunyuan translators)
+// ---------------------------------------------------------------------------
+
+/** Timeout for a single SLM translation request (ms) */
+export const WORKER_TRANSLATE_TIMEOUT_MS = 30_000
+
+/** Timeout for SLM meeting summarization (ms) */
+export const WORKER_SUMMARIZE_TIMEOUT_MS = 120_000
+
+/** Timeout for SLM / Hunyuan model initialization (ms) */
+export const WORKER_INIT_TIMEOUT_MS = 5 * 60_000
+
+/** Grace period after sending dispose to the worker before force-killing (ms) */
+export const WORKER_DISPOSE_GRACE_MS = 1_000
+
+/** Upper bound on pending requests in UtilityProcess workers before oldest is rejected */
+export const WORKER_MAX_PENDING_REQUESTS = 50
+
+// ---------------------------------------------------------------------------
+// CTranslate2 bridges (OPUS-MT, Madlad-400)
+// ---------------------------------------------------------------------------
+
+/** Command timeout for CT2 OPUS-MT translation (ms) */
+export const CT2_OPUS_MT_TRANSLATE_TIMEOUT_MS = 15_000
+
+/** Init timeout for CT2 OPUS-MT bridge (ms) */
+export const CT2_OPUS_MT_INIT_TIMEOUT_MS = 120_000
+
+/** Command timeout for CT2 Madlad-400 translation (ms) */
+export const CT2_MADLAD400_TRANSLATE_TIMEOUT_MS = 15_000
+
+/** Init timeout for CT2 Madlad-400 bridge (ms) */
+export const CT2_MADLAD400_INIT_TIMEOUT_MS = 180_000
+
+// ---------------------------------------------------------------------------
+// STT bridges (mlx-whisper, Qwen-ASR)
+// ---------------------------------------------------------------------------
+
+/** Command timeout for mlx-whisper transcription (ms) */
+export const MLX_WHISPER_TRANSCRIBE_TIMEOUT_MS = 30_000
+
+/** Init timeout for mlx-whisper bridge (ms) */
+export const MLX_WHISPER_INIT_TIMEOUT_MS = 60_000
+
+/** Command timeout for Qwen-ASR transcription (ms) */
+export const QWEN_ASR_TRANSCRIBE_TIMEOUT_MS = 30_000
+
+/** Init timeout for Qwen-ASR bridge (ms) */
+export const QWEN_ASR_INIT_TIMEOUT_MS = 120_000
+
+// ---------------------------------------------------------------------------
+// ANE translator
+// ---------------------------------------------------------------------------
+
+/** Command timeout for ANE translation (ms) */
+export const ANE_TRANSLATE_TIMEOUT_MS = 30_000
+
+/** Init timeout for ANE bridge — first-run CoreML conversion can be slow (ms) */
+export const ANE_INIT_TIMEOUT_MS = 600_000

--- a/src/engines/stt/MlxWhisperEngine.ts
+++ b/src/engines/stt/MlxWhisperEngine.ts
@@ -5,9 +5,7 @@ import { tmpdir, homedir } from 'os'
 import type { STTEngine, STTResult, Language } from '../types'
 import { ALL_LANGUAGES } from '../types'
 import { SubprocessBridge, type SpawnConfig, type InitResult } from '../SubprocessBridge'
-
-const TRANSCRIBE_TIMEOUT_MS = 30_000
-const INIT_TIMEOUT_MS = 60_000
+import { MLX_WHISPER_TRANSCRIBE_TIMEOUT_MS, MLX_WHISPER_INIT_TIMEOUT_MS } from '../constants'
 
 export class MlxWhisperEngine extends SubprocessBridge implements STTEngine {
   readonly id = 'mlx-whisper'
@@ -31,11 +29,11 @@ export class MlxWhisperEngine extends SubprocessBridge implements STTEngine {
   }
 
   protected getInitTimeout(): number {
-    return INIT_TIMEOUT_MS
+    return MLX_WHISPER_INIT_TIMEOUT_MS
   }
 
   protected getCommandTimeout(): number {
-    return TRANSCRIBE_TIMEOUT_MS
+    return MLX_WHISPER_TRANSCRIBE_TIMEOUT_MS
   }
 
   protected getSpawnConfig(): SpawnConfig {

--- a/src/engines/stt/QwenASREngine.ts
+++ b/src/engines/stt/QwenASREngine.ts
@@ -5,9 +5,7 @@ import { tmpdir, homedir } from 'os'
 import type { STTEngine, STTResult, Language } from '../types'
 import { ALL_LANGUAGES } from '../types'
 import { SubprocessBridge, type SpawnConfig, type InitResult } from '../SubprocessBridge'
-
-const TRANSCRIBE_TIMEOUT_MS = 30_000
-const INIT_TIMEOUT_MS = 120_000
+import { QWEN_ASR_TRANSCRIBE_TIMEOUT_MS, QWEN_ASR_INIT_TIMEOUT_MS } from '../constants'
 
 /** Qwen3-ASR model variant */
 export type QwenASRVariant = '0.6b' | '1.7b'
@@ -69,11 +67,11 @@ export class QwenASREngine extends SubprocessBridge implements STTEngine {
   }
 
   protected getInitTimeout(): number {
-    return INIT_TIMEOUT_MS
+    return QWEN_ASR_INIT_TIMEOUT_MS
   }
 
   protected getCommandTimeout(): number {
-    return TRANSCRIBE_TIMEOUT_MS
+    return QWEN_ASR_TRANSCRIBE_TIMEOUT_MS
   }
 
   protected getSpawnConfig(): SpawnConfig {

--- a/src/engines/translator/ANETranslator.ts
+++ b/src/engines/translator/ANETranslator.ts
@@ -1,9 +1,7 @@
 import { join } from 'path'
 import type { TranslatorEngine, Language, TranslateContext } from '../types'
 import { SubprocessBridge, type SpawnConfig, type InitResult } from '../SubprocessBridge'
-
-const TRANSLATE_TIMEOUT_MS = 30_000
-const INIT_TIMEOUT_MS = 600_000 // 10 min — first-run CoreML conversion can be slow
+import { ANE_TRANSLATE_TIMEOUT_MS, ANE_INIT_TIMEOUT_MS } from '../constants'
 
 /**
  * ANEMLL Apple Neural Engine translator (#241).
@@ -39,11 +37,11 @@ export class ANETranslator extends SubprocessBridge implements TranslatorEngine 
   }
 
   protected getInitTimeout(): number {
-    return INIT_TIMEOUT_MS
+    return ANE_INIT_TIMEOUT_MS
   }
 
   protected getCommandTimeout(): number {
-    return TRANSLATE_TIMEOUT_MS
+    return ANE_TRANSLATE_TIMEOUT_MS
   }
 
   protected getSpawnConfig(): SpawnConfig {

--- a/src/engines/translator/CT2Madlad400Translator.ts
+++ b/src/engines/translator/CT2Madlad400Translator.ts
@@ -1,9 +1,7 @@
 import { join } from 'path'
 import type { TranslatorEngine, Language, TranslateContext } from '../types'
 import { SubprocessBridge, type SpawnConfig, type InitResult } from '../SubprocessBridge'
-
-const TRANSLATE_TIMEOUT_MS = 15_000
-const INIT_TIMEOUT_MS = 180_000
+import { CT2_MADLAD400_TRANSLATE_TIMEOUT_MS, CT2_MADLAD400_INIT_TIMEOUT_MS } from '../constants'
 
 /**
  * CTranslate2-accelerated Madlad-400 translator (#262).
@@ -32,11 +30,11 @@ export class CT2Madlad400Translator extends SubprocessBridge implements Translat
   }
 
   protected getInitTimeout(): number {
-    return INIT_TIMEOUT_MS
+    return CT2_MADLAD400_INIT_TIMEOUT_MS
   }
 
   protected getCommandTimeout(): number {
-    return TRANSLATE_TIMEOUT_MS
+    return CT2_MADLAD400_TRANSLATE_TIMEOUT_MS
   }
 
   protected getSpawnConfig(): SpawnConfig {

--- a/src/engines/translator/CT2OpusMTTranslator.ts
+++ b/src/engines/translator/CT2OpusMTTranslator.ts
@@ -1,9 +1,7 @@
 import { join } from 'path'
 import type { TranslatorEngine, Language, TranslateContext } from '../types'
 import { SubprocessBridge, type SpawnConfig, type InitResult } from '../SubprocessBridge'
-
-const TRANSLATE_TIMEOUT_MS = 15_000
-const INIT_TIMEOUT_MS = 120_000
+import { CT2_OPUS_MT_TRANSLATE_TIMEOUT_MS, CT2_OPUS_MT_INIT_TIMEOUT_MS } from '../constants'
 
 /**
  * CTranslate2-accelerated OPUS-MT translator (#242).
@@ -32,11 +30,11 @@ export class CT2OpusMTTranslator extends SubprocessBridge implements TranslatorE
   }
 
   protected getInitTimeout(): number {
-    return INIT_TIMEOUT_MS
+    return CT2_OPUS_MT_INIT_TIMEOUT_MS
   }
 
   protected getCommandTimeout(): number {
-    return TRANSLATE_TIMEOUT_MS
+    return CT2_OPUS_MT_TRANSLATE_TIMEOUT_MS
   }
 
   protected getSpawnConfig(): SpawnConfig {

--- a/src/engines/translator/HunyuanMT15Translator.ts
+++ b/src/engines/translator/HunyuanMT15Translator.ts
@@ -2,8 +2,12 @@ import { utilityProcess } from 'electron'
 import { join } from 'path'
 import type { TranslatorEngine, Language, TranslateContext } from '../types'
 import { getGGUFDir, downloadGGUF, getHunyuanMT15Variants } from '../model-downloader'
-
-const TRANSLATE_TIMEOUT_MS = 30_000
+import {
+  WORKER_TRANSLATE_TIMEOUT_MS,
+  WORKER_INIT_TIMEOUT_MS,
+  WORKER_DISPOSE_GRACE_MS,
+  WORKER_MAX_PENDING_REQUESTS
+} from '../constants'
 
 interface PendingRequest {
   resolve: (text: string) => void
@@ -58,7 +62,7 @@ export class HunyuanMT15Translator implements TranslatorEngine {
     this.worker = utilityProcess.fork(workerPath)
 
     this.worker.on('exit', (code) => {
-      console.log(`[hunyuan-mt-15] Worker exited with code ${code}`)
+      console.log(`[hunyuan-mt-15-worker] Worker exited with code ${code}`)
       this.worker = null
       for (const [id, req] of this.pending) {
         clearTimeout(req.timer)
@@ -71,10 +75,10 @@ export class HunyuanMT15Translator implements TranslatorEngine {
     await new Promise<void>((resolve, reject) => {
       const timeout = setTimeout(() => {
         this.worker?.removeListener('message', initHandler)
-        try { this.worker?.kill() } catch (e) { console.warn('[hy-mt1.5] Failed to kill worker on timeout:', e) }
+        try { this.worker?.kill() } catch (e) { console.warn('[hunyuan-mt-15-worker] Failed to kill worker on timeout:', e) }
         this.worker = null
         reject(new Error('HY-MT1.5 initialization timed out'))
-      }, 5 * 60_000)
+      }, WORKER_INIT_TIMEOUT_MS)
 
       const initHandler = (msg: any): void => {
         if (!this.worker) return
@@ -126,25 +130,37 @@ export class HunyuanMT15Translator implements TranslatorEngine {
         return
       }
       if (msg.type === 'error') {
-        console.error('[hunyuan-mt-15] Worker error:', msg.message)
+        console.error('[hunyuan-mt-15-worker] Worker error:', msg.message)
       }
     })
+  }
+
+  /** Evict the oldest pending request if the map is at capacity */
+  private evictOldestPending(): void {
+    if (this.pending.size >= WORKER_MAX_PENDING_REQUESTS) {
+      const oldestKey = this.pending.keys().next().value!
+      const oldest = this.pending.get(oldestKey)!
+      this.pending.delete(oldestKey)
+      clearTimeout(oldest.timer)
+      oldest.reject(new Error('Evicted: worker pending request limit exceeded'))
+    }
   }
 
   async translate(text: string, from: Language, to: Language, context?: TranslateContext): Promise<string> {
     if (!text.trim()) return ''
     if (from === to) return text
     if (!this.worker) {
-      throw new Error('[hunyuan-mt-15] Not initialized')
+      throw new Error('[hunyuan-mt-15-worker] Not initialized')
     }
 
     const id = String(this.nextId++)
 
     return new Promise<string>((resolve, reject) => {
+      this.evictOldestPending()
       const timer = setTimeout(() => {
         this.pending.delete(id)
         reject(new Error('HY-MT1.5 translation timed out'))
-      }, TRANSLATE_TIMEOUT_MS)
+      }, WORKER_TRANSLATE_TIMEOUT_MS)
 
       this.pending.set(id, { resolve, reject, timer })
       this.worker!.postMessage({ type: 'translate', id, text, from, to, context })
@@ -161,16 +177,17 @@ export class HunyuanMT15Translator implements TranslatorEngine {
     if (!text.trim()) return previousOutput || ''
     if (from === to) return text
     if (!this.worker) {
-      throw new Error('[hunyuan-mt-15] Not initialized')
+      throw new Error('[hunyuan-mt-15-worker] Not initialized')
     }
 
     const id = String(this.nextId++)
 
     return new Promise<string>((resolve, reject) => {
+      this.evictOldestPending()
       const timer = setTimeout(() => {
         this.pending.delete(id)
         reject(new Error('HY-MT1.5 incremental translation timed out'))
-      }, TRANSLATE_TIMEOUT_MS)
+      }, WORKER_TRANSLATE_TIMEOUT_MS)
 
       this.pending.set(id, { resolve, reject, timer })
       this.worker!.postMessage({
@@ -187,11 +204,20 @@ export class HunyuanMT15Translator implements TranslatorEngine {
 
   async dispose(): Promise<void> {
     if (this.worker) {
-      // Remove all listeners before killing to prevent exit handler from firing
+      // Remove all listeners before sending dispose to prevent exit handler from firing
       this.worker.removeAllListeners()
       try {
-        this.worker.postMessage({ type: 'dispose' })
-        await new Promise((resolve) => setTimeout(resolve, 1000))
+        // Wait for the worker to confirm disposal or fall back to timeout
+        await new Promise<void>((resolve) => {
+          const timeout = setTimeout(resolve, WORKER_DISPOSE_GRACE_MS)
+          this.worker!.on('message', (msg: any) => {
+            if (msg.type === 'disposed') {
+              clearTimeout(timeout)
+              resolve()
+            }
+          })
+          this.worker!.postMessage({ type: 'dispose' })
+        })
       } catch {
         // Ignore errors during disposal
       }

--- a/src/engines/translator/HunyuanMTTranslator.ts
+++ b/src/engines/translator/HunyuanMTTranslator.ts
@@ -2,8 +2,12 @@ import { utilityProcess } from 'electron'
 import { join } from 'path'
 import type { TranslatorEngine, Language, TranslateContext } from '../types'
 import { getGGUFDir, downloadGGUF, getHunyuanMTVariants } from '../model-downloader'
-
-const TRANSLATE_TIMEOUT_MS = 30_000
+import {
+  WORKER_TRANSLATE_TIMEOUT_MS,
+  WORKER_INIT_TIMEOUT_MS,
+  WORKER_DISPOSE_GRACE_MS,
+  WORKER_MAX_PENDING_REQUESTS
+} from '../constants'
 
 interface PendingRequest {
   resolve: (text: string) => void
@@ -58,7 +62,7 @@ export class HunyuanMTTranslator implements TranslatorEngine {
     this.worker = utilityProcess.fork(workerPath)
 
     this.worker.on('exit', (code) => {
-      console.log(`[hunyuan-mt] Worker exited with code ${code}`)
+      console.log(`[hunyuan-mt-worker] Worker exited with code ${code}`)
       this.worker = null
       for (const [id, req] of this.pending) {
         clearTimeout(req.timer)
@@ -71,10 +75,10 @@ export class HunyuanMTTranslator implements TranslatorEngine {
     await new Promise<void>((resolve, reject) => {
       const timeout = setTimeout(() => {
         this.worker?.removeListener('message', initHandler)
-        try { this.worker?.kill() } catch (e) { console.warn('[hunyuan-mt] Failed to kill worker on timeout:', e) }
+        try { this.worker?.kill() } catch (e) { console.warn('[hunyuan-mt-worker] Failed to kill worker on timeout:', e) }
         this.worker = null
         reject(new Error('Hunyuan-MT initialization timed out'))
-      }, 5 * 60_000)
+      }, WORKER_INIT_TIMEOUT_MS)
 
       const initHandler = (msg: any): void => {
         if (!this.worker) return
@@ -126,25 +130,37 @@ export class HunyuanMTTranslator implements TranslatorEngine {
         return
       }
       if (msg.type === 'error') {
-        console.error('[hunyuan-mt] Worker error:', msg.message)
+        console.error('[hunyuan-mt-worker] Worker error:', msg.message)
       }
     })
+  }
+
+  /** Evict the oldest pending request if the map is at capacity */
+  private evictOldestPending(): void {
+    if (this.pending.size >= WORKER_MAX_PENDING_REQUESTS) {
+      const oldestKey = this.pending.keys().next().value!
+      const oldest = this.pending.get(oldestKey)!
+      this.pending.delete(oldestKey)
+      clearTimeout(oldest.timer)
+      oldest.reject(new Error('Evicted: worker pending request limit exceeded'))
+    }
   }
 
   async translate(text: string, from: Language, to: Language, context?: TranslateContext): Promise<string> {
     if (!text.trim()) return ''
     if (from === to) return text
     if (!this.worker) {
-      throw new Error('[hunyuan-mt] Not initialized')
+      throw new Error('[hunyuan-mt-worker] Not initialized')
     }
 
     const id = String(this.nextId++)
 
     return new Promise<string>((resolve, reject) => {
+      this.evictOldestPending()
       const timer = setTimeout(() => {
         this.pending.delete(id)
         reject(new Error('Hunyuan-MT translation timed out'))
-      }, TRANSLATE_TIMEOUT_MS)
+      }, WORKER_TRANSLATE_TIMEOUT_MS)
 
       this.pending.set(id, { resolve, reject, timer })
       this.worker!.postMessage({ type: 'translate', id, text, from, to, context })
@@ -161,16 +177,17 @@ export class HunyuanMTTranslator implements TranslatorEngine {
     if (!text.trim()) return previousOutput || ''
     if (from === to) return text
     if (!this.worker) {
-      throw new Error('[hunyuan-mt] Not initialized')
+      throw new Error('[hunyuan-mt-worker] Not initialized')
     }
 
     const id = String(this.nextId++)
 
     return new Promise<string>((resolve, reject) => {
+      this.evictOldestPending()
       const timer = setTimeout(() => {
         this.pending.delete(id)
         reject(new Error('Hunyuan-MT incremental translation timed out'))
-      }, TRANSLATE_TIMEOUT_MS)
+      }, WORKER_TRANSLATE_TIMEOUT_MS)
 
       this.pending.set(id, { resolve, reject, timer })
       this.worker!.postMessage({
@@ -187,11 +204,20 @@ export class HunyuanMTTranslator implements TranslatorEngine {
 
   async dispose(): Promise<void> {
     if (this.worker) {
-      // Remove all listeners before killing to prevent exit handler from firing
+      // Remove all listeners before sending dispose to prevent exit handler from firing
       this.worker.removeAllListeners()
       try {
-        this.worker.postMessage({ type: 'dispose' })
-        await new Promise((resolve) => setTimeout(resolve, 1000))
+        // Wait for the worker to confirm disposal or fall back to timeout
+        await new Promise<void>((resolve) => {
+          const timeout = setTimeout(resolve, WORKER_DISPOSE_GRACE_MS)
+          this.worker!.on('message', (msg: any) => {
+            if (msg.type === 'disposed') {
+              clearTimeout(timeout)
+              resolve()
+            }
+          })
+          this.worker!.postMessage({ type: 'dispose' })
+        })
       } catch {
         // Ignore errors during disposal
       }

--- a/src/engines/translator/SLMTranslator.ts
+++ b/src/engines/translator/SLMTranslator.ts
@@ -3,8 +3,13 @@ import { join } from 'path'
 import type { TranslatorEngine, Language, TranslateContext } from '../types'
 import { getGGUFDir, downloadGGUF, getGGUFVariants, isGGUFDownloaded } from '../model-downloader'
 import type { SLMModelSize } from '../model-downloader'
-
-const TRANSLATE_TIMEOUT_MS = 30_000
+import {
+  WORKER_TRANSLATE_TIMEOUT_MS,
+  WORKER_SUMMARIZE_TIMEOUT_MS,
+  WORKER_INIT_TIMEOUT_MS,
+  WORKER_DISPOSE_GRACE_MS,
+  WORKER_MAX_PENDING_REQUESTS
+} from '../constants'
 
 interface PendingRequest {
   resolve: (text: string) => void
@@ -71,7 +76,7 @@ export class SLMTranslator implements TranslatorEngine {
     this.worker = utilityProcess.fork(workerPath)
 
     this.worker.on('exit', (code) => {
-      console.log(`[slm-translator] Worker exited with code ${code}`)
+      console.log(`[slm-worker] Worker exited with code ${code}`)
       this.worker = null
       for (const [id, req] of this.pending) {
         clearTimeout(req.timer)
@@ -85,10 +90,10 @@ export class SLMTranslator implements TranslatorEngine {
       const timeout = setTimeout(() => {
         this.worker?.removeListener('message', initHandler)
         // Kill orphaned worker on timeout
-        try { this.worker?.kill() } catch (e) { console.warn('[slm] Failed to kill worker on timeout:', e) }
+        try { this.worker?.kill() } catch (e) { console.warn('[slm-worker] Failed to kill worker on timeout:', e) }
         this.worker = null
         reject(new Error('TranslateGemma initialization timed out'))
-      }, 5 * 60_000)
+      }, WORKER_INIT_TIMEOUT_MS)
 
       const initHandler = (msg: any): void => {
         // Guard: ignore messages if worker was killed during timeout (#205)
@@ -143,25 +148,37 @@ export class SLMTranslator implements TranslatorEngine {
         return
       }
       if (msg.type === 'error') {
-        console.error('[slm-translator] Worker error:', msg.message)
+        console.error('[slm-worker] Worker error:', msg.message)
       }
     })
+  }
+
+  /** Evict the oldest pending request if the map is at capacity */
+  private evictOldestPending(): void {
+    if (this.pending.size >= WORKER_MAX_PENDING_REQUESTS) {
+      const oldestKey = this.pending.keys().next().value!
+      const oldest = this.pending.get(oldestKey)!
+      this.pending.delete(oldestKey)
+      clearTimeout(oldest.timer)
+      oldest.reject(new Error('Evicted: worker pending request limit exceeded'))
+    }
   }
 
   async translate(text: string, from: Language, to: Language, context?: TranslateContext): Promise<string> {
     if (!text.trim()) return ''
     if (from === to) return text
     if (!this.worker) {
-      throw new Error('[slm-translator] Not initialized')
+      throw new Error('[slm-worker] Not initialized')
     }
 
     const id = String(this.nextId++)
 
     return new Promise<string>((resolve, reject) => {
+      this.evictOldestPending()
       const timer = setTimeout(() => {
         this.pending.delete(id)
         reject(new Error('TranslateGemma translation timed out'))
-      }, TRANSLATE_TIMEOUT_MS)
+      }, WORKER_TRANSLATE_TIMEOUT_MS)
 
       this.pending.set(id, { resolve, reject, timer })
       this.worker!.postMessage({ type: 'translate', id, text, from, to, context })
@@ -178,16 +195,17 @@ export class SLMTranslator implements TranslatorEngine {
     if (!text.trim()) return previousOutput || ''
     if (from === to) return text
     if (!this.worker) {
-      throw new Error('[slm-translator] Not initialized')
+      throw new Error('[slm-worker] Not initialized')
     }
 
     const id = String(this.nextId++)
 
     return new Promise<string>((resolve, reject) => {
+      this.evictOldestPending()
       const timer = setTimeout(() => {
         this.pending.delete(id)
         reject(new Error('TranslateGemma incremental translation timed out'))
-      }, TRANSLATE_TIMEOUT_MS)
+      }, WORKER_TRANSLATE_TIMEOUT_MS)
 
       this.pending.set(id, { resolve, reject, timer })
       this.worker!.postMessage({
@@ -204,17 +222,16 @@ export class SLMTranslator implements TranslatorEngine {
 
   async summarize(transcript: string): Promise<string> {
     if (!this.worker) {
-      throw new Error('[slm-translator] Not initialized')
+      throw new Error('[slm-worker] Not initialized')
     }
 
     const id = String(this.nextId++)
-    const SUMMARIZE_TIMEOUT_MS = 120_000 // 2 minutes for summarization
-
     return new Promise<string>((resolve, reject) => {
+      this.evictOldestPending()
       const timer = setTimeout(() => {
         this.pending.delete(id)
         reject(new Error('Summarization timed out'))
-      }, SUMMARIZE_TIMEOUT_MS)
+      }, WORKER_SUMMARIZE_TIMEOUT_MS)
 
       this.pending.set(id, { resolve, reject, timer })
       this.worker!.postMessage({ type: 'summarize', id, transcript })
@@ -223,12 +240,20 @@ export class SLMTranslator implements TranslatorEngine {
 
   async dispose(): Promise<void> {
     if (this.worker) {
-      // Remove all listeners before killing to prevent exit handler from firing
+      // Remove all listeners before sending dispose to prevent exit handler from firing
       this.worker.removeAllListeners()
       try {
-        this.worker.postMessage({ type: 'dispose' })
-        // Give worker time to clean up
-        await new Promise((resolve) => setTimeout(resolve, 1000))
+        // Wait for the worker to confirm disposal or fall back to timeout
+        await new Promise<void>((resolve) => {
+          const timeout = setTimeout(resolve, WORKER_DISPOSE_GRACE_MS)
+          this.worker!.on('message', (msg: any) => {
+            if (msg.type === 'disposed') {
+              clearTimeout(timeout)
+              resolve()
+            }
+          })
+          this.worker!.postMessage({ type: 'dispose' })
+        })
       } catch {
         // Ignore errors during disposal
       }

--- a/src/main/slm-worker.ts
+++ b/src/main/slm-worker.ts
@@ -382,7 +382,7 @@ async function handleDispose(): Promise<void> {
       llama = null
     }
   } finally {
-    process.exit(0)
+    process.parentPort!.postMessage({ type: 'disposed' })
   }
 }
 


### PR DESCRIPTION
## Summary

- **#304**: Extract magic timeout constants to named exports in `src/engines/constants.ts`. All engine files now import from the shared constants module instead of defining local duplicates.
- **#305**: Add `WORKER_MAX_PENDING_REQUESTS` bound and oldest-request eviction to SLMTranslator, HunyuanMTTranslator, and HunyuanMT15Translator pending maps (matching SubprocessBridge pattern).
- **#306**: Replace `process.exit(0)` in slm-worker `handleDispose()` with `postMessage({ type: 'disposed' })`. All three translator dispose methods now wait for the `disposed` message (with timeout fallback) before killing the worker.
- **#307**: Standardize log prefixes: "bridge" for Python subprocess messages in SubprocessBridge, "worker" for UtilityProcess messages in SLM/Hunyuan translators. Fixed inconsistent `[hy-mt1.5]` prefix.

Closes #304, Closes #305, Closes #306, Closes #307

## Test plan

- [x] `npm run typecheck` passes (only pre-existing ws-audio-server errors)
- [x] `npm test` — all 45 tests pass
- [ ] Manual: verify translation pipeline works with each engine type
- [ ] Manual: verify dispose/cleanup works without orphaned processes