### PR TITLE
Add SenseVoice STT engine for faster CJK recognition

### DIFF
--- a/resources/sensevoice-bridge.py
+++ b/resources/sensevoice-bridge.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+"""
+Python subprocess bridge for SenseVoice STT (FunASR).
+Communicates with the Electron main process via JSON-over-stdio.
+
+Protocol:
+  Input (one per line):
+    {"action": "init", "model": "FunAudioLLM/SenseVoiceSmall"}
+    {"action": "transcribe", "audio_path": "/tmp/audio.wav", "sample_rate": 16000}
+    {"action": "dispose"}
+  Output (one per line):
+    {"ready": true, "model": "..."}
+    {"text": "...", "language": "ja", "emotion": "happy"}
+    {"error": "..."}
+"""
+import sys
+import json
+
+model_instance = None
+
+# SenseVoice language tokens to ISO 639-1 mapping
+LANG_MAP = {
+    "zh": "zh",
+    "en": "en",
+    "ja": "ja",
+    "ko": "ko",
+    "yue": "zh",  # Cantonese -> Chinese
+    "nospeech": "",
+}
+
+_current_req_id = None
+
+
+def output(data):
+    if _current_req_id is not None:
+        data["_reqId"] = _current_req_id
+    print(json.dumps(data, ensure_ascii=False), flush=True)
+
+
+def init_model(model_name="FunAudioLLM/SenseVoiceSmall"):
+    global model_instance
+    try:
+        from funasr import AutoModel
+
+        output({"status": "Loading SenseVoice model..."})
+
+        # Determine device: prefer MPS on macOS, then CUDA, then CPU
+        device = "cpu"
+        try:
+            import torch
+            if torch.backends.mps.is_available():
+                device = "mps"
+            elif torch.cuda.is_available():
+                device = "cuda:0"
+        except Exception:
+            pass
+
+        model_instance = AutoModel(
+            model=model_name,
+            trust_remote_code=True,
+            vad_model="fsmn-vad",
+            vad_kwargs={"max_single_segment_time": 30000},
+            device=device,
+            hub="hf",
+        )
+
+        output({"ready": True, "model": model_name, "device": device})
+    except ImportError:
+        output({"error": "funasr not installed. Run: pip install funasr"})
+    except Exception as e:
+        output({"error": f"Failed to initialize SenseVoice: {e}"})
+
+
+def transcribe(audio_path, sample_rate=16000):
+    global model_instance
+    if model_instance is None:
+        output({"error": "Model not initialized"})
+        return
+
+    try:
+        from funasr.utils.postprocess_utils import rich_transcription_postprocess
+
+        res = model_instance.generate(
+            input=audio_path,
+            cache={},
+            language="auto",
+            use_itn=True,
+            batch_size_s=60,
+            merge_vad=True,
+            merge_length_s=15,
+        )
+
+        if not res or len(res) == 0:
+            output({"text": "", "language": "en"})
+            return
+
+        raw_text = res[0].get("text", "")
+
+        # Extract language from the raw output tags (e.g. <|ja|>, <|en|>)
+        detected_lang = "en"
+        for token, iso_code in LANG_MAP.items():
+            if f"<|{token}|>" in raw_text:
+                detected_lang = iso_code if iso_code else "en"
+                break
+
+        # Extract emotion tag if present (e.g. <|HAPPY|>, <|SAD|>, <|ANGRY|>, <|NEUTRAL|>)
+        emotion = None
+        for emo_tag in ["HAPPY", "SAD", "ANGRY", "NEUTRAL"]:
+            if f"<|{emo_tag}|>" in raw_text:
+                emotion = emo_tag.lower()
+                break
+
+        # Clean up the text using FunASR's postprocessing
+        text = rich_transcription_postprocess(raw_text)
+
+        result = {"text": text.strip(), "language": detected_lang}
+        if emotion:
+            result["emotion"] = emotion
+
+        output(result)
+    except Exception as e:
+        output({"error": f"Transcription failed: {e}"})
+
+
+def main():
+    global _current_req_id
+    for line in sys.stdin:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            msg = json.loads(line)
+            _current_req_id = msg.get("_reqId")
+            action = msg.get("action")
+
+            if action == "init":
+                init_model(msg.get("model", "FunAudioLLM/SenseVoiceSmall"))
+            elif action == "transcribe":
+                transcribe(msg["audio_path"], msg.get("sample_rate", 16000))
+            elif action == "dispose":
+                output({"disposed": True})
+                sys.exit(0)
+            else:
+                output({"error": f"Unknown action: {action}"})
+        except json.JSONDecodeError:
+            _current_req_id = None
+            output({"error": "Invalid JSON"})
+        except Exception as e:
+            output({"error": str(e)})
+        finally:
+            _current_req_id = None
+
+
+if __name__ == "__main__":
+    main()

--- a/src/engines/constants.ts
+++ b/src/engines/constants.ts
@@ -75,6 +75,12 @@ export const QWEN_ASR_TRANSCRIBE_TIMEOUT_MS = 30_000
 /** Init timeout for Qwen-ASR bridge (ms) */
 export const QWEN_ASR_INIT_TIMEOUT_MS = 120_000
 
+/** Command timeout for SenseVoice transcription (ms) */
+export const SENSEVOICE_TRANSCRIBE_TIMEOUT_MS = 30_000
+
+/** Init timeout for SenseVoice bridge — model download on first run can be slow (ms) */
+export const SENSEVOICE_INIT_TIMEOUT_MS = 180_000
+
 // ---------------------------------------------------------------------------
 // ANE translator
 // ---------------------------------------------------------------------------

--- a/src/engines/stt/SenseVoiceEngine.ts
+++ b/src/engines/stt/SenseVoiceEngine.ts
@@ -1,0 +1,177 @@
+import { execSync } from 'child_process'
+import { join } from 'path'
+import { writeFileSync, unlinkSync, existsSync } from 'fs'
+import { tmpdir, homedir } from 'os'
+import type { STTEngine, STTResult, Language } from '../types'
+import { ALL_LANGUAGES } from '../types'
+import { SubprocessBridge, type SpawnConfig, type InitResult } from '../SubprocessBridge'
+import { SENSEVOICE_TRANSCRIBE_TIMEOUT_MS, SENSEVOICE_INIT_TIMEOUT_MS } from '../constants'
+
+/**
+ * SenseVoice STT engine using FunASR Python subprocess bridge.
+ * SenseVoice-Small achieves up to 15x faster inference than Whisper
+ * with strong accuracy on CJK languages (JA/EN/ZH/KO).
+ * Also provides emotion recognition and audio event detection.
+ *
+ * Requires: python3 with `funasr` package installed.
+ */
+export class SenseVoiceEngine extends SubprocessBridge implements STTEngine {
+  readonly id = 'sensevoice'
+  readonly name = 'SenseVoice (CJK-optimized, fast)'
+  readonly isOffline = true
+
+  private model: string
+  private onProgress?: (message: string) => void
+
+  constructor(options?: {
+    model?: string
+    onProgress?: (message: string) => void
+  }) {
+    super()
+    this.model = options?.model ?? 'FunAudioLLM/SenseVoiceSmall'
+    this.onProgress = options?.onProgress
+  }
+
+  protected getLogPrefix(): string {
+    return '[sensevoice]'
+  }
+
+  protected getInitTimeout(): number {
+    return SENSEVOICE_INIT_TIMEOUT_MS
+  }
+
+  protected getCommandTimeout(): number {
+    return SENSEVOICE_TRANSCRIBE_TIMEOUT_MS
+  }
+
+  protected override onStatusMessage(status: string): void {
+    this.onProgress?.(status)
+  }
+
+  protected getSpawnConfig(): SpawnConfig {
+    this.onProgress?.('Starting SenseVoice bridge...')
+    const python3 = findPython3WithFunASR()
+    this.onProgress?.(`Using Python: ${python3}`)
+    return {
+      command: python3,
+      args: [join(__dirname, '../../resources/sensevoice-bridge.py')],
+      initMessage: {
+        action: 'init',
+        model: this.model
+      }
+    }
+  }
+
+  protected getSpawnError(): Error {
+    return new Error(
+      'Python 3 with funasr not found. Create a venv and install: ' +
+      'python3 -m venv ~/sensevoice-env && ~/sensevoice-env/bin/pip install funasr torch torchaudio'
+    )
+  }
+
+  protected onInitComplete(result: InitResult): void {
+    const device = result.device ? ` on ${result.device}` : ''
+    this.onProgress?.(`SenseVoice ready${device}`)
+  }
+
+  async processAudio(audioChunk: Float32Array, sampleRate: number): Promise<STTResult | null> {
+    if (!this.process) return null
+
+    const tempPath = join(tmpdir(), `sensevoice-${Date.now()}.wav`)
+    try {
+      writeWav(tempPath, audioChunk, sampleRate)
+
+      let result: Record<string, unknown>
+      try {
+        result = await this.sendCommand({
+          action: 'transcribe',
+          audio_path: tempPath,
+          sample_rate: sampleRate
+        })
+      } catch (err) {
+        console.error('[sensevoice] Bridge error:', err instanceof Error ? err.message : err)
+        return null
+      }
+
+      if (result.error) {
+        console.error('[sensevoice] Transcription error:', result.error)
+        return null
+      }
+
+      if (!result.text || !(result.text as string).trim()) return null
+
+      const detectedLang = result.language as string | undefined
+      const language: Language = (detectedLang && ALL_LANGUAGES.includes(detectedLang as Language))
+        ? (detectedLang as Language)
+        : 'en'
+
+      return {
+        text: (result.text as string).trim(),
+        language,
+        isFinal: true,
+        timestamp: Date.now()
+      }
+    } finally {
+      try { unlinkSync(tempPath) } catch (e) { console.warn('[sensevoice] Failed to delete temp file:', e) }
+    }
+  }
+}
+
+/** Find a python3 binary that has funasr installed */
+function findPython3WithFunASR(): string {
+  const venvPaths = [
+    join(homedir(), 'sensevoice-env', 'bin', 'python3'),
+    join(homedir(), 'funasr-env', 'bin', 'python3'),
+    join(homedir(), 'mlx-env', 'bin', 'python3'),
+    join(homedir(), '.venv', 'bin', 'python3'),
+    join(homedir(), 'venv', 'bin', 'python3')
+  ]
+
+  for (const p of venvPaths) {
+    if (!existsSync(p)) continue
+    try {
+      execSync(`${p} -c "import funasr"`, { stdio: 'ignore', timeout: 5000 })
+      return p
+    } catch { /* funasr not installed in this venv */ }
+  }
+
+  // Fall back to system python3
+  try {
+    execSync('python3 -c "import funasr"', { stdio: 'ignore', timeout: 5000 })
+    return 'python3'
+  } catch { /* not available */ }
+
+  throw new Error('funasr not found')
+}
+
+/** Write Float32Array as a minimal WAV file */
+function writeWav(path: string, samples: Float32Array, sampleRate: number): void {
+  const numChannels = 1
+  const bitsPerSample = 16
+  const bytesPerSample = bitsPerSample / 8
+  const dataSize = samples.length * bytesPerSample
+  const buffer = Buffer.alloc(44 + dataSize)
+
+  // WAV header
+  buffer.write('RIFF', 0)
+  buffer.writeUInt32LE(36 + dataSize, 4)
+  buffer.write('WAVE', 8)
+  buffer.write('fmt ', 12)
+  buffer.writeUInt32LE(16, 16) // chunk size
+  buffer.writeUInt16LE(1, 20) // PCM
+  buffer.writeUInt16LE(numChannels, 22)
+  buffer.writeUInt32LE(sampleRate, 24)
+  buffer.writeUInt32LE(sampleRate * numChannels * bytesPerSample, 28)
+  buffer.writeUInt16LE(numChannels * bytesPerSample, 32)
+  buffer.writeUInt16LE(bitsPerSample, 34)
+  buffer.write('data', 36)
+  buffer.writeUInt32LE(dataSize, 40)
+
+  // Convert Float32 [-1, 1] to Int16
+  for (let i = 0; i < samples.length; i++) {
+    const s = Math.max(-1, Math.min(1, samples[i]))
+    buffer.writeInt16LE(Math.round(s * 32767), 44 + i * 2)
+  }
+
+  writeFileSync(path, buffer)
+}

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -3,6 +3,7 @@ import { TranslationPipeline } from '../pipeline/TranslationPipeline'
 import { WhisperLocalEngine } from '../engines/stt/WhisperLocalEngine'
 import { MlxWhisperEngine } from '../engines/stt/MlxWhisperEngine'
 import { MoonshineEngine } from '../engines/stt/MoonshineEngine'
+import { SenseVoiceEngine } from '../engines/stt/SenseVoiceEngine'
 import { OpusMTTranslator } from '../engines/translator/OpusMTTranslator'
 import { CT2OpusMTTranslator } from '../engines/translator/CT2OpusMTTranslator'
 import { CT2Madlad400Translator } from '../engines/translator/CT2Madlad400Translator'
@@ -50,6 +51,9 @@ function initPipeline(): void {
   ctx.pipeline.registerSTT('moonshine', () => new MoonshineEngine({
     onProgress: (msg) => ctx.mainWindow?.webContents.send('status-update', msg),
     variant: (store.get('moonshineVariant') as MoonshineVariant) || undefined
+  }))
+  ctx.pipeline.registerSTT('sensevoice', () => new SenseVoiceEngine({
+    onProgress: (msg) => ctx.mainWindow?.webContents.send('status-update', msg)
   }))
 
   // Register translator engines

--- a/src/renderer/components/SettingsPanel.tsx
+++ b/src/renderer/components/SettingsPanel.tsx
@@ -500,6 +500,7 @@ function SettingsPanel(): React.JSX.Element {
           ? 'Whisper (large-v3-turbo)'
           : 'Whisper (kotoba-v2.0)'
       case 'moonshine': return 'Moonshine AI'
+      case 'sensevoice': return 'SenseVoice (CJK-optimized)'
       default: return sttEngine
     }
   }

--- a/src/renderer/components/settings/STTSettings.tsx
+++ b/src/renderer/components/settings/STTSettings.tsx
@@ -38,6 +38,7 @@ export function STTSettings({
           <option value="mlx-whisper">mlx-whisper (Apple Silicon, faster)</option>
         )}
         <option value="moonshine">Moonshine AI (ultra-fast, experimental)</option>
+        <option value="sensevoice">SenseVoice (CJK-optimized, 15x faster)</option>
       </select>
       {sttEngine === 'whisper-local' && (
         <div style={{ marginTop: '8px' }}>
@@ -78,6 +79,14 @@ export function STTSettings({
           </select>
           <div style={{ marginTop: '4px', fontSize: '11px', color: '#f59e0b' }}>
             English-focused. Japanese/CJK accuracy is unverified — switch to Whisper if results are poor.
+          </div>
+        </div>
+      )}
+      {sttEngine === 'sensevoice' && (
+        <div style={{ marginTop: '8px' }}>
+          <div style={{ marginTop: '4px', fontSize: '11px', color: '#94a3b8' }}>
+            SenseVoice-Small: 15x faster than Whisper with strong CJK accuracy. Supports 50+ languages with emotion detection.
+            Requires: <code style={{ color: '#7dd3fc' }}>pip install funasr torch torchaudio</code>
           </div>
         </div>
       )}

--- a/src/renderer/components/settings/shared.ts
+++ b/src/renderer/components/settings/shared.ts
@@ -27,7 +27,7 @@ export const ALL_LANGUAGES = Object.keys(LANGUAGE_LABELS) as Language[]
 
 export type EngineMode = 'auto' | 'rotation' | 'online' | 'online-deepl' | 'online-gemini' | 'offline-opus' | 'offline-ct2-opus' | 'offline-madlad-400' | 'offline-slm' | 'offline-hunyuan-mt' | 'offline-hunyuan-mt-15' | 'offline-ane' | 'offline-hybrid'
 
-export type SttEngineType = 'whisper-local' | 'mlx-whisper' | 'moonshine'
+export type SttEngineType = 'whisper-local' | 'mlx-whisper' | 'moonshine' | 'sensevoice'
 export type WhisperVariantType = 'kotoba-v2.0' | 'large-v3-turbo'
 export type MoonshineVariantType = 'tiny' | 'base'
 export type SlmModelSizeType = '4b' | '12b'


### PR DESCRIPTION
## Summary
- Add SenseVoice (FunASR) as a new STT engine option, optimized for CJK languages with up to 15x faster inference than Whisper
- Implements `SenseVoiceEngine` extending `SubprocessBridge` with a Python bridge (`sensevoice-bridge.py`) using FunASR's `AutoModel` API
- Registers engine in pipeline factory and adds UI option in Settings Panel with install instructions
- Supports auto language detection (50+ languages), emotion recognition, and MPS/CUDA/CPU device selection

## Test plan
- [x] `npm run typecheck` passes (pre-existing ws-audio-server errors only)
- [x] `npm test` passes (45/45 tests)
- [ ] Manual: select SenseVoice in STT dropdown, verify bridge spawns with `funasr` installed
- [ ] Manual: test JA/EN audio transcription accuracy and latency vs Whisper
- [ ] Manual: verify emotion tag extraction in bridge output

Closes #310