### PR TITLE
Add Lightning Whisper MLX engine for 10x faster STT

### DIFF
--- a/resources/lightning-whisper-bridge.py
+++ b/resources/lightning-whisper-bridge.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+"""
+Python subprocess bridge for Lightning Whisper MLX STT.
+Uses lightning-whisper-mlx for ~10x faster inference on Apple Silicon,
+with automatic fallback to standard mlx-whisper if lightning variant is unavailable.
+
+Protocol:
+  Input (one per line): JSON {"action": "transcribe", "audio_path": "/tmp/audio.wav", "sample_rate": 16000}
+  Input: {"action": "init", "model": "distil-large-v3", "batch_size": 12, "quant": null}
+  Input: {"action": "dispose"}
+  Output: JSON {"text": "...", "language": "ja"} or {"error": "..."}
+"""
+import sys
+import json
+
+# Supported language codes matching the TypeScript Language type
+SUPPORTED_LANGUAGES = {
+    "ja", "en", "zh", "ko", "fr", "de", "es", "pt",
+    "ru", "it", "nl", "pl", "ar", "th", "vi", "id"
+}
+
+whisper = None
+fallback_model = None
+using_fallback = False
+
+_current_req_id = None
+
+
+def output(data):
+    if _current_req_id is not None:
+        data["_reqId"] = _current_req_id
+    print(json.dumps(data), flush=True)
+
+
+def init_model(model="distil-large-v3", batch_size=12, quant=None):
+    global whisper, fallback_model, using_fallback
+
+    # Try lightning-whisper-mlx first
+    try:
+        from lightning_whisper_mlx import LightningWhisperMLX
+        whisper = LightningWhisperMLX(model=model, batch_size=batch_size, quant=quant)
+        using_fallback = False
+        output({"ready": True, "model": model, "engine": "lightning-whisper-mlx"})
+        return
+    except ImportError:
+        output({"status": "lightning-whisper-mlx not found, trying mlx-whisper fallback..."})
+    except Exception as e:
+        output({"status": f"lightning-whisper-mlx init failed ({e}), trying fallback..."})
+
+    # Fallback to standard mlx-whisper
+    try:
+        import mlx_whisper
+        # Map lightning model names to mlx-whisper HF repo names
+        model_map = {
+            "tiny": "mlx-community/whisper-tiny",
+            "base": "mlx-community/whisper-base",
+            "small": "mlx-community/whisper-small",
+            "medium": "mlx-community/whisper-medium",
+            "large": "mlx-community/whisper-large",
+            "large-v2": "mlx-community/whisper-large-v2-mlx",
+            "large-v3": "mlx-community/whisper-large-v3-mlx",
+            "large-v3-turbo": "mlx-community/whisper-large-v3-turbo",
+            "distil-small.en": "mlx-community/distil-whisper-small.en",
+            "distil-medium.en": "mlx-community/distil-whisper-medium.en",
+            "distil-large-v2": "mlx-community/distil-whisper-large-v2",
+            "distil-large-v3": "mlx-community/distil-whisper-large-v3",
+        }
+        fallback_model = model_map.get(model, "mlx-community/whisper-large-v3-turbo")
+        using_fallback = True
+        output({"ready": True, "model": fallback_model, "engine": "mlx-whisper-fallback"})
+    except ImportError:
+        output({"error": "Neither lightning-whisper-mlx nor mlx-whisper installed. Run: pip install lightning-whisper-mlx"})
+
+
+def transcribe(audio_path, sample_rate=16000):
+    global whisper, fallback_model, using_fallback
+
+    if not using_fallback and whisper is None:
+        output({"error": "Model not initialized"})
+        return
+    if using_fallback and fallback_model is None:
+        output({"error": "Model not initialized"})
+        return
+
+    try:
+        if not using_fallback:
+            # Lightning Whisper MLX path
+            result = whisper.transcribe(audio_path=audio_path)
+        else:
+            # Standard mlx-whisper fallback
+            import mlx_whisper
+            result = mlx_whisper.transcribe(
+                audio_path,
+                path_or_hf_repo=fallback_model,
+                language=None,
+            )
+
+        text = result.get("text", "").strip()
+        language = result.get("language", "en")
+
+        # Normalize language code to supported set
+        lang = language if language in SUPPORTED_LANGUAGES else "en"
+
+        output({"text": text, "language": lang})
+    except Exception as e:
+        output({"error": str(e)})
+
+
+def main():
+    global _current_req_id
+    for line in sys.stdin:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            msg = json.loads(line)
+            _current_req_id = msg.get("_reqId")
+            action = msg.get("action")
+
+            if action == "init":
+                init_model(
+                    model=msg.get("model", "distil-large-v3"),
+                    batch_size=msg.get("batch_size", 12),
+                    quant=msg.get("quant"),
+                )
+            elif action == "transcribe":
+                transcribe(msg["audio_path"], msg.get("sample_rate", 16000))
+            elif action == "dispose":
+                output({"disposed": True})
+                sys.exit(0)
+            else:
+                output({"error": f"Unknown action: {action}"})
+        except json.JSONDecodeError:
+            _current_req_id = None
+            output({"error": "Invalid JSON"})
+        except Exception as e:
+            output({"error": str(e)})
+        finally:
+            _current_req_id = None
+
+
+if __name__ == "__main__":
+    main()

--- a/src/engines/constants.ts
+++ b/src/engines/constants.ts
@@ -60,8 +60,14 @@ export const CT2_MADLAD400_TRANSLATE_TIMEOUT_MS = 15_000
 export const CT2_MADLAD400_INIT_TIMEOUT_MS = 180_000
 
 // ---------------------------------------------------------------------------
-// STT bridges (mlx-whisper, Qwen-ASR)
+// STT bridges (mlx-whisper, Lightning Whisper MLX, Qwen-ASR)
 // ---------------------------------------------------------------------------
+
+/** Command timeout for Lightning Whisper MLX transcription (ms) */
+export const LIGHTNING_WHISPER_TRANSCRIBE_TIMEOUT_MS = 30_000
+
+/** Init timeout for Lightning Whisper MLX bridge — model download on first use (ms) */
+export const LIGHTNING_WHISPER_INIT_TIMEOUT_MS = 120_000
 
 /** Command timeout for mlx-whisper transcription (ms) */
 export const MLX_WHISPER_TRANSCRIBE_TIMEOUT_MS = 30_000

--- a/src/engines/stt/LightningWhisperEngine.ts
+++ b/src/engines/stt/LightningWhisperEngine.ts
@@ -1,0 +1,203 @@
+import { execSync } from 'child_process'
+import { join } from 'path'
+import { writeFileSync, unlinkSync, existsSync } from 'fs'
+import { tmpdir, homedir } from 'os'
+import type { STTEngine, STTResult, Language } from '../types'
+import { ALL_LANGUAGES } from '../types'
+import { SubprocessBridge, type SpawnConfig, type InitResult } from '../SubprocessBridge'
+import { LIGHTNING_WHISPER_TRANSCRIBE_TIMEOUT_MS, LIGHTNING_WHISPER_INIT_TIMEOUT_MS } from '../constants'
+
+/** Lightning Whisper MLX model variants */
+export type LightningWhisperModel =
+  | 'tiny' | 'base' | 'small' | 'medium'
+  | 'distil-small.en' | 'distil-medium.en'
+  | 'large' | 'large-v2' | 'large-v3'
+  | 'distil-large-v2' | 'distil-large-v3'
+
+/** Quantization options for Lightning Whisper MLX */
+export type LightningWhisperQuant = null | '4bit' | '8bit'
+
+export class LightningWhisperEngine extends SubprocessBridge implements STTEngine {
+  readonly id = 'lightning-whisper'
+  readonly name = 'Lightning Whisper MLX (Apple Silicon, 10x faster)'
+  readonly isOffline = true
+
+  private model: LightningWhisperModel
+  private batchSize: number
+  private quant: LightningWhisperQuant
+  private onProgress?: (message: string) => void
+
+  constructor(options?: {
+    model?: LightningWhisperModel
+    batchSize?: number
+    quant?: LightningWhisperQuant
+    onProgress?: (message: string) => void
+  }) {
+    super()
+    this.model = options?.model ?? 'distil-large-v3'
+    this.batchSize = options?.batchSize ?? 12
+    this.quant = options?.quant ?? null
+    this.onProgress = options?.onProgress
+  }
+
+  protected getLogPrefix(): string {
+    return '[lightning-whisper]'
+  }
+
+  protected getInitTimeout(): number {
+    return LIGHTNING_WHISPER_INIT_TIMEOUT_MS
+  }
+
+  protected getCommandTimeout(): number {
+    return LIGHTNING_WHISPER_TRANSCRIBE_TIMEOUT_MS
+  }
+
+  protected getSpawnConfig(): SpawnConfig {
+    this.onProgress?.('Starting Lightning Whisper MLX bridge...')
+    const python3 = findPython3WithLightningWhisper()
+    this.onProgress?.(`Using Python: ${python3}`)
+    return {
+      command: python3,
+      args: [join(__dirname, '../../resources/lightning-whisper-bridge.py')],
+      initMessage: {
+        action: 'init',
+        model: this.model,
+        batch_size: this.batchSize,
+        quant: this.quant
+      }
+    }
+  }
+
+  protected getSpawnError(): Error {
+    return new Error(
+      'Python 3 with lightning-whisper-mlx not found. Create a venv and install: python3 -m venv ~/mlx-env && ~/mlx-env/bin/pip install lightning-whisper-mlx'
+    )
+  }
+
+  protected onInitComplete(result: InitResult): void {
+    const engine = result.engine as string | undefined
+    if (engine === 'mlx-whisper-fallback') {
+      this.onProgress?.('Lightning Whisper MLX unavailable, using mlx-whisper fallback')
+    } else {
+      this.onProgress?.('Lightning Whisper MLX ready')
+    }
+  }
+
+  protected onStatusMessage(status: string): void {
+    this.onProgress?.(status)
+  }
+
+  async processAudio(audioChunk: Float32Array, sampleRate: number): Promise<STTResult | null> {
+    if (!this.process) return null
+
+    const tempPath = join(tmpdir(), `lightning-whisper-${Date.now()}.wav`)
+    try {
+      writeWav(tempPath, audioChunk, sampleRate)
+
+      let result: Record<string, unknown>
+      try {
+        result = await this.sendCommand({
+          action: 'transcribe',
+          audio_path: tempPath,
+          sample_rate: sampleRate
+        })
+      } catch (err) {
+        // Timeout or bridge error — return null per interface contract
+        console.error('[lightning-whisper] Bridge error:', err instanceof Error ? err.message : err)
+        return null
+      }
+
+      if (result.error) {
+        console.error('[lightning-whisper] Transcription error:', result.error)
+        return null
+      }
+
+      if (!result.text || !(result.text as string).trim()) return null
+
+      return {
+        text: result.text as string,
+        language: (ALL_LANGUAGES.includes(result.language as Language) ? result.language : 'en') as Language,
+        isFinal: true,
+        timestamp: Date.now()
+      }
+    } finally {
+      try { unlinkSync(tempPath) } catch (e) { console.warn('[lightning-whisper] Failed to delete temp file:', e) }
+    }
+  }
+}
+
+/**
+ * Find a python3 binary that has lightning_whisper_mlx or mlx_whisper installed.
+ * Prefers lightning_whisper_mlx but accepts mlx_whisper as fallback
+ * (the bridge handles the fallback logic).
+ */
+function findPython3WithLightningWhisper(): string {
+  const venvPaths = [
+    join(homedir(), 'mlx-env', 'bin', 'python3'),
+    join(homedir(), '.venv', 'bin', 'python3'),
+    join(homedir(), 'venv', 'bin', 'python3')
+  ]
+
+  // First pass: look for lightning_whisper_mlx
+  for (const p of venvPaths) {
+    if (!existsSync(p)) continue
+    try {
+      execSync(`${p} -c "import lightning_whisper_mlx"`, { stdio: 'ignore', timeout: 5000 })
+      return p
+    } catch { /* not installed in this venv */ }
+  }
+
+  // System python3 with lightning_whisper_mlx
+  try {
+    execSync('python3 -c "import lightning_whisper_mlx"', { stdio: 'ignore', timeout: 5000 })
+    return 'python3'
+  } catch { /* not available */ }
+
+  // Second pass: accept mlx_whisper as fallback
+  for (const p of venvPaths) {
+    if (!existsSync(p)) continue
+    try {
+      execSync(`${p} -c "import mlx_whisper"`, { stdio: 'ignore', timeout: 5000 })
+      return p
+    } catch { /* not installed in this venv */ }
+  }
+
+  try {
+    execSync('python3 -c "import mlx_whisper"', { stdio: 'ignore', timeout: 5000 })
+    return 'python3'
+  } catch { /* not available */ }
+
+  throw new Error('Neither lightning-whisper-mlx nor mlx-whisper found')
+}
+
+/** Write Float32Array as a minimal WAV file */
+function writeWav(path: string, samples: Float32Array, sampleRate: number): void {
+  const numChannels = 1
+  const bitsPerSample = 16
+  const bytesPerSample = bitsPerSample / 8
+  const dataSize = samples.length * bytesPerSample
+  const buffer = Buffer.alloc(44 + dataSize)
+
+  // WAV header
+  buffer.write('RIFF', 0)
+  buffer.writeUInt32LE(36 + dataSize, 4)
+  buffer.write('WAVE', 8)
+  buffer.write('fmt ', 12)
+  buffer.writeUInt32LE(16, 16) // chunk size
+  buffer.writeUInt16LE(1, 20) // PCM
+  buffer.writeUInt16LE(numChannels, 22)
+  buffer.writeUInt32LE(sampleRate, 24)
+  buffer.writeUInt32LE(sampleRate * numChannels * bytesPerSample, 28)
+  buffer.writeUInt16LE(numChannels * bytesPerSample, 32)
+  buffer.writeUInt16LE(bitsPerSample, 34)
+  buffer.write('data', 36)
+  buffer.writeUInt32LE(dataSize, 40)
+
+  // Convert Float32 [-1, 1] to Int16
+  for (let i = 0; i < samples.length; i++) {
+    const s = Math.max(-1, Math.min(1, samples[i]))
+    buffer.writeInt16LE(Math.round(s * 32767), 44 + i * 2)
+  }
+
+  writeFileSync(path, buffer)
+}

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -2,6 +2,7 @@ import { app } from 'electron'
 import { TranslationPipeline } from '../pipeline/TranslationPipeline'
 import { WhisperLocalEngine } from '../engines/stt/WhisperLocalEngine'
 import { MlxWhisperEngine } from '../engines/stt/MlxWhisperEngine'
+import { LightningWhisperEngine } from '../engines/stt/LightningWhisperEngine'
 import { MoonshineEngine } from '../engines/stt/MoonshineEngine'
 import { OpusMTTranslator } from '../engines/translator/OpusMTTranslator'
 import { CT2OpusMTTranslator } from '../engines/translator/CT2OpusMTTranslator'
@@ -44,6 +45,9 @@ function initPipeline(): void {
   // mlx-whisper is Apple Silicon only — skip registration on other platforms
   if (process.platform === 'darwin') {
     ctx.pipeline.registerSTT('mlx-whisper', () => new MlxWhisperEngine({
+      onProgress: (msg) => ctx.mainWindow?.webContents.send('status-update', msg)
+    }))
+    ctx.pipeline.registerSTT('lightning-whisper', () => new LightningWhisperEngine({
       onProgress: (msg) => ctx.mainWindow?.webContents.send('status-update', msg)
     }))
   }

--- a/src/renderer/components/SettingsPanel.tsx
+++ b/src/renderer/components/SettingsPanel.tsx
@@ -151,7 +151,7 @@ function SettingsPanel(): React.JSX.Element {
       // Only set default if no saved setting exists
       window.api.getSettings().then((s) => {
         if (!s.sttEngine && p === 'darwin') {
-          setSttEngine('mlx-whisper')
+          setSttEngine('lightning-whisper')
         }
       })
     }).catch((e) => console.warn('[settings] Failed to load platform/settings:', e))
@@ -494,6 +494,7 @@ function SettingsPanel(): React.JSX.Element {
 
   const sttDisplayName = (): string => {
     switch (sttEngine) {
+      case 'lightning-whisper': return 'Lightning Whisper MLX (10x faster)'
       case 'mlx-whisper': return 'mlx-whisper (Apple Silicon)'
       case 'whisper-local':
         return whisperVariant === 'large-v3-turbo'

--- a/src/renderer/components/settings/STTSettings.tsx
+++ b/src/renderer/components/settings/STTSettings.tsx
@@ -35,7 +35,10 @@ export function STTSettings({
       >
         <option value="whisper-local">Whisper (whisper.cpp)</option>
         {platform === 'darwin' && (
-          <option value="mlx-whisper">mlx-whisper (Apple Silicon, faster)</option>
+          <option value="lightning-whisper">Lightning Whisper MLX (Apple Silicon, 10x faster)</option>
+        )}
+        {platform === 'darwin' && (
+          <option value="mlx-whisper">mlx-whisper (Apple Silicon)</option>
         )}
         <option value="moonshine">Moonshine AI (ultra-fast, experimental)</option>
       </select>

--- a/src/renderer/components/settings/shared.ts
+++ b/src/renderer/components/settings/shared.ts
@@ -27,7 +27,7 @@ export const ALL_LANGUAGES = Object.keys(LANGUAGE_LABELS) as Language[]
 
 export type EngineMode = 'auto' | 'rotation' | 'online' | 'online-deepl' | 'online-gemini' | 'offline-opus' | 'offline-ct2-opus' | 'offline-madlad-400' | 'offline-slm' | 'offline-hunyuan-mt' | 'offline-hunyuan-mt-15' | 'offline-ane' | 'offline-hybrid'
 
-export type SttEngineType = 'whisper-local' | 'mlx-whisper' | 'moonshine'
+export type SttEngineType = 'whisper-local' | 'mlx-whisper' | 'lightning-whisper' | 'moonshine'
 export type WhisperVariantType = 'kotoba-v2.0' | 'large-v3-turbo'
 export type MoonshineVariantType = 'tiny' | 'base'
 export type SlmModelSizeType = '4b' | '12b'


### PR DESCRIPTION
## Summary
- Add new `LightningWhisperEngine` STT engine using lightning-whisper-mlx for ~10x faster inference on Apple Silicon
- Python bridge (`lightning-whisper-bridge.py`) with automatic fallback to standard mlx-whisper if lightning variant is unavailable
- Supports all model variants (tiny through large-v3) with optional 4bit/8bit quantization
- Default STT engine on macOS changed from mlx-whisper to lightning-whisper
- Full language detection support with normalization to supported language codes

## Test plan
- [ ] Verify typecheck passes (pre-existing `ws` module errors excluded)
- [ ] Verify all 45 unit tests pass
- [ ] Manual test: install `lightning-whisper-mlx` in venv, select Lightning Whisper in settings, verify transcription works
- [ ] Manual test: without `lightning-whisper-mlx` installed but with `mlx-whisper`, verify fallback works
- [ ] Manual test: verify model download on first launch
- [ ] Benchmark latency on M1/M2/M3 chips vs standard mlx-whisper

Closes #308