### PR TITLE
Add macOS code signing and notarization infrastructure

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,16 @@ jobs:
 
       - run: npm ci
 
-      - run: npm run package:dmg
+      - name: Build and package DMG
+        env:
+          # Code signing: base64-encoded .p12 certificate
+          CSC_LINK: ${{ secrets.CSC_LINK }}
+          CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
+          # Notarization: Apple ID + app-specific password
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+        run: npm run package:dmg
 
       - name: Upload DMG artifact
         uses: actions/upload-artifact@v4

--- a/build/entitlements.mac.inherit.plist
+++ b/build/entitlements.mac.inherit.plist
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>com.apple.security.cs.allow-jit</key>
+    <true/>
+    <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+    <true/>
+    <key>com.apple.security.cs.disable-library-validation</key>
+    <true/>
+</dict>
+</plist>

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -20,8 +20,11 @@ mac:
     - target: dir
       arch:
         - arm64
-  identity: null
-  entitlementsInherit: build/entitlements.mac.plist
+  hardenedRuntime: true
+  gatekeeperAssess: false
+  entitlements: build/entitlements.mac.plist
+  entitlementsInherit: build/entitlements.mac.inherit.plist
+  notarize: true
   extendInfo:
     NSMicrophoneUsageDescription: "live-translate needs microphone access for real-time speech recognition and translation."
 win:


### PR DESCRIPTION
## Summary
- Configure electron-builder for code signing: hardened runtime, entitlements, and built-in notarization via `notarize: true`
- Add separate `entitlements.mac.inherit.plist` for helper/child processes (no mic access needed)
- Update `build.yml` workflow to pass signing and notarization secrets as env vars (`CSC_LINK`, `CSC_KEY_PASSWORD`, `APPLE_ID`, `APPLE_APP_SPECIFIC_PASSWORD`, `APPLE_TEAM_ID`)

## Setup Required
To enable signing, add these GitHub Actions secrets:

| Secret | Description |
|---|---|
| `CSC_LINK` | Base64-encoded `.p12` Developer ID Application certificate |
| `CSC_KEY_PASSWORD` | Password for the `.p12` file |
| `APPLE_ID` | Apple ID email for notarization |
| `APPLE_APP_SPECIFIC_PASSWORD` | App-specific password from appleid.apple.com |
| `APPLE_TEAM_ID` | Apple Developer Team ID |

Without these secrets, electron-builder gracefully skips signing (no CI breakage).

## Test plan
- [ ] Verify CI workflow passes without signing secrets (unsigned build)
- [ ] Add secrets and verify signed + notarized DMG is produced
- [ ] Install signed DMG on clean macOS — no Gatekeeper bypass needed

Closes #309