### PR TITLE
Add JA-EN specialized translation models (Gemma-2-2B-JPN, ALMA-7B-Ja-V2)

### DIFF
--- a/src/engines/model-downloader.ts
+++ b/src/engines/model-downloader.ts
@@ -217,6 +217,60 @@ export function getGGUFVariants(modelSize: SLMModelSize): Record<string, GGUFVar
   return modelSize === '12b' ? GGUF_VARIANTS_12B : GGUF_VARIANTS_4B
 }
 
+/** Gemma-2-2B-JPN-IT-Translate GGUF variants (JA↔EN specialized, webbigdata) */
+export const GEMMA2_JPN_VARIANTS: Record<string, GGUFVariant> = {
+  'Q4_K_M': {
+    filename: 'gemma-2-2b-jpn-it-translate-Q4_K_M.gguf',
+    url: 'https://huggingface.co/webbigdata/gemma-2-2b-jpn-it-translate-gguf/resolve/main/gemma-2-2b-jpn-it-translate-Q4_K_M.gguf',
+    sizeMB: 1630,
+    label: 'Q4_K_M (Recommended, ~1.6GB)'
+  },
+  'Q6_K': {
+    filename: 'gemma-2-2b-jpn-it-translate-Q6_K.gguf',
+    url: 'https://huggingface.co/webbigdata/gemma-2-2b-jpn-it-translate-gguf/resolve/main/gemma-2-2b-jpn-it-translate-Q6_K.gguf',
+    sizeMB: 2050,
+    label: 'Q6_K (Balanced, ~2.1GB)'
+  },
+  'Q8_0': {
+    filename: 'gemma-2-2b-jpn-it-translate-Q8_0.gguf',
+    url: 'https://huggingface.co/webbigdata/gemma-2-2b-jpn-it-translate-gguf/resolve/main/gemma-2-2b-jpn-it-translate-Q8_0.gguf',
+    sizeMB: 3180,
+    label: 'Q8_0 (Best quality, ~3.2GB)'
+  }
+}
+
+/** Get Gemma-2-2B-JPN GGUF variants */
+export function getGemma2JpnVariants(): Record<string, GGUFVariant> {
+  return GEMMA2_JPN_VARIANTS
+}
+
+/** ALMA-7B-Ja-V2 GGUF variants (JA↔EN specialized, mmnga quantizations) */
+export const ALMA_JA_VARIANTS: Record<string, GGUFVariant> = {
+  'Q4_K_M': {
+    filename: 'webbigdata-ALMA-7B-Ja-V2-q4_K_M.gguf',
+    url: 'https://huggingface.co/mmnga/webbigdata-ALMA-7B-Ja-V2-gguf/resolve/main/webbigdata-ALMA-7B-Ja-V2-q4_K_M.gguf',
+    sizeMB: 3890,
+    label: 'Q4_K_M (Recommended, ~3.9GB)'
+  },
+  'Q5_K_M': {
+    filename: 'webbigdata-ALMA-7B-Ja-V2-q5_K_M.gguf',
+    url: 'https://huggingface.co/mmnga/webbigdata-ALMA-7B-Ja-V2-gguf/resolve/main/webbigdata-ALMA-7B-Ja-V2-q5_K_M.gguf',
+    sizeMB: 4560,
+    label: 'Q5_K_M (Balanced, ~4.6GB)'
+  },
+  'Q8_0': {
+    filename: 'webbigdata-ALMA-7B-Ja-V2-q8_0.gguf',
+    url: 'https://huggingface.co/mmnga/webbigdata-ALMA-7B-Ja-V2-gguf/resolve/main/webbigdata-ALMA-7B-Ja-V2-q8_0.gguf',
+    sizeMB: 6830,
+    label: 'Q8_0 (Best quality, ~6.8GB)'
+  }
+}
+
+/** Get ALMA-7B-Ja GGUF variants */
+export function getAlmaJaVariants(): Record<string, GGUFVariant> {
+  return ALMA_JA_VARIANTS
+}
+
 // GGUF download lock uses shared activeDownloads map
 
 /** Get the GGUF models subdirectory */

--- a/src/engines/translator/AlmaJaTranslator.ts
+++ b/src/engines/translator/AlmaJaTranslator.ts
@@ -1,0 +1,244 @@
+import { utilityProcess } from 'electron'
+import { join } from 'path'
+import type { TranslatorEngine, Language, TranslateContext } from '../types'
+import { getGGUFDir, downloadGGUF, getAlmaJaVariants } from '../model-downloader'
+import {
+  WORKER_TRANSLATE_TIMEOUT_MS,
+  WORKER_INIT_TIMEOUT_MS,
+  WORKER_DISPOSE_GRACE_MS,
+  WORKER_MAX_PENDING_REQUESTS
+} from '../constants'
+
+/** Messages received from the slm-worker UtilityProcess */
+type WorkerMessage =
+  | { type: 'ready' }
+  | { type: 'result'; id: string; text: string }
+  | { type: 'error'; id?: string; message: string }
+
+interface PendingRequest {
+  resolve: (text: string) => void
+  reject: (err: Error) => void
+  timer: ReturnType<typeof setTimeout>
+}
+
+/**
+ * ALMA-7B-Ja-V2 translator via node-llama-cpp UtilityProcess.
+ * Uses the same slm-worker.ts as other GGUF-based translators.
+ * 7B parameter model (~3.9GB Q4_K_M) specialized for JA↔EN translation.
+ * ALMA (Advanced Language Model-based trAnslator) — COMET 0.8818 for EN→JA.
+ * License: Llama 2 Community License.
+ */
+export class AlmaJaTranslator implements TranslatorEngine {
+  readonly id = 'alma-ja'
+  readonly name = 'ALMA-7B-Ja-V2 (Offline)'
+  readonly isOffline = true
+
+  private worker: Electron.UtilityProcess | null = null
+  private pending = new Map<string, PendingRequest>()
+  private nextId = 0
+  private initPromise: Promise<void> | null = null
+  private onProgress?: (message: string) => void
+  private variant: string
+  private kvCacheQuant: boolean
+
+  constructor(options?: { onProgress?: (message: string) => void; variant?: string; kvCacheQuant?: boolean }) {
+    this.onProgress = options?.onProgress
+    this.variant = options?.variant ?? 'Q4_K_M'
+    this.kvCacheQuant = options?.kvCacheQuant ?? true
+  }
+
+  async initialize(): Promise<void> {
+    if (this.initPromise) return this.initPromise
+    this.initPromise = this.doInitialize()
+    return this.initPromise
+  }
+
+  private async doInitialize(): Promise<void> {
+    if (this.worker) return
+
+    // Download model if needed
+    const variants = getAlmaJaVariants()
+    const variantConfig = variants[this.variant] ?? variants['Q4_K_M']!
+    const modelPath = join(getGGUFDir(), variantConfig.filename)
+    await downloadGGUF(variantConfig.filename, variantConfig.url, this.onProgress, variantConfig.sha256)
+
+    // Spawn UtilityProcess (reuses the same slm-worker)
+    this.onProgress?.('Starting ALMA-7B-Ja-V2 worker...')
+    const workerPath = join(__dirname, 'slm-worker.js')
+
+    this.worker = utilityProcess.fork(workerPath)
+
+    this.worker.on('exit', (code) => {
+      console.log(`[alma-ja-worker] Worker exited with code ${code}`)
+      this.worker = null
+      for (const [id, req] of this.pending) {
+        clearTimeout(req.timer)
+        req.reject(new Error('Worker process exited'))
+        this.pending.delete(id)
+      }
+    })
+
+    // Wait for init before registering the general message handler
+    await new Promise<void>((resolve, reject) => {
+      const timeout = setTimeout(() => {
+        this.worker?.removeListener('message', initHandler)
+        try { this.worker?.kill() } catch (e) { console.warn('[alma-ja-worker] Failed to kill worker on timeout:', e) }
+        this.worker = null
+        reject(new Error('ALMA-7B-Ja-V2 initialization timed out'))
+      }, WORKER_INIT_TIMEOUT_MS)
+
+      const initHandler = (msg: WorkerMessage): void => {
+        if (!this.worker) return
+
+        if (msg.type === 'ready') {
+          clearTimeout(timeout)
+          this.worker?.removeListener('message', initHandler)
+          this.onProgress?.('ALMA-7B-Ja-V2 model loaded')
+          resolve()
+        } else if (msg.type === 'error') {
+          clearTimeout(timeout)
+          this.worker?.removeListener('message', initHandler)
+          reject(new Error(msg.message))
+        }
+      }
+
+      this.worker!.on('message', initHandler)
+      this.worker!.postMessage({
+        type: 'init',
+        modelPath,
+        kvCacheQuant: this.kvCacheQuant,
+        modelType: 'alma-ja'
+      })
+    })
+
+    if (!this.worker) {
+      throw new Error('Worker was killed during initialization')
+    }
+
+    // Clear any leftover listeners before registering to prevent duplicates
+    this.worker.removeAllListeners('message')
+    this.worker.on('message', (msg: WorkerMessage) => {
+      if (msg.type === 'result' && msg.id) {
+        const req = this.pending.get(msg.id)
+        if (req) {
+          clearTimeout(req.timer)
+          this.pending.delete(msg.id)
+          req.resolve(msg.text)
+        }
+        return
+      }
+      if (msg.type === 'error' && msg.id) {
+        const req = this.pending.get(msg.id)
+        if (req) {
+          clearTimeout(req.timer)
+          this.pending.delete(msg.id)
+          req.reject(new Error(msg.message))
+        }
+        return
+      }
+      if (msg.type === 'error') {
+        console.error('[alma-ja-worker] Worker error:', msg.message)
+      }
+    })
+  }
+
+  /** Evict the oldest pending request if the map is at capacity */
+  private evictOldestPending(): void {
+    if (this.pending.size >= WORKER_MAX_PENDING_REQUESTS) {
+      const oldestKey = this.pending.keys().next().value!
+      const oldest = this.pending.get(oldestKey)!
+      this.pending.delete(oldestKey)
+      clearTimeout(oldest.timer)
+      oldest.reject(new Error('Evicted: worker pending request limit exceeded'))
+    }
+  }
+
+  async translate(text: string, from: Language, to: Language, context?: TranslateContext): Promise<string> {
+    if (!text.trim()) return ''
+    if (from === to) return text
+    if (!this.worker) {
+      throw new Error('[alma-ja-worker] Not initialized')
+    }
+
+    const id = String(this.nextId++)
+
+    return new Promise<string>((resolve, reject) => {
+      this.evictOldestPending()
+      const timer = setTimeout(() => {
+        this.pending.delete(id)
+        reject(new Error('ALMA-7B-Ja-V2 translation timed out'))
+      }, WORKER_TRANSLATE_TIMEOUT_MS)
+
+      this.pending.set(id, { resolve, reject, timer })
+      this.worker!.postMessage({ type: 'translate', id, text, from, to, context })
+    })
+  }
+
+  async translateIncremental(
+    text: string,
+    previousOutput: string,
+    from: Language,
+    to: Language,
+    context?: TranslateContext
+  ): Promise<string> {
+    if (!text.trim()) return previousOutput || ''
+    if (from === to) return text
+    if (!this.worker) {
+      throw new Error('[alma-ja-worker] Not initialized')
+    }
+
+    const id = String(this.nextId++)
+
+    return new Promise<string>((resolve, reject) => {
+      this.evictOldestPending()
+      const timer = setTimeout(() => {
+        this.pending.delete(id)
+        reject(new Error('ALMA-7B-Ja-V2 incremental translation timed out'))
+      }, WORKER_TRANSLATE_TIMEOUT_MS)
+
+      this.pending.set(id, { resolve, reject, timer })
+      this.worker!.postMessage({
+        type: 'translate-incremental',
+        id,
+        text,
+        previousOutput,
+        from,
+        to,
+        context
+      })
+    })
+  }
+
+  async dispose(): Promise<void> {
+    if (this.worker) {
+      this.worker.removeAllListeners()
+      try {
+        await new Promise<void>((resolve) => {
+          const timeout = setTimeout(resolve, WORKER_DISPOSE_GRACE_MS)
+          this.worker!.on('message', (msg: any) => {
+            if (msg.type === 'disposed') {
+              clearTimeout(timeout)
+              resolve()
+            }
+          })
+          this.worker!.postMessage({ type: 'dispose' })
+        })
+      } catch {
+        // Ignore errors during disposal
+      }
+      try {
+        this.worker.kill()
+      } catch {
+        // Already exited
+      }
+      this.worker = null
+    }
+
+    for (const [, req] of this.pending) {
+      clearTimeout(req.timer)
+      req.reject(new Error('Translator disposed'))
+    }
+    this.pending.clear()
+    this.initPromise = null
+  }
+}

--- a/src/engines/translator/Gemma2JpnTranslator.ts
+++ b/src/engines/translator/Gemma2JpnTranslator.ts
@@ -1,0 +1,244 @@
+import { utilityProcess } from 'electron'
+import { join } from 'path'
+import type { TranslatorEngine, Language, TranslateContext } from '../types'
+import { getGGUFDir, downloadGGUF, getGemma2JpnVariants } from '../model-downloader'
+import {
+  WORKER_TRANSLATE_TIMEOUT_MS,
+  WORKER_INIT_TIMEOUT_MS,
+  WORKER_DISPOSE_GRACE_MS,
+  WORKER_MAX_PENDING_REQUESTS
+} from '../constants'
+
+/** Messages received from the slm-worker UtilityProcess */
+type WorkerMessage =
+  | { type: 'ready' }
+  | { type: 'result'; id: string; text: string }
+  | { type: 'error'; id?: string; message: string }
+
+interface PendingRequest {
+  resolve: (text: string) => void
+  reject: (err: Error) => void
+  timer: ReturnType<typeof setTimeout>
+}
+
+/**
+ * Gemma-2-2B-JPN-IT-Translate via node-llama-cpp UtilityProcess.
+ * Uses the same slm-worker.ts as other GGUF-based translators.
+ * 2B parameter model (~1.6GB Q4_K_M) specialized for JA↔EN translation.
+ * Comparable quality to 7B general-purpose models at half the size.
+ * License: Gemma Terms of Use (commercial OK).
+ */
+export class Gemma2JpnTranslator implements TranslatorEngine {
+  readonly id = 'gemma2-jpn'
+  readonly name = 'Gemma-2-2B JA↔EN (Offline)'
+  readonly isOffline = true
+
+  private worker: Electron.UtilityProcess | null = null
+  private pending = new Map<string, PendingRequest>()
+  private nextId = 0
+  private initPromise: Promise<void> | null = null
+  private onProgress?: (message: string) => void
+  private variant: string
+  private kvCacheQuant: boolean
+
+  constructor(options?: { onProgress?: (message: string) => void; variant?: string; kvCacheQuant?: boolean }) {
+    this.onProgress = options?.onProgress
+    this.variant = options?.variant ?? 'Q4_K_M'
+    this.kvCacheQuant = options?.kvCacheQuant ?? true
+  }
+
+  async initialize(): Promise<void> {
+    if (this.initPromise) return this.initPromise
+    this.initPromise = this.doInitialize()
+    return this.initPromise
+  }
+
+  private async doInitialize(): Promise<void> {
+    if (this.worker) return
+
+    // Download model if needed
+    const variants = getGemma2JpnVariants()
+    const variantConfig = variants[this.variant] ?? variants['Q4_K_M']!
+    const modelPath = join(getGGUFDir(), variantConfig.filename)
+    await downloadGGUF(variantConfig.filename, variantConfig.url, this.onProgress, variantConfig.sha256)
+
+    // Spawn UtilityProcess (reuses the same slm-worker)
+    this.onProgress?.('Starting Gemma-2-2B JA↔EN worker...')
+    const workerPath = join(__dirname, 'slm-worker.js')
+
+    this.worker = utilityProcess.fork(workerPath)
+
+    this.worker.on('exit', (code) => {
+      console.log(`[gemma2-jpn-worker] Worker exited with code ${code}`)
+      this.worker = null
+      for (const [id, req] of this.pending) {
+        clearTimeout(req.timer)
+        req.reject(new Error('Worker process exited'))
+        this.pending.delete(id)
+      }
+    })
+
+    // Wait for init before registering the general message handler
+    await new Promise<void>((resolve, reject) => {
+      const timeout = setTimeout(() => {
+        this.worker?.removeListener('message', initHandler)
+        try { this.worker?.kill() } catch (e) { console.warn('[gemma2-jpn-worker] Failed to kill worker on timeout:', e) }
+        this.worker = null
+        reject(new Error('Gemma-2-2B JA↔EN initialization timed out'))
+      }, WORKER_INIT_TIMEOUT_MS)
+
+      const initHandler = (msg: WorkerMessage): void => {
+        if (!this.worker) return
+
+        if (msg.type === 'ready') {
+          clearTimeout(timeout)
+          this.worker?.removeListener('message', initHandler)
+          this.onProgress?.('Gemma-2-2B JA↔EN model loaded')
+          resolve()
+        } else if (msg.type === 'error') {
+          clearTimeout(timeout)
+          this.worker?.removeListener('message', initHandler)
+          reject(new Error(msg.message))
+        }
+      }
+
+      this.worker!.on('message', initHandler)
+      this.worker!.postMessage({
+        type: 'init',
+        modelPath,
+        kvCacheQuant: this.kvCacheQuant,
+        modelType: 'gemma2-jpn'
+      })
+    })
+
+    if (!this.worker) {
+      throw new Error('Worker was killed during initialization')
+    }
+
+    // Clear any leftover listeners before registering to prevent duplicates
+    this.worker.removeAllListeners('message')
+    this.worker.on('message', (msg: WorkerMessage) => {
+      if (msg.type === 'result' && msg.id) {
+        const req = this.pending.get(msg.id)
+        if (req) {
+          clearTimeout(req.timer)
+          this.pending.delete(msg.id)
+          req.resolve(msg.text)
+        }
+        return
+      }
+      if (msg.type === 'error' && msg.id) {
+        const req = this.pending.get(msg.id)
+        if (req) {
+          clearTimeout(req.timer)
+          this.pending.delete(msg.id)
+          req.reject(new Error(msg.message))
+        }
+        return
+      }
+      if (msg.type === 'error') {
+        console.error('[gemma2-jpn-worker] Worker error:', msg.message)
+      }
+    })
+  }
+
+  /** Evict the oldest pending request if the map is at capacity */
+  private evictOldestPending(): void {
+    if (this.pending.size >= WORKER_MAX_PENDING_REQUESTS) {
+      const oldestKey = this.pending.keys().next().value!
+      const oldest = this.pending.get(oldestKey)!
+      this.pending.delete(oldestKey)
+      clearTimeout(oldest.timer)
+      oldest.reject(new Error('Evicted: worker pending request limit exceeded'))
+    }
+  }
+
+  async translate(text: string, from: Language, to: Language, context?: TranslateContext): Promise<string> {
+    if (!text.trim()) return ''
+    if (from === to) return text
+    if (!this.worker) {
+      throw new Error('[gemma2-jpn-worker] Not initialized')
+    }
+
+    const id = String(this.nextId++)
+
+    return new Promise<string>((resolve, reject) => {
+      this.evictOldestPending()
+      const timer = setTimeout(() => {
+        this.pending.delete(id)
+        reject(new Error('Gemma-2-2B JA↔EN translation timed out'))
+      }, WORKER_TRANSLATE_TIMEOUT_MS)
+
+      this.pending.set(id, { resolve, reject, timer })
+      this.worker!.postMessage({ type: 'translate', id, text, from, to, context })
+    })
+  }
+
+  async translateIncremental(
+    text: string,
+    previousOutput: string,
+    from: Language,
+    to: Language,
+    context?: TranslateContext
+  ): Promise<string> {
+    if (!text.trim()) return previousOutput || ''
+    if (from === to) return text
+    if (!this.worker) {
+      throw new Error('[gemma2-jpn-worker] Not initialized')
+    }
+
+    const id = String(this.nextId++)
+
+    return new Promise<string>((resolve, reject) => {
+      this.evictOldestPending()
+      const timer = setTimeout(() => {
+        this.pending.delete(id)
+        reject(new Error('Gemma-2-2B JA↔EN incremental translation timed out'))
+      }, WORKER_TRANSLATE_TIMEOUT_MS)
+
+      this.pending.set(id, { resolve, reject, timer })
+      this.worker!.postMessage({
+        type: 'translate-incremental',
+        id,
+        text,
+        previousOutput,
+        from,
+        to,
+        context
+      })
+    })
+  }
+
+  async dispose(): Promise<void> {
+    if (this.worker) {
+      this.worker.removeAllListeners()
+      try {
+        await new Promise<void>((resolve) => {
+          const timeout = setTimeout(resolve, WORKER_DISPOSE_GRACE_MS)
+          this.worker!.on('message', (msg: any) => {
+            if (msg.type === 'disposed') {
+              clearTimeout(timeout)
+              resolve()
+            }
+          })
+          this.worker!.postMessage({ type: 'dispose' })
+        })
+      } catch {
+        // Ignore errors during disposal
+      }
+      try {
+        this.worker.kill()
+      } catch {
+        // Already exited
+      }
+      this.worker = null
+    }
+
+    for (const [, req] of this.pending) {
+      clearTimeout(req.timer)
+      req.reject(new Error('Translator disposed'))
+    }
+    this.pending.clear()
+    this.initPromise = null
+  }
+}

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -10,6 +10,8 @@ import { CT2Madlad400Translator } from '../engines/translator/CT2Madlad400Transl
 import { SLMTranslator } from '../engines/translator/SLMTranslator'
 import { HunyuanMTTranslator } from '../engines/translator/HunyuanMTTranslator'
 import { HunyuanMT15Translator } from '../engines/translator/HunyuanMT15Translator'
+import { Gemma2JpnTranslator } from '../engines/translator/Gemma2JpnTranslator'
+import { AlmaJaTranslator } from '../engines/translator/AlmaJaTranslator'
 import { ANETranslator } from '../engines/translator/ANETranslator'
 import { HybridTranslator } from '../engines/translator/HybridTranslator'
 import { discoverPlugins, loadPluginEngine } from '../engines/plugin-loader'
@@ -77,6 +79,15 @@ function initPipeline(): void {
     kvCacheQuant: store.get('slmKvCacheQuant')
   }))
   ctx.pipeline.registerTranslator('hunyuan-mt-15', () => new HunyuanMT15Translator({
+    onProgress: (msg) => ctx.mainWindow?.webContents.send('status-update', msg),
+    kvCacheQuant: store.get('slmKvCacheQuant')
+  }))
+  // JA↔EN specialized models (#312)
+  ctx.pipeline.registerTranslator('gemma2-jpn', () => new Gemma2JpnTranslator({
+    onProgress: (msg) => ctx.mainWindow?.webContents.send('status-update', msg),
+    kvCacheQuant: store.get('slmKvCacheQuant')
+  }))
+  ctx.pipeline.registerTranslator('alma-ja', () => new AlmaJaTranslator({
     onProgress: (msg) => ctx.mainWindow?.webContents.send('status-update', msg),
     kvCacheQuant: store.get('slmKvCacheQuant')
   }))

--- a/src/main/slm-worker.ts
+++ b/src/main/slm-worker.ts
@@ -17,7 +17,7 @@
 import type { Llama, LlamaModel, LlamaContext, LlamaContextSequence } from 'node-llama-cpp'
 import { LANG_NAMES_EN, LANG_NAMES_ZH } from '../engines/language-names'
 
-type ModelType = 'translategemma' | 'hunyuan-mt' | 'hunyuan-mt-15'
+type ModelType = 'translategemma' | 'hunyuan-mt' | 'hunyuan-mt-15' | 'gemma2-jpn' | 'alma-ja'
 
 /** Messages sent from main process to this worker */
 type WorkerInboundMessage =
@@ -210,6 +210,13 @@ async function handleTranslate(
       }
       // Hunyuan-MT recommended parameters
       inferenceParams = { temperature: 0.7, maxTokens: 512, topK: 20, topP: 0.6, repeatPenalty: { penalty: 1.05 } }
+    } else if (activeModelType === 'gemma2-jpn' || activeModelType === 'alma-ja') {
+      // JA↔EN specialized models: simple translation prompt
+      // These models are fine-tuned specifically for JA↔EN, so a simple prompt works best.
+      // Gemma-2-2B-JPN-IT-Translate is trained to translate sentence by sentence.
+      const contextSection = buildContextPrompt(translateContext)
+      prompt = `${contextSection}Translate the following text from ${fromLang} to ${toLang}. Output only the translation, nothing else.\n\n${text}`
+      inferenceParams = { temperature: 0.1, maxTokens: 512 }
     } else {
       // TranslateGemma prompt
       const contextSection = buildContextPrompt(translateContext)
@@ -294,6 +301,8 @@ async function handleTranslateIncremental(
       } else {
         prompt = `${contextSection}Translate the following segment into ${toLang}, without additional explanation.\n\n${text}`
       }
+    } else if (activeModelType === 'gemma2-jpn' || activeModelType === 'alma-ja') {
+      prompt = `${contextSection}Translate the following text from ${fromLang} to ${toLang}. Output only the translation, nothing else.\n\n${text}`
     } else {
       prompt = `${contextSection}Translate the following text from ${fromLang} to ${toLang}. Output only the translation, nothing else.\n\n${text}`
     }

--- a/src/renderer/components/SettingsPanel.tsx
+++ b/src/renderer/components/SettingsPanel.tsx
@@ -351,6 +351,18 @@ function SettingsPanel(): React.JSX.Element {
           sttEngineId: sttEngine,
           translatorEngineId: 'hunyuan-mt-15'
         }
+      } else if (resolvedMode === 'offline-gemma2-jpn') {
+        config = {
+          mode: 'cascade' as const,
+          sttEngineId: sttEngine,
+          translatorEngineId: 'gemma2-jpn'
+        }
+      } else if (resolvedMode === 'offline-alma-ja') {
+        config = {
+          mode: 'cascade' as const,
+          sttEngineId: sttEngine,
+          translatorEngineId: 'alma-ja'
+        }
       } else if (resolvedMode === 'offline-ane') {
         config = {
           mode: 'cascade' as const,
@@ -478,6 +490,8 @@ function SettingsPanel(): React.JSX.Element {
       case 'offline-hybrid': return 'Hybrid (OPUS-MT + TranslateGemma)'
       case 'offline-slm': return 'TranslateGemma'
       case 'offline-hunyuan-mt-15': return 'HY-MT1.5-1.8B'
+      case 'offline-gemma2-jpn': return 'Gemma-2-2B JA↔EN'
+      case 'offline-alma-ja': return 'ALMA-7B-Ja-V2'
       case 'offline-hunyuan-mt': return 'Hunyuan-MT 7B'
       case 'offline-opus': return 'OPUS-MT'
       case 'offline-ct2-opus': return 'OPUS-MT (CTranslate2)'

--- a/src/renderer/components/settings/TranslatorSettings.tsx
+++ b/src/renderer/components/settings/TranslatorSettings.tsx
@@ -76,7 +76,7 @@ export function TranslatorSettings({
   const [newGlossarySource, setNewGlossarySource] = useState('')
   const [newGlossaryTarget, setNewGlossaryTarget] = useState('')
 
-  const showSlmOptions = ['offline-slm', 'offline-hunyuan-mt', 'offline-hunyuan-mt-15', 'offline-hybrid'].includes(engineMode)
+  const showSlmOptions = ['offline-slm', 'offline-hunyuan-mt', 'offline-hunyuan-mt-15', 'offline-gemma2-jpn', 'offline-alma-ja', 'offline-hybrid'].includes(engineMode)
   const isApiEngine = ['rotation', 'online', 'online-deepl', 'online-gemini'].includes(engineMode)
 
   return (
@@ -122,6 +122,32 @@ export function TranslatorSettings({
           <div>
             <div style={{ fontWeight: 500 }}>HY-MT1.5-1.8B (Recommended)</div>
             <div style={{ fontSize: '12px', color: '#94a3b8' }}>36 languages, ~1.1GB — fast and lightweight</div>
+          </div>
+        </label>
+        <label style={radioLabelStyle}>
+          <input
+            type="radio"
+            name="engine"
+            checked={engineMode === 'offline-gemma2-jpn'}
+            onChange={() => onEngineModeChange('offline-gemma2-jpn')}
+            disabled={disabled}
+          />
+          <div>
+            <div style={{ fontWeight: 500 }}>Gemma-2-2B JA↔EN</div>
+            <div style={{ fontSize: '12px', color: '#94a3b8' }}>JA↔EN specialized, ~1.6GB — fast and compact</div>
+          </div>
+        </label>
+        <label style={radioLabelStyle}>
+          <input
+            type="radio"
+            name="engine"
+            checked={engineMode === 'offline-alma-ja'}
+            onChange={() => onEngineModeChange('offline-alma-ja')}
+            disabled={disabled}
+          />
+          <div>
+            <div style={{ fontWeight: 500 }}>ALMA-7B-Ja-V2</div>
+            <div style={{ fontSize: '12px', color: '#94a3b8' }}>JA↔EN specialized, COMET 0.88, ~3.9GB</div>
           </div>
         </label>
         <label style={radioLabelStyle}>

--- a/src/renderer/components/settings/shared.ts
+++ b/src/renderer/components/settings/shared.ts
@@ -25,7 +25,7 @@ export const LANGUAGE_LABELS: Record<Language, string> = {
 
 export const ALL_LANGUAGES = Object.keys(LANGUAGE_LABELS) as Language[]
 
-export type EngineMode = 'auto' | 'rotation' | 'online' | 'online-deepl' | 'online-gemini' | 'offline-opus' | 'offline-ct2-opus' | 'offline-madlad-400' | 'offline-slm' | 'offline-hunyuan-mt' | 'offline-hunyuan-mt-15' | 'offline-ane' | 'offline-hybrid'
+export type EngineMode = 'auto' | 'rotation' | 'online' | 'online-deepl' | 'online-gemini' | 'offline-opus' | 'offline-ct2-opus' | 'offline-madlad-400' | 'offline-slm' | 'offline-hunyuan-mt' | 'offline-hunyuan-mt-15' | 'offline-gemma2-jpn' | 'offline-alma-ja' | 'offline-ane' | 'offline-hybrid'
 
 export type SttEngineType = 'whisper-local' | 'mlx-whisper' | 'moonshine' | 'sensevoice'
 export type WhisperVariantType = 'kotoba-v2.0' | 'large-v3-turbo'


### PR DESCRIPTION
## Description

Add two JA↔EN specialized translation models that significantly outperform general-purpose models for Japanese-English translation:

- **Gemma-2-2B-JPN-IT-Translate** (~1.6GB Q4_K_M): Compact 2B model specialized for JA↔EN, comparable quality to 7B general-purpose models at half the size
- **ALMA-7B-Ja-V2** (~3.9GB Q4_K_M): High-quality 7B model achieving COMET 0.8818 for EN→JA translation

Both models reuse the existing `slm-worker.ts` UtilityProcess infrastructure (node-llama-cpp), following the same pattern as HunyuanMTTranslator and HunyuanMT15Translator.

### Changes
- Added GGUF variant configs for both models in `model-downloader.ts`
- Created `Gemma2JpnTranslator.ts` and `AlmaJaTranslator.ts` engine classes
- Added `gemma2-jpn` and `alma-ja` model types to `slm-worker.ts`
- Registered both engines in `main/index.ts` pipeline initialization
- Added engine options to SettingsPanel UI with radio buttons
- Updated `EngineMode` type to include new offline modes

Closes #312