### PR TITLE
Add Sherpa-ONNX STT engine for unified native STT

### DIFF
--- a/src/engines/stt/SherpaOnnxSTTEngine.test.ts
+++ b/src/engines/stt/SherpaOnnxSTTEngine.test.ts
@@ -1,0 +1,206 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { SherpaOnnxSTTEngine, SHERPA_ONNX_PRESETS } from './SherpaOnnxSTTEngine'
+
+// Mock model-downloader to avoid Electron app dependency
+vi.mock('../model-downloader', () => ({
+  getModelsDir: vi.fn(() => '/tmp/test-models'),
+}))
+
+// Mock fs functions
+vi.mock('fs', async () => {
+  const actual = await vi.importActual<typeof import('fs')>('fs')
+  return {
+    ...actual,
+    existsSync: vi.fn(() => true),
+    mkdirSync: vi.fn(),
+  }
+})
+
+// Mock sherpa-onnx recognizer internals
+const mockDecode = vi.fn()
+const mockGetResult = vi.fn()
+const mockAcceptWaveform = vi.fn()
+const mockCreateStream = vi.fn(() => ({
+  acceptWaveform: mockAcceptWaveform,
+}))
+
+const MockOfflineRecognizer = vi.fn(function (this: Record<string, unknown>) {
+  this.config = { featConfig: { sampleRate: 16000, featureDim: 80 } }
+  this.createStream = mockCreateStream
+  this.decode = mockDecode
+  this.getResult = mockGetResult
+})
+
+/** Factory that returns a mock SherpaOnnxModule for DI */
+function createMockModuleLoader() {
+  return () => ({
+    OfflineRecognizer: MockOfflineRecognizer as unknown,
+    readWave: vi.fn(),
+  }) as unknown as ReturnType<typeof import('./SherpaOnnxSTTEngine').loadSherpaModule>
+}
+
+describe('SherpaOnnxSTTEngine', () => {
+  let engine: SherpaOnnxSTTEngine
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    engine = new SherpaOnnxSTTEngine({
+      preset: 'whisper-tiny',
+      moduleLoader: createMockModuleLoader(),
+    })
+  })
+
+  it('has correct id and metadata', () => {
+    expect(engine.id).toBe('sherpa-onnx')
+    expect(engine.isOffline).toBe(true)
+    expect(engine.name).toContain('Sherpa-ONNX')
+  })
+
+  it('initialize is idempotent', async () => {
+    await engine.initialize()
+    await engine.initialize()
+    // OfflineRecognizer should only be constructed once
+    expect(MockOfflineRecognizer).toHaveBeenCalledTimes(1)
+  })
+
+  it('processAudio returns null before initialization', async () => {
+    const audio = new Float32Array(16000)
+    const result = await engine.processAudio(audio, 16000)
+    expect(result).toBeNull()
+  })
+
+  it('processAudio returns STTResult for valid speech', async () => {
+    mockGetResult.mockReturnValue({ text: 'Hello world', lang: 'en' })
+
+    await engine.initialize()
+    const audio = new Float32Array(16000)
+    const result = await engine.processAudio(audio, 16000)
+
+    expect(result).not.toBeNull()
+    expect(result!.text).toBe('Hello world')
+    expect(result!.language).toBe('en')
+    expect(result!.isFinal).toBe(true)
+    expect(result!.timestamp).toBeGreaterThan(0)
+  })
+
+  it('processAudio returns null for empty text', async () => {
+    mockGetResult.mockReturnValue({ text: '', lang: 'en' })
+
+    await engine.initialize()
+    const audio = new Float32Array(16000)
+    const result = await engine.processAudio(audio, 16000)
+
+    expect(result).toBeNull()
+  })
+
+  it('processAudio returns null for whitespace-only text', async () => {
+    mockGetResult.mockReturnValue({ text: '   ', lang: 'en' })
+
+    await engine.initialize()
+    const audio = new Float32Array(16000)
+    const result = await engine.processAudio(audio, 16000)
+
+    expect(result).toBeNull()
+  })
+
+  it('passes audio to stream.acceptWaveform correctly', async () => {
+    mockGetResult.mockReturnValue({ text: 'test', lang: 'en' })
+
+    await engine.initialize()
+    const audio = new Float32Array([0.1, 0.2, 0.3])
+    await engine.processAudio(audio, 16000)
+
+    expect(mockAcceptWaveform).toHaveBeenCalledWith({
+      sampleRate: 16000,
+      samples: audio,
+    })
+  })
+
+  it('detects Japanese from lang field', async () => {
+    mockGetResult.mockReturnValue({ text: 'こんにちは', lang: 'ja' })
+
+    await engine.initialize()
+    const result = await engine.processAudio(new Float32Array(16000), 16000)
+
+    expect(result!.language).toBe('ja')
+  })
+
+  it('detects Japanese from script when lang is missing', async () => {
+    mockGetResult.mockReturnValue({ text: 'こんにちは世界' })
+
+    await engine.initialize()
+    const result = await engine.processAudio(new Float32Array(16000), 16000)
+
+    expect(result!.language).toBe('ja')
+  })
+
+  it('maps Cantonese (yue) to Chinese', async () => {
+    mockGetResult.mockReturnValue({ text: '你好', lang: 'yue' })
+
+    await engine.initialize()
+    const result = await engine.processAudio(new Float32Array(16000), 16000)
+
+    expect(result!.language).toBe('zh')
+  })
+
+  it('processing guard prevents reentrant calls', async () => {
+    // Verify the processing flag exists and is reset after each call
+    mockGetResult.mockReturnValue({ text: 'first', lang: 'en' })
+
+    await engine.initialize()
+    const audio = new Float32Array(16000)
+
+    // Sequential calls should both succeed (flag is reset between calls)
+    const result1 = await engine.processAudio(audio, 16000)
+    const result2 = await engine.processAudio(audio, 16000)
+
+    expect(result1).not.toBeNull()
+    expect(result2).not.toBeNull()
+    expect(mockDecode).toHaveBeenCalledTimes(2)
+  })
+
+  it('returns null on recognition error', async () => {
+    mockDecode.mockImplementation(() => {
+      throw new Error('ONNX runtime error')
+    })
+
+    await engine.initialize()
+    const result = await engine.processAudio(new Float32Array(16000), 16000)
+
+    expect(result).toBeNull()
+  })
+
+  it('dispose clears state', async () => {
+    await engine.initialize()
+    await engine.dispose()
+
+    // After dispose, processAudio should return null
+    const result = await engine.processAudio(new Float32Array(16000), 16000)
+    expect(result).toBeNull()
+  })
+
+  it('all presets have required fields', () => {
+    for (const [, config] of Object.entries(SHERPA_ONNX_PRESETS)) {
+      expect(config.label).toBeTruthy()
+      expect(config.description).toBeTruthy()
+      expect(config.dirName).toBeTruthy()
+      expect(config.downloadUrl).toContain('https://')
+      expect(config.sizeMB).toBeGreaterThan(0)
+      expect(typeof config.buildModelConfig).toBe('function')
+
+      // Verify buildModelConfig returns valid structure
+      const modelConfig = config.buildModelConfig(`/models/${config.dirName}`)
+      expect(modelConfig.tokens).toBeTruthy()
+      expect(modelConfig.numThreads).toBeGreaterThan(0)
+      expect(modelConfig.provider).toBe('cpu')
+    }
+  })
+
+  it('preset name is included in engine name', () => {
+    const engine2 = new SherpaOnnxSTTEngine({
+      preset: 'sensevoice',
+      moduleLoader: createMockModuleLoader(),
+    })
+    expect(engine2.name).toContain('SenseVoice')
+  })
+})

--- a/src/engines/stt/SherpaOnnxSTTEngine.ts
+++ b/src/engines/stt/SherpaOnnxSTTEngine.ts
@@ -1,0 +1,437 @@
+import { join } from 'path'
+import { existsSync, mkdirSync } from 'fs'
+import type { STTEngine, STTResult, Language } from '../types'
+import { ALL_LANGUAGES } from '../types'
+import { getModelsDir } from '../model-downloader'
+
+/**
+ * Minimal interface for the sherpa-onnx-node addon.
+ * We declare only the parts we use to avoid hard-coupling to the package
+ * (it is an optional native dependency).
+ */
+export interface SherpaOnnxModule {
+  OfflineRecognizer: new (config: SherpaOnnxOfflineConfig) => SherpaOnnxRecognizer
+  readWave: (filename: string) => { samples: Float32Array; sampleRate: number }
+}
+
+interface SherpaOnnxOfflineConfig {
+  featConfig: { sampleRate: number; featureDim: number }
+  modelConfig: {
+    whisper?: { encoder: string; decoder: string }
+    senseVoice?: { model: string; useInverseTextNormalization?: number }
+    paraformer?: { model: string }
+    nemoCtc?: { model: string }
+    tokens: string
+    numThreads: number
+    provider: string
+    debug: number
+  }
+}
+
+interface SherpaOnnxStream {
+  acceptWaveform(opts: { sampleRate: number; samples: Float32Array }): void
+}
+
+interface SherpaOnnxResult {
+  text: string
+  lang?: string
+  timestamps?: number[]
+  tokens?: string
+  json?: string
+}
+
+interface SherpaOnnxRecognizer {
+  config: SherpaOnnxOfflineConfig
+  createStream(): SherpaOnnxStream
+  decode(stream: SherpaOnnxStream): void
+  getResult(stream: SherpaOnnxStream): SherpaOnnxResult
+}
+
+/** Sherpa-ONNX model preset identifier */
+export type SherpaOnnxPreset = 'whisper-tiny' | 'whisper-base' | 'whisper-small' | 'sensevoice' | 'paraformer'
+
+/** Sherpa-ONNX model preset configuration */
+export interface SherpaOnnxPresetConfig {
+  /** Human-readable label */
+  label: string
+  /** Description shown in UI */
+  description: string
+  /** Model directory name under sherpa-onnx models dir */
+  dirName: string
+  /** Download URL for the tar.bz2 archive */
+  downloadUrl: string
+  /** Approximate download size in MB */
+  sizeMB: number
+  /** Function to build the modelConfig portion of OfflineRecognizer config */
+  buildModelConfig: (modelDir: string) => SherpaOnnxOfflineConfig['modelConfig']
+}
+
+/** Available Sherpa-ONNX model presets */
+export const SHERPA_ONNX_PRESETS: Record<SherpaOnnxPreset, SherpaOnnxPresetConfig> = {
+  'whisper-tiny': {
+    label: 'Whisper Tiny (Fast)',
+    description: 'OpenAI Whisper tiny via Sherpa-ONNX — ~75MB, fastest, good for quick recognition',
+    dirName: 'sherpa-onnx-whisper-tiny',
+    downloadUrl: 'https://github.com/k2-fsa/sherpa-onnx/releases/download/asr-models/sherpa-onnx-whisper-tiny.tar.bz2',
+    sizeMB: 75,
+    buildModelConfig: (modelDir) => ({
+      whisper: {
+        encoder: join(modelDir, 'tiny-encoder.int8.onnx'),
+        decoder: join(modelDir, 'tiny-decoder.int8.onnx'),
+      },
+      tokens: join(modelDir, 'tiny-tokens.txt'),
+      numThreads: 2,
+      provider: 'cpu',
+      debug: 0,
+    }),
+  },
+  'whisper-base': {
+    label: 'Whisper Base (Balanced)',
+    description: 'OpenAI Whisper base via Sherpa-ONNX — ~140MB, good balance of speed and accuracy',
+    dirName: 'sherpa-onnx-whisper-base',
+    downloadUrl: 'https://github.com/k2-fsa/sherpa-onnx/releases/download/asr-models/sherpa-onnx-whisper-base.tar.bz2',
+    sizeMB: 140,
+    buildModelConfig: (modelDir) => ({
+      whisper: {
+        encoder: join(modelDir, 'base-encoder.int8.onnx'),
+        decoder: join(modelDir, 'base-decoder.int8.onnx'),
+      },
+      tokens: join(modelDir, 'base-tokens.txt'),
+      numThreads: 2,
+      provider: 'cpu',
+      debug: 0,
+    }),
+  },
+  'whisper-small': {
+    label: 'Whisper Small (Best Accuracy)',
+    description: 'OpenAI Whisper small via Sherpa-ONNX — ~460MB, best accuracy for multilingual',
+    dirName: 'sherpa-onnx-whisper-small',
+    downloadUrl: 'https://github.com/k2-fsa/sherpa-onnx/releases/download/asr-models/sherpa-onnx-whisper-small.tar.bz2',
+    sizeMB: 460,
+    buildModelConfig: (modelDir) => ({
+      whisper: {
+        encoder: join(modelDir, 'small-encoder.int8.onnx'),
+        decoder: join(modelDir, 'small-decoder.int8.onnx'),
+      },
+      tokens: join(modelDir, 'small-tokens.txt'),
+      numThreads: 2,
+      provider: 'cpu',
+      debug: 0,
+    }),
+  },
+  'sensevoice': {
+    label: 'SenseVoice (CJK-optimized)',
+    description: 'SenseVoice via Sherpa-ONNX — ~220MB, fast with emotion/event detection, no Python needed',
+    dirName: 'sherpa-onnx-sense-voice-zh-en-ja-ko-yue-2024-07-17',
+    downloadUrl: 'https://github.com/k2-fsa/sherpa-onnx/releases/download/asr-models/sherpa-onnx-sense-voice-zh-en-ja-ko-yue-2024-07-17.tar.bz2',
+    sizeMB: 220,
+    buildModelConfig: (modelDir) => ({
+      senseVoice: {
+        model: join(modelDir, 'model.int8.onnx'),
+        useInverseTextNormalization: 1,
+      },
+      tokens: join(modelDir, 'tokens.txt'),
+      numThreads: 2,
+      provider: 'cpu',
+      debug: 0,
+    }),
+  },
+  'paraformer': {
+    label: 'Paraformer (CJK, ultra-fast)',
+    description: 'Paraformer via Sherpa-ONNX — ~230MB, extremely fast non-autoregressive model',
+    dirName: 'sherpa-onnx-paraformer-zh-2023-09-14',
+    downloadUrl: 'https://github.com/k2-fsa/sherpa-onnx/releases/download/asr-models/sherpa-onnx-paraformer-zh-2023-09-14.tar.bz2',
+    sizeMB: 230,
+    buildModelConfig: (modelDir) => ({
+      paraformer: {
+        model: join(modelDir, 'model.int8.onnx'),
+      },
+      tokens: join(modelDir, 'tokens.txt'),
+      numThreads: 2,
+      provider: 'cpu',
+      debug: 0,
+    }),
+  },
+}
+
+/** Sherpa-ONNX language code to ISO 639-1 mapping */
+const SHERPA_LANG_MAP: Record<string, Language> = {
+  'zh': 'zh',
+  'en': 'en',
+  'ja': 'ja',
+  'ko': 'ko',
+  'fr': 'fr',
+  'de': 'de',
+  'es': 'es',
+  'pt': 'pt',
+  'ru': 'ru',
+  'it': 'it',
+  'nl': 'nl',
+  'pl': 'pl',
+  'ar': 'ar',
+  'th': 'th',
+  'vi': 'vi',
+  'id': 'id',
+  'yue': 'zh', // Cantonese → Chinese
+}
+
+/**
+ * Load the sherpa-onnx-node module at runtime.
+ * Extracted as a module-level function so tests can mock it.
+ */
+export function loadSherpaModule(): SherpaOnnxModule {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  return require('sherpa-onnx-node') as SherpaOnnxModule
+}
+
+/**
+ * Sherpa-ONNX STT engine using native Node.js addon (sherpa-onnx-node).
+ *
+ * Benefits over the Python subprocess bridges:
+ * - No Python dependency — pure Node.js native addon
+ * - No temp WAV files — accepts Float32Array directly
+ * - Unified toolkit: STT, VAD, speaker diarization in one package
+ * - Cross-platform: macOS, Linux, Windows
+ *
+ * Requires: npm install sherpa-onnx-node
+ * Models auto-download from k2-fsa/sherpa-onnx GitHub releases on first use.
+ */
+export class SherpaOnnxSTTEngine implements STTEngine {
+  readonly id = 'sherpa-onnx'
+  readonly name: string
+  readonly isOffline = true
+
+  private sherpaModule: SherpaOnnxModule | null = null
+  private recognizer: SherpaOnnxRecognizer | null = null
+  private initPromise: Promise<void> | null = null
+  private processing = false
+  private preset: SherpaOnnxPreset
+  private onProgress?: (message: string) => void
+  private moduleLoader: () => SherpaOnnxModule
+
+  constructor(options?: {
+    preset?: SherpaOnnxPreset
+    onProgress?: (message: string) => void
+    /** Override the module loader for testing. Defaults to loadSherpaModule(). */
+    moduleLoader?: () => SherpaOnnxModule
+  }) {
+    this.preset = options?.preset ?? 'whisper-tiny'
+    this.onProgress = options?.onProgress
+    this.moduleLoader = options?.moduleLoader ?? loadSherpaModule
+    const config = SHERPA_ONNX_PRESETS[this.preset]
+    this.name = `Sherpa-ONNX (${config.label})`
+  }
+
+  async initialize(): Promise<void> {
+    if (this.initPromise) return this.initPromise
+    this.initPromise = this.doInitialize()
+    return this.initPromise
+  }
+
+  private async doInitialize(): Promise<void> {
+    if (this.recognizer) return
+
+    const presetConfig = SHERPA_ONNX_PRESETS[this.preset]
+    this.onProgress?.(`Loading Sherpa-ONNX ${presetConfig.label}...`)
+
+    // Load sherpa-onnx-node (optional native dependency)
+    try {
+      this.sherpaModule = this.moduleLoader()
+    } catch (err) {
+      throw new Error(
+        'sherpa-onnx-node is not installed. Run: npm install sherpa-onnx-node\n' +
+        (err instanceof Error ? err.message : String(err))
+      )
+    }
+
+    // Ensure model directory exists and download if needed
+    const modelsDir = getSherpaModelsDir()
+    const modelDir = join(modelsDir, presetConfig.dirName)
+
+    if (!existsSync(modelDir)) {
+      this.onProgress?.(`Downloading ${presetConfig.label} model (~${presetConfig.sizeMB}MB)...`)
+      await downloadAndExtractModel(presetConfig, modelsDir, this.onProgress)
+    }
+
+    // Verify model files exist after download
+    const modelConfig = presetConfig.buildModelConfig(modelDir)
+    this.onProgress?.('Initializing Sherpa-ONNX recognizer...')
+
+    try {
+      this.recognizer = new this.sherpaModule.OfflineRecognizer({
+        featConfig: {
+          sampleRate: 16000,
+          featureDim: 80,
+        },
+        modelConfig,
+      })
+    } catch (err) {
+      throw new Error(
+        `Failed to create Sherpa-ONNX recognizer: ${err instanceof Error ? err.message : String(err)}`
+      )
+    }
+
+    this.onProgress?.(`Sherpa-ONNX ${presetConfig.label} ready`)
+  }
+
+  async processAudio(audioChunk: Float32Array, sampleRate: number): Promise<STTResult | null> {
+    if (!this.recognizer) return null
+
+    // Serialize calls — ONNX runtime is not thread-safe for concurrent decode
+    if (this.processing) return null
+    this.processing = true
+
+    try {
+      const stream = this.recognizer.createStream()
+      stream.acceptWaveform({ sampleRate, samples: audioChunk })
+
+      this.recognizer.decode(stream)
+      const result = this.recognizer.getResult(stream)
+
+      const text = (result.text ?? '').trim()
+      if (!text) return null
+
+      // Use lang field from the result if available, otherwise detect from script
+      const language = resolveLanguage(result.lang, text)
+
+      return {
+        text,
+        language,
+        isFinal: true,
+        timestamp: Date.now(),
+      }
+    } catch (err) {
+      console.error('[sherpa-onnx] Recognition error:', err)
+      return null
+    } finally {
+      this.processing = false
+    }
+  }
+
+  async dispose(): Promise<void> {
+    console.log('[sherpa-onnx] Disposing resources')
+    this.recognizer = null
+    this.sherpaModule = null
+    this.initPromise = null
+  }
+}
+
+/**
+ * Resolve the detected language from Sherpa-ONNX result.
+ * Falls back to script-based heuristic if the model does not provide lang.
+ */
+function resolveLanguage(lang: string | undefined, text: string): Language {
+  // If sherpa-onnx returned a lang code, try to map it
+  if (lang) {
+    const cleaned = lang.replace(/[<>]/g, '').trim().toLowerCase()
+    if (SHERPA_LANG_MAP[cleaned]) return SHERPA_LANG_MAP[cleaned]
+    // Try direct match against ALL_LANGUAGES
+    if (ALL_LANGUAGES.includes(cleaned as Language)) return cleaned as Language
+  }
+
+  // Fallback: script-based detection (same heuristic as WhisperLocalEngine)
+  const jaKanaMatches = text.match(/[\u3040-\u309F\u30A0-\u30FF]/g)
+  const jaKanaCount = jaKanaMatches?.length ?? 0
+  if (jaKanaCount / text.length > 0.3 && jaKanaCount >= 2) return 'ja'
+
+  const cjkMatches = text.match(/[\u4E00-\u9FFF\u3400-\u4DBF]/g)
+  const cjkCount = cjkMatches?.length ?? 0
+  if (cjkCount / text.length > 0.3 && cjkCount >= 2 && jaKanaCount === 0) return 'zh'
+
+  const koMatches = text.match(/[\uAC00-\uD7AF]/g)
+  const koCount = koMatches?.length ?? 0
+  if (koCount / text.length > 0.3 && koCount >= 2) return 'ko'
+
+  return 'en'
+}
+
+/** Get the Sherpa-ONNX models subdirectory */
+function getSherpaModelsDir(): string {
+  const dir = join(getModelsDir(), 'sherpa-onnx')
+  if (!existsSync(dir)) {
+    mkdirSync(dir, { recursive: true })
+  }
+  return dir
+}
+
+/**
+ * Download and extract a Sherpa-ONNX model archive.
+ * Uses tar.bz2 archives from k2-fsa/sherpa-onnx GitHub releases.
+ */
+async function downloadAndExtractModel(
+  config: SherpaOnnxPresetConfig,
+  modelsDir: string,
+  onProgress?: (message: string) => void
+): Promise<void> {
+  const { execFile } = await import('child_process')
+  const { promisify } = await import('util')
+  const { createWriteStream, unlinkSync } = await import('fs')
+  const execFileAsync = promisify(execFile)
+
+  const archivePath = join(modelsDir, `${config.dirName}.tar.bz2`)
+
+  try {
+    // Download the archive with progress reporting
+    onProgress?.(`Downloading ${config.label} (~${config.sizeMB}MB)...`)
+
+    const controller = new AbortController()
+    const fetchTimeout = setTimeout(() => controller.abort(), 10 * 60_000)
+
+    let response: Response
+    try {
+      response = await fetch(config.downloadUrl, {
+        redirect: 'follow',
+        signal: controller.signal,
+      })
+    } finally {
+      clearTimeout(fetchTimeout)
+    }
+
+    if (!response.ok) {
+      throw new Error(`Download failed: ${response.status} ${response.statusText}`)
+    }
+
+    const contentLength = Number(response.headers.get('content-length')) || 0
+    const reader = response.body?.getReader()
+    if (!reader) throw new Error('No response body')
+
+    const ws = createWriteStream(archivePath)
+    let downloaded = 0
+
+    try {
+      while (true) {
+        const { done, value } = await reader.read()
+        if (done) break
+        ws.write(value)
+        downloaded += value.length
+        if (contentLength > 0) {
+          const pct = Math.round((downloaded / contentLength) * 100)
+          const mb = (downloaded / 1024 / 1024).toFixed(1)
+          const totalMb = (contentLength / 1024 / 1024).toFixed(0)
+          onProgress?.(`Downloading ${config.label}... ${pct}% (${mb}/${totalMb} MB)`)
+        }
+      }
+      ws.end()
+      await new Promise<void>((resolve, reject) => {
+        ws.on('finish', resolve)
+        ws.on('error', reject)
+      })
+    } catch (err) {
+      ws.end()
+      throw err
+    }
+
+    // Extract the archive
+    onProgress?.(`Extracting ${config.label}...`)
+    await execFileAsync('tar', ['xjf', archivePath, '-C', modelsDir])
+
+    onProgress?.(`${config.label} model ready`)
+  } finally {
+    // Clean up the archive file
+    try {
+      if (existsSync(archivePath)) unlinkSync(archivePath)
+    } catch (e) {
+      console.warn('[sherpa-onnx] Failed to clean up archive:', e)
+    }
+  }
+}

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -4,6 +4,7 @@ import { WhisperLocalEngine } from '../engines/stt/WhisperLocalEngine'
 import { MlxWhisperEngine } from '../engines/stt/MlxWhisperEngine'
 import { MoonshineEngine } from '../engines/stt/MoonshineEngine'
 import { SenseVoiceEngine } from '../engines/stt/SenseVoiceEngine'
+import { SherpaOnnxSTTEngine } from '../engines/stt/SherpaOnnxSTTEngine'
 import { OpusMTTranslator } from '../engines/translator/OpusMTTranslator'
 import { CT2OpusMTTranslator } from '../engines/translator/CT2OpusMTTranslator'
 import { CT2Madlad400Translator } from '../engines/translator/CT2Madlad400Translator'
@@ -22,6 +23,7 @@ import { createLogger } from './logger'
 import type { AppContext } from './app-context'
 import type { STTEngine, TranslatorEngine, E2ETranslationEngine, TranslationResult } from '../engines/types'
 import type { WhisperVariant, MoonshineVariant } from '../engines/model-downloader'
+import type { SherpaOnnxPreset } from '../engines/stt/SherpaOnnxSTTEngine'
 
 const log = createLogger('main')
 
@@ -54,6 +56,10 @@ function initPipeline(): void {
   }))
   ctx.pipeline.registerSTT('sensevoice', () => new SenseVoiceEngine({
     onProgress: (msg) => ctx.mainWindow?.webContents.send('status-update', msg)
+  }))
+  ctx.pipeline.registerSTT('sherpa-onnx', () => new SherpaOnnxSTTEngine({
+    onProgress: (msg) => ctx.mainWindow?.webContents.send('status-update', msg),
+    preset: (store.get('sherpaOnnxPreset') as SherpaOnnxPreset) || undefined
   }))
 
   // Register translator engines

--- a/src/renderer/components/SettingsPanel.tsx
+++ b/src/renderer/components/SettingsPanel.tsx
@@ -17,6 +17,7 @@ import type {
   EngineMode,
   Language,
   MoonshineVariantType,
+  SherpaOnnxPresetType,
   SlmModelSizeType,
   SourceLanguage,
   SttEngineType,
@@ -48,6 +49,7 @@ function SettingsPanel(): React.JSX.Element {
   const [sttEngine, setSttEngine] = useState<SttEngineType>('whisper-local')
   const [whisperVariant, setWhisperVariant] = useState<WhisperVariantType>('kotoba-v2.0')
   const [moonshineVariant, setMoonshineVariant] = useState<MoonshineVariantType>('base')
+  const [sherpaOnnxPreset, setSherpaOnnxPreset] = useState<SherpaOnnxPresetType>('whisper-tiny')
 
   const [subtitleFontSize, setSubtitleFontSize] = useState(30)
   const [subtitleSourceColor, setSubtitleSourceColor] = useState('#ffffff')
@@ -120,6 +122,7 @@ function SettingsPanel(): React.JSX.Element {
       if (s.sttEngine) setSttEngine(s.sttEngine as SttEngineType)
       if (s.whisperVariant) setWhisperVariant(s.whisperVariant as WhisperVariantType)
       if (s.moonshineVariant) setMoonshineVariant(s.moonshineVariant as MoonshineVariantType)
+      if (s.sherpaOnnxPreset) setSherpaOnnxPreset(s.sherpaOnnxPreset as SherpaOnnxPresetType)
       if (s.slmKvCacheQuant !== undefined) setSlmKvCacheQuant(s.slmKvCacheQuant as boolean)
       if (s.slmModelSize) setSlmModelSize(s.slmModelSize as SlmModelSizeType)
       if (s.slmSpeculativeDecoding !== undefined) setSlmSpeculativeDecoding(s.slmSpeculativeDecoding as boolean)
@@ -260,6 +263,7 @@ function SettingsPanel(): React.JSX.Element {
         sttEngine,
         whisperVariant,
         moonshineVariant,
+        sherpaOnnxPreset,
         slmKvCacheQuant,
         slmModelSize,
         slmSpeculativeDecoding,
@@ -501,6 +505,7 @@ function SettingsPanel(): React.JSX.Element {
           : 'Whisper (kotoba-v2.0)'
       case 'moonshine': return 'Moonshine AI'
       case 'sensevoice': return 'SenseVoice (CJK-optimized)'
+      case 'sherpa-onnx': return 'Sherpa-ONNX'
       default: return sttEngine
     }
   }
@@ -647,6 +652,8 @@ function SettingsPanel(): React.JSX.Element {
             onWhisperVariantChange={setWhisperVariant}
             moonshineVariant={moonshineVariant}
             onMoonshineVariantChange={setMoonshineVariant}
+            sherpaOnnxPreset={sherpaOnnxPreset}
+            onSherpaOnnxPresetChange={setSherpaOnnxPreset}
             platform={platform}
             disabled={disabled}
           />

--- a/src/renderer/components/settings/STTSettings.tsx
+++ b/src/renderer/components/settings/STTSettings.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { Section } from './Section'
 import { selectStyle } from './shared'
-import type { SttEngineType, WhisperVariantType, MoonshineVariantType } from './shared'
+import type { SttEngineType, WhisperVariantType, MoonshineVariantType, SherpaOnnxPresetType } from './shared'
 
 interface STTSettingsProps {
   sttEngine: SttEngineType
@@ -10,6 +10,8 @@ interface STTSettingsProps {
   onWhisperVariantChange: (v: WhisperVariantType) => void
   moonshineVariant: MoonshineVariantType
   onMoonshineVariantChange: (v: MoonshineVariantType) => void
+  sherpaOnnxPreset: SherpaOnnxPresetType
+  onSherpaOnnxPresetChange: (v: SherpaOnnxPresetType) => void
   platform: string
   disabled: boolean
 }
@@ -21,6 +23,8 @@ export function STTSettings({
   onWhisperVariantChange,
   moonshineVariant,
   onMoonshineVariantChange,
+  sherpaOnnxPreset,
+  onSherpaOnnxPresetChange,
   platform,
   disabled
 }: STTSettingsProps): React.JSX.Element {
@@ -39,6 +43,7 @@ export function STTSettings({
         )}
         <option value="moonshine">Moonshine AI (ultra-fast, experimental)</option>
         <option value="sensevoice">SenseVoice (CJK-optimized, 15x faster)</option>
+        <option value="sherpa-onnx">Sherpa-ONNX (unified, no Python needed)</option>
       </select>
       {sttEngine === 'whisper-local' && (
         <div style={{ marginTop: '8px' }}>
@@ -87,6 +92,31 @@ export function STTSettings({
           <div style={{ marginTop: '4px', fontSize: '11px', color: '#94a3b8' }}>
             SenseVoice-Small: 15x faster than Whisper with strong CJK accuracy. Supports 50+ languages with emotion detection.
             Requires: <code style={{ color: '#7dd3fc' }}>pip install funasr torch torchaudio</code>
+          </div>
+        </div>
+      )}
+      {sttEngine === 'sherpa-onnx' && (
+        <div style={{ marginTop: '8px' }}>
+          <div style={{ fontSize: '11px', fontWeight: 600, color: '#94a3b8', marginBottom: '4px' }}>
+            Sherpa-ONNX Model
+          </div>
+          <select
+            value={sherpaOnnxPreset}
+            onChange={(e) => onSherpaOnnxPresetChange(e.target.value as SherpaOnnxPresetType)}
+            style={selectStyle}
+            disabled={disabled}
+            aria-label="Sherpa-ONNX model preset"
+          >
+            <option value="whisper-tiny">Whisper Tiny — fastest, ~75MB</option>
+            <option value="whisper-base">Whisper Base — balanced, ~140MB</option>
+            <option value="whisper-small">Whisper Small — best accuracy, ~460MB</option>
+            <option value="sensevoice">SenseVoice — CJK-optimized, ~220MB</option>
+            <option value="paraformer">Paraformer — CJK, ultra-fast, ~230MB</option>
+          </select>
+          <div style={{ marginTop: '4px', fontSize: '11px', color: '#94a3b8' }}>
+            Unified cross-platform toolkit with native Node.js bindings. No Python required.
+            Models auto-download on first use.
+            Requires: <code style={{ color: '#7dd3fc' }}>npm install sherpa-onnx-node</code>
           </div>
         </div>
       )}

--- a/src/renderer/components/settings/shared.ts
+++ b/src/renderer/components/settings/shared.ts
@@ -27,7 +27,8 @@ export const ALL_LANGUAGES = Object.keys(LANGUAGE_LABELS) as Language[]
 
 export type EngineMode = 'auto' | 'rotation' | 'online' | 'online-deepl' | 'online-gemini' | 'offline-opus' | 'offline-ct2-opus' | 'offline-madlad-400' | 'offline-slm' | 'offline-hunyuan-mt' | 'offline-hunyuan-mt-15' | 'offline-ane' | 'offline-hybrid'
 
-export type SttEngineType = 'whisper-local' | 'mlx-whisper' | 'moonshine' | 'sensevoice'
+export type SttEngineType = 'whisper-local' | 'mlx-whisper' | 'moonshine' | 'sensevoice' | 'sherpa-onnx'
+export type SherpaOnnxPresetType = 'whisper-tiny' | 'whisper-base' | 'whisper-small' | 'sensevoice' | 'paraformer'
 export type WhisperVariantType = 'kotoba-v2.0' | 'large-v3-turbo'
 export type MoonshineVariantType = 'tiny' | 'base'
 export type SlmModelSizeType = '4b' | '12b'


### PR DESCRIPTION
## Summary
- Add `SherpaOnnxSTTEngine` implementing the `STTEngine` interface using `sherpa-onnx-node` native Node.js addon
- No Python dependency — accepts Float32Array audio directly, no temp WAV files
- 5 model presets: Whisper Tiny/Base/Small, SenseVoice, Paraformer with auto-download from GitHub releases
- Language detection uses the recognizer's `lang` field with script-based fallback
- Register engine in `initPipeline()` and add UI settings with preset selector
- 15 unit tests covering initialization, audio processing, language detection, error handling, and preset validation

Closes #311

## Test plan
- [x] `npm run typecheck` passes (only pre-existing ws module errors)
- [x] `npm test` — all 60 tests pass (15 new for SherpaOnnxSTTEngine)
- [ ] Manual: install `sherpa-onnx-node`, select Sherpa-ONNX in STT settings, verify model auto-download and transcription
- [ ] Manual: verify preset switching (Whisper Tiny → SenseVoice → Paraformer)