### PR TITLE
Add Lightning Whisper MLX engine for 10x faster STT

### DIFF
--- a/resources/lightning-whisper-bridge.py
+++ b/resources/lightning-whisper-bridge.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+"""
+Python subprocess bridge for Lightning Whisper MLX STT.
+Communicates with the Electron main process via JSON-over-stdio.
+
+Lightning Whisper MLX achieves ~10x faster inference than whisper.cpp
+and ~4x faster than standard MLX Whisper on Apple Silicon.
+
+Protocol:
+  Input (one per line):
+    {"action": "init", "model": "distil-large-v3", "batch_size": 12, "quant": null}
+    {"action": "transcribe", "audio_path": "/tmp/audio.wav", "sample_rate": 16000}
+    {"action": "dispose"}
+  Output (one per line):
+    {"ready": true, "model": "..."}
+    {"text": "...", "language": "ja"}
+    {"error": "..."}
+"""
+import sys
+import json
+
+whisper_instance = None
+
+_current_req_id = None
+
+
+def output(data):
+    if _current_req_id is not None:
+        data["_reqId"] = _current_req_id
+    print(json.dumps(data, ensure_ascii=False), flush=True)
+
+
+def init_model(model="distil-large-v3", batch_size=12, quant=None):
+    global whisper_instance
+    try:
+        from lightning_whisper_mlx import LightningWhisperMLX
+
+        output({"status": "Loading Lightning Whisper MLX model..."})
+
+        whisper_instance = LightningWhisperMLX(
+            model=model,
+            batch_size=batch_size,
+            quant=quant,
+        )
+
+        output({"ready": True, "model": model})
+    except ImportError:
+        output(
+            {
+                "error": "lightning-whisper-mlx not installed. Run: pip install lightning-whisper-mlx"
+            }
+        )
+    except Exception as e:
+        output({"error": f"Failed to initialize Lightning Whisper MLX: {e}"})
+
+
+def transcribe(audio_path, sample_rate=16000):
+    global whisper_instance
+    if whisper_instance is None:
+        output({"error": "Model not initialized"})
+        return
+
+    try:
+        result = whisper_instance.transcribe(audio_path=audio_path)
+
+        text = result.get("text", "").strip()
+        language = result.get("language", "en")
+
+        output({"text": text, "language": language})
+    except Exception as e:
+        output({"error": f"Transcription failed: {e}"})
+
+
+def main():
+    global _current_req_id
+    for line in sys.stdin:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            msg = json.loads(line)
+            _current_req_id = msg.get("_reqId")
+            action = msg.get("action")
+
+            if action == "init":
+                init_model(
+                    model=msg.get("model", "distil-large-v3"),
+                    batch_size=msg.get("batch_size", 12),
+                    quant=msg.get("quant"),
+                )
+            elif action == "transcribe":
+                transcribe(msg["audio_path"], msg.get("sample_rate", 16000))
+            elif action == "dispose":
+                output({"disposed": True})
+                sys.exit(0)
+            else:
+                output({"error": f"Unknown action: {action}"})
+        except json.JSONDecodeError:
+            _current_req_id = None
+            output({"error": "Invalid JSON"})
+        except Exception as e:
+            output({"error": str(e)})
+        finally:
+            _current_req_id = None
+
+
+if __name__ == "__main__":
+    main()

--- a/src/engines/constants.ts
+++ b/src/engines/constants.ts
@@ -81,6 +81,12 @@ export const SENSEVOICE_TRANSCRIBE_TIMEOUT_MS = 30_000
 /** Init timeout for SenseVoice bridge — model download on first run can be slow (ms) */
 export const SENSEVOICE_INIT_TIMEOUT_MS = 180_000
 
+/** Command timeout for Lightning Whisper MLX transcription (ms) */
+export const LIGHTNING_WHISPER_TRANSCRIBE_TIMEOUT_MS = 30_000
+
+/** Init timeout for Lightning Whisper MLX bridge — model download on first run can be slow (ms) */
+export const LIGHTNING_WHISPER_INIT_TIMEOUT_MS = 120_000
+
 // ---------------------------------------------------------------------------
 // ANE translator
 // ---------------------------------------------------------------------------

--- a/src/engines/stt/LightningWhisperEngine.ts
+++ b/src/engines/stt/LightningWhisperEngine.ts
@@ -1,0 +1,202 @@
+import { execSync } from 'child_process'
+import { join } from 'path'
+import { writeFileSync, unlinkSync, existsSync } from 'fs'
+import { tmpdir, homedir } from 'os'
+import type { STTEngine, STTResult, Language } from '../types'
+import { ALL_LANGUAGES } from '../types'
+import { SubprocessBridge, type SpawnConfig, type InitResult } from '../SubprocessBridge'
+import {
+  LIGHTNING_WHISPER_TRANSCRIBE_TIMEOUT_MS,
+  LIGHTNING_WHISPER_INIT_TIMEOUT_MS
+} from '../constants'
+
+/**
+ * Lightning Whisper MLX model size options.
+ * See https://github.com/mustafaaljadery/lightning-whisper-mlx
+ */
+export type LightningWhisperModel =
+  | 'tiny'
+  | 'base'
+  | 'small'
+  | 'medium'
+  | 'large'
+  | 'large-v2'
+  | 'large-v3'
+  | 'distil-small.en'
+  | 'distil-medium.en'
+  | 'distil-large-v2'
+  | 'distil-large-v3'
+
+/**
+ * Lightning Whisper MLX STT engine.
+ * Achieves ~10x faster inference than whisper.cpp and ~4x faster than
+ * standard MLX Whisper on Apple Silicon via optimized MLX kernels.
+ *
+ * Requires: python3 with `lightning-whisper-mlx` package installed.
+ */
+export class LightningWhisperEngine extends SubprocessBridge implements STTEngine {
+  readonly id = 'lightning-whisper'
+  readonly name = 'Lightning Whisper MLX (Apple Silicon, 10x faster)'
+  readonly isOffline = true
+
+  private model: LightningWhisperModel
+  private batchSize: number
+  private quant: '4bit' | '8bit' | null
+  private onProgress?: (message: string) => void
+
+  constructor(options?: {
+    model?: LightningWhisperModel
+    batchSize?: number
+    quant?: '4bit' | '8bit' | null
+    onProgress?: (message: string) => void
+  }) {
+    super()
+    this.model = options?.model ?? 'distil-large-v3'
+    this.batchSize = options?.batchSize ?? 12
+    this.quant = options?.quant ?? null
+    this.onProgress = options?.onProgress
+  }
+
+  protected getLogPrefix(): string {
+    return '[lightning-whisper]'
+  }
+
+  protected getInitTimeout(): number {
+    return LIGHTNING_WHISPER_INIT_TIMEOUT_MS
+  }
+
+  protected getCommandTimeout(): number {
+    return LIGHTNING_WHISPER_TRANSCRIBE_TIMEOUT_MS
+  }
+
+  protected override onStatusMessage(status: string): void {
+    this.onProgress?.(status)
+  }
+
+  protected getSpawnConfig(): SpawnConfig {
+    this.onProgress?.('Starting Lightning Whisper MLX bridge...')
+    const python3 = findPython3WithLightningWhisper()
+    this.onProgress?.(`Using Python: ${python3}`)
+    return {
+      command: python3,
+      args: [join(__dirname, '../../resources/lightning-whisper-bridge.py')],
+      initMessage: {
+        action: 'init',
+        model: this.model,
+        batch_size: this.batchSize,
+        quant: this.quant
+      }
+    }
+  }
+
+  protected getSpawnError(): Error {
+    return new Error(
+      'Python 3 with lightning-whisper-mlx not found. Create a venv and install: ' +
+      'python3 -m venv ~/mlx-env && ~/mlx-env/bin/pip install lightning-whisper-mlx'
+    )
+  }
+
+  protected onInitComplete(_result: InitResult): void {
+    this.onProgress?.('Lightning Whisper MLX ready')
+  }
+
+  async processAudio(audioChunk: Float32Array, sampleRate: number): Promise<STTResult | null> {
+    if (!this.process) return null
+
+    const tempPath = join(tmpdir(), `lightning-whisper-${Date.now()}.wav`)
+    try {
+      writeWav(tempPath, audioChunk, sampleRate)
+
+      let result: Record<string, unknown>
+      try {
+        result = await this.sendCommand({
+          action: 'transcribe',
+          audio_path: tempPath,
+          sample_rate: sampleRate
+        })
+      } catch (err) {
+        console.error('[lightning-whisper] Bridge error:', err instanceof Error ? err.message : err)
+        return null
+      }
+
+      if (result.error) {
+        console.error('[lightning-whisper] Transcription error:', result.error)
+        return null
+      }
+
+      if (!result.text || !(result.text as string).trim()) return null
+
+      const detectedLang = result.language as string | undefined
+      const language: Language = (detectedLang && ALL_LANGUAGES.includes(detectedLang as Language))
+        ? (detectedLang as Language)
+        : 'en'
+
+      return {
+        text: (result.text as string).trim(),
+        language,
+        isFinal: true,
+        timestamp: Date.now()
+      }
+    } finally {
+      try { unlinkSync(tempPath) } catch (e) { console.warn('[lightning-whisper] Failed to delete temp file:', e) }
+    }
+  }
+}
+
+/** Find a python3 binary that has lightning_whisper_mlx installed */
+function findPython3WithLightningWhisper(): string {
+  const venvPaths = [
+    join(homedir(), 'mlx-env', 'bin', 'python3'),
+    join(homedir(), 'lightning-whisper-env', 'bin', 'python3'),
+    join(homedir(), '.venv', 'bin', 'python3'),
+    join(homedir(), 'venv', 'bin', 'python3')
+  ]
+
+  for (const p of venvPaths) {
+    if (!existsSync(p)) continue
+    try {
+      execSync(`${p} -c "import lightning_whisper_mlx"`, { stdio: 'ignore', timeout: 5000 })
+      return p
+    } catch { /* lightning_whisper_mlx not installed in this venv */ }
+  }
+
+  // Fall back to system python3
+  try {
+    execSync('python3 -c "import lightning_whisper_mlx"', { stdio: 'ignore', timeout: 5000 })
+    return 'python3'
+  } catch { /* not available */ }
+
+  throw new Error('lightning-whisper-mlx not found')
+}
+
+/** Write Float32Array as a minimal WAV file */
+function writeWav(path: string, samples: Float32Array, sampleRate: number): void {
+  const numChannels = 1
+  const bitsPerSample = 16
+  const bytesPerSample = bitsPerSample / 8
+  const dataSize = samples.length * bytesPerSample
+  const buffer = Buffer.alloc(44 + dataSize)
+
+  // WAV header
+  buffer.write('RIFF', 0)
+  buffer.writeUInt32LE(36 + dataSize, 4)
+  buffer.write('WAVE', 8)
+  buffer.write('fmt ', 12)
+  buffer.writeUInt32LE(16, 16) // chunk size
+  buffer.writeUInt16LE(1, 20) // PCM
+  buffer.writeUInt16LE(numChannels, 22)
+  buffer.writeUInt32LE(sampleRate, 24)
+  buffer.writeUInt32LE(sampleRate * numChannels * bytesPerSample, 28)
+  buffer.writeUInt16LE(numChannels * bytesPerSample, 32)
+  buffer.writeUInt16LE(bitsPerSample, 34)
+  buffer.write('data', 36)
+  buffer.writeUInt32LE(dataSize, 40)
+
+  // Convert Float32 [-1, 1] to Int16
+  for (let i = 0; i < samples.length; i++) {
+    const s = Math.max(-1, Math.min(1, samples[i]))
+    buffer.writeInt16LE(Math.round(s * 32767), 44 + i * 2)
+  }
+
+  writeFileSync(path, buffer)
+}

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -4,6 +4,7 @@ import { WhisperLocalEngine } from '../engines/stt/WhisperLocalEngine'
 import { MlxWhisperEngine } from '../engines/stt/MlxWhisperEngine'
 import { MoonshineEngine } from '../engines/stt/MoonshineEngine'
 import { SenseVoiceEngine } from '../engines/stt/SenseVoiceEngine'
+import { LightningWhisperEngine } from '../engines/stt/LightningWhisperEngine'
 import { OpusMTTranslator } from '../engines/translator/OpusMTTranslator'
 import { CT2OpusMTTranslator } from '../engines/translator/CT2OpusMTTranslator'
 import { CT2Madlad400Translator } from '../engines/translator/CT2Madlad400Translator'
@@ -45,6 +46,9 @@ function initPipeline(): void {
   // mlx-whisper is Apple Silicon only — skip registration on other platforms
   if (process.platform === 'darwin') {
     ctx.pipeline.registerSTT('mlx-whisper', () => new MlxWhisperEngine({
+      onProgress: (msg) => ctx.mainWindow?.webContents.send('status-update', msg)
+    }))
+    ctx.pipeline.registerSTT('lightning-whisper', () => new LightningWhisperEngine({
       onProgress: (msg) => ctx.mainWindow?.webContents.send('status-update', msg)
     }))
   }

--- a/src/renderer/components/settings/STTSettings.tsx
+++ b/src/renderer/components/settings/STTSettings.tsx
@@ -37,6 +37,9 @@ export function STTSettings({
         {platform === 'darwin' && (
           <option value="mlx-whisper">mlx-whisper (Apple Silicon, faster)</option>
         )}
+        {platform === 'darwin' && (
+          <option value="lightning-whisper">Lightning Whisper MLX (Apple Silicon, 10x faster)</option>
+        )}
         <option value="moonshine">Moonshine AI (ultra-fast, experimental)</option>
         <option value="sensevoice">SenseVoice (CJK-optimized, 15x faster)</option>
       </select>
@@ -79,6 +82,14 @@ export function STTSettings({
           </select>
           <div style={{ marginTop: '4px', fontSize: '11px', color: '#f59e0b' }}>
             English-focused. Japanese/CJK accuracy is unverified — switch to Whisper if results are poor.
+          </div>
+        </div>
+      )}
+      {sttEngine === 'lightning-whisper' && (
+        <div style={{ marginTop: '8px' }}>
+          <div style={{ marginTop: '4px', fontSize: '11px', color: '#94a3b8' }}>
+            Lightning Whisper MLX: ~10x faster than whisper.cpp on Apple Silicon. Supports all Whisper model sizes including distil variants.
+            Requires: <code style={{ color: '#7dd3fc' }}>pip install lightning-whisper-mlx</code>
           </div>
         </div>
       )}

--- a/src/renderer/components/settings/shared.ts
+++ b/src/renderer/components/settings/shared.ts
@@ -27,7 +27,7 @@ export const ALL_LANGUAGES = Object.keys(LANGUAGE_LABELS) as Language[]
 
 export type EngineMode = 'auto' | 'rotation' | 'online' | 'online-deepl' | 'online-gemini' | 'offline-opus' | 'offline-ct2-opus' | 'offline-madlad-400' | 'offline-slm' | 'offline-hunyuan-mt' | 'offline-hunyuan-mt-15' | 'offline-ane' | 'offline-hybrid'
 
-export type SttEngineType = 'whisper-local' | 'mlx-whisper' | 'moonshine' | 'sensevoice'
+export type SttEngineType = 'whisper-local' | 'mlx-whisper' | 'lightning-whisper' | 'moonshine' | 'sensevoice'
 export type WhisperVariantType = 'kotoba-v2.0' | 'large-v3-turbo'
 export type MoonshineVariantType = 'tiny' | 'base'
 export type SlmModelSizeType = '4b' | '12b'


### PR DESCRIPTION
## Description

Add Lightning Whisper MLX as a new STT engine option for Apple Silicon Macs. Lightning Whisper MLX achieves ~10x faster inference than whisper.cpp and ~4x faster than standard MLX Whisper via optimized MLX kernels.

- New `LightningWhisperEngine` extending `SubprocessBridge` (same pattern as MlxWhisperEngine/SenseVoiceEngine)
- New `lightning-whisper-bridge.py` Python subprocess bridge
- Registered as `lightning-whisper` in pipeline (macOS only)
- Added to STT engine dropdown in Settings UI
- Supports all Whisper model sizes including distil variants, with optional 4bit/8bit quantization

Closes #308