### PR TITLE
Add DeepFilterNet3 noise suppression for cleaner STT input

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@huggingface/transformers": "^3.8.0",
         "@kutalia/whisper-node-addon": "^1.1.0",
         "@ricky0123/vad-web": "^0.0.30",
+        "deepfilternet3-noise-filter": "^1.2.1",
         "electron-store": "^10.0.0",
         "node-llama-cpp": "^3.0.0",
         "ws": "^8.20.0"
@@ -334,6 +335,12 @@
       "engines": {
         "node": ">=6.9.0"
       }
+    },
+    "node_modules/@bufbuild/protobuf": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-1.10.1.tgz",
+      "integrity": "sha512-wJ8ReQbHxsAfXhrf9ixl0aYbZorRuOWpBNzm8pL8ftmSxQx/wnJD5Eg861NwJU/czy2VXFIebCeZnZrI9rktIQ==",
+      "license": "(Apache-2.0 AND BSD-3-Clause)"
     },
     "node_modules/@develar/schema-utils": {
       "version": "2.6.5",
@@ -2085,6 +2092,21 @@
       "integrity": "sha512-GaHYm+c0O9MjZRu0ongGBRbinu8gVAMd2UZjji6jVmqKtZluZnptXGWhz1E8j8D2HJ3f/yMxKAUC0b+57wncIw==",
       "license": "MIT"
     },
+    "node_modules/@livekit/mutex": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@livekit/mutex/-/mutex-1.1.1.tgz",
+      "integrity": "sha512-EsshAucklmpuUAfkABPxJNhzj9v2sG7JuzFDL4ML1oJQSV14sqrpTYnsaOudMAw9yOaW53NU3QQTlUQoRs4czw==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@livekit/protocol": {
+      "version": "1.44.0",
+      "resolved": "https://registry.npmjs.org/@livekit/protocol/-/protocol-1.44.0.tgz",
+      "integrity": "sha512-/vfhDUGcUKO8Q43r6i+5FrDhl5oZjm/X3U4x2Iciqvgn5C8qbj+57YPcWSJ1kyIZm5Cm6AV2nAPjMm3ETD/iyg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@bufbuild/protobuf": "^1.10.0"
+      }
+    },
     "node_modules/@malept/cross-spawn-promise": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@malept/cross-spawn-promise/-/cross-spawn-promise-2.0.0.tgz",
@@ -3473,6 +3495,13 @@
       "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/dom-mediacapture-record": {
+      "version": "1.0.22",
+      "resolved": "https://registry.npmjs.org/@types/dom-mediacapture-record/-/dom-mediacapture-record-1.0.22.tgz",
+      "integrity": "sha512-mUMZLK3NvwRLcAAT9qmcK+9p7tpU2FHdDsntR3YI4+GY88XrgG4XiE7u1Q2LAN2/FZOz/tdMDC3GQCR4T8nFuw==",
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/esrecurse": {
       "version": "4.3.1",
@@ -5544,6 +5573,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/deepfilternet3-noise-filter": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/deepfilternet3-noise-filter/-/deepfilternet3-noise-filter-1.2.1.tgz",
+      "integrity": "sha512-OAyrHTDlUHH+AhfpVNKYEOhVqb9cZpu0fdNThplA/tB/Ts4PF/UsI+abl2n1IbSxUkhiF0OqDejEhk1n42Oqpw==",
+      "license": "(Apache-2.0 OR MIT)",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "livekit-client": "^2.0.0"
+      }
+    },
     "node_modules/defaults": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.4.tgz",
@@ -6430,6 +6471,15 @@
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
       "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
       "license": "MIT"
+    },
+    "node_modules/events": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.x"
+      }
     },
     "node_modules/expect-type": {
       "version": "1.3.0",
@@ -7690,6 +7740,15 @@
         "node": ">=10"
       }
     },
+    "node_modules/jose": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.2.tgz",
+      "integrity": "sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -8121,6 +8180,27 @@
         "url": "https://opencollective.com/parcel"
       }
     },
+    "node_modules/livekit-client": {
+      "version": "2.18.0",
+      "resolved": "https://registry.npmjs.org/livekit-client/-/livekit-client-2.18.0.tgz",
+      "integrity": "sha512-wjH4y0rw5fnkPmmaxutPhD4XcAq6goQszS8lw9PEpGXVwiRE6sI/ZH+mOT/s8AHJnEC3tjmfiMZ4MQt8BlaWew==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@livekit/mutex": "1.1.1",
+        "@livekit/protocol": "1.44.0",
+        "events": "^3.3.0",
+        "jose": "^6.1.0",
+        "loglevel": "^1.9.2",
+        "sdp-transform": "^2.15.0",
+        "tslib": "2.8.1",
+        "typed-emitter": "^2.1.0",
+        "webrtc-adapter": "^9.0.1"
+      },
+      "peerDependencies": {
+        "@types/dom-mediacapture-record": "^1"
+      }
+    },
     "node_modules/locate-path": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
@@ -8200,6 +8280,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/loglevel": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.9.2.tgz",
+      "integrity": "sha512-HgMmCqIJSAKqo68l0rS2AanEWfkxaZ5wNiEFb5ggm08lDs9Xl2KxBlX3PTcaD2chBM1gXAYf491/M2Rv8Jwayg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6.0"
+      },
+      "funding": {
+        "type": "tidelift",
+        "url": "https://tidelift.com/funding/github/npm/loglevel"
       }
     },
     "node_modules/long": {
@@ -9538,6 +9631,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -10097,6 +10191,16 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/rxjs": {
+      "version": "7.8.2",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
+      "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
@@ -10151,6 +10255,21 @@
       "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/sdp": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/sdp/-/sdp-3.2.1.tgz",
+      "integrity": "sha512-lwsAIzOPlH8/7IIjjz3K0zYBk7aBVVcvjMwt3M4fLxpjMYyy7i3I97SLHebgn4YBjirkzfp3RvRDWSKsh/+WFw==",
+      "license": "MIT"
+    },
+    "node_modules/sdp-transform": {
+      "version": "2.15.0",
+      "resolved": "https://registry.npmjs.org/sdp-transform/-/sdp-transform-2.15.0.tgz",
+      "integrity": "sha512-KrOH82c/W+GYQ0LHqtr3caRpM3ITglq3ljGUIb8LTki7ByacJZ9z+piSGiwZDsRyhQbYBOBJgr2k6X4BZXi3Kw==",
+      "license": "MIT",
+      "bin": {
+        "sdp-verify": "checker.js"
+      }
     },
     "node_modules/semver": {
       "version": "6.3.1",
@@ -10891,8 +11010,7 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "license": "0BSD",
-      "optional": true
+      "license": "0BSD"
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -10917,6 +11035,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/typed-emitter": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/typed-emitter/-/typed-emitter-2.1.0.tgz",
+      "integrity": "sha512-g/KzbYKbH5C2vPkaXGu8DJlHrGKHLsM25Zg9WuC9pMGfuvT+X25tZQWo5fK1BjBm8+UrVE9LDCvaY0CQk+fXDA==",
+      "license": "MIT",
+      "optionalDependencies": {
+        "rxjs": "*"
       }
     },
     "node_modules/typescript": {
@@ -11745,6 +11872,19 @@
       "license": "MIT",
       "dependencies": {
         "defaults": "^1.0.3"
+      }
+    },
+    "node_modules/webrtc-adapter": {
+      "version": "9.0.4",
+      "resolved": "https://registry.npmjs.org/webrtc-adapter/-/webrtc-adapter-9.0.4.tgz",
+      "integrity": "sha512-5ZZY1+lGq8LEKuDlg9M2RPJHlH3R7OVwyHqMcUsLKCgd9Wvf+QrFTCItkXXYPmrJn8H6gRLXbSgxLLdexiqHxw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "sdp": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=6.0.0",
+        "npm": ">=3.10.0"
       }
     },
     "node_modules/when-exit": {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "@huggingface/transformers": "^3.8.0",
     "@kutalia/whisper-node-addon": "^1.1.0",
     "@ricky0123/vad-web": "^0.0.30",
+    "deepfilternet3-noise-filter": "^1.2.1",
     "electron-store": "^10.0.0",
     "node-llama-cpp": "^3.0.0",
     "ws": "^8.20.0"

--- a/src/main/store.ts
+++ b/src/main/store.ts
@@ -64,6 +64,8 @@ export interface AppSettings {
   targetLanguage: Language
   /** WebSocket port for Chrome extension audio server (default 9876) */
   wsAudioPort: number
+  /** Enable DeepFilterNet3 noise suppression for cleaner STT input (#313) */
+  noiseSuppressionEnabled: boolean
 }
 
 export const store = new Store<AppSettings>({
@@ -98,6 +100,7 @@ export const store = new Store<AppSettings>({
     moonshineVariant: 'base',
     sourceLanguage: 'auto',
     targetLanguage: 'en',
-    wsAudioPort: 9876
+    wsAudioPort: 9876,
+    noiseSuppressionEnabled: false
   }
 })

--- a/src/renderer/components/SettingsPanel.tsx
+++ b/src/renderer/components/SettingsPanel.tsx
@@ -1,5 +1,6 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react'
 import { useAudioCapture } from '../hooks/useAudioCapture'
+import { useNoiseSuppression } from '../hooks/useNoiseSuppression'
 import {
   AudioSettings,
   LanguageSettings,
@@ -76,7 +77,9 @@ function SettingsPanel(): React.JSX.Element {
   const [showAdvanced, setShowAdvanced] = useState(false)
   const [showApiOptions, setShowApiOptions] = useState(false)
 
-  const audio = useAudioCapture()
+  // #313: Noise suppression
+  const noiseSuppression = useNoiseSuppression()
+  const audio = useAudioCapture(noiseSuppression.enabled ? noiseSuppression : undefined)
 
   const formatDuration = useCallback((ms: number): string => {
     const totalSec = Math.floor(ms / 1000)
@@ -128,6 +131,7 @@ function SettingsPanel(): React.JSX.Element {
       if (s.simulMtWaitK !== undefined) setSimulMtWaitK(s.simulMtWaitK as number)
       if (s.sourceLanguage) setSourceLanguage(s.sourceLanguage as SourceLanguage)
       if (s.targetLanguage) setTargetLanguage(s.targetLanguage as Language)
+      if (s.noiseSuppressionEnabled !== undefined) noiseSuppression.setEnabled(s.noiseSuppressionEnabled as boolean)
       if (s.subtitleSettings) {
         const sub = s.subtitleSettings as Record<string, unknown>
         if (sub.fontSize) setSubtitleFontSize(sub.fontSize as number)
@@ -266,7 +270,8 @@ function SettingsPanel(): React.JSX.Element {
         simulMtEnabled,
         simulMtWaitK,
         sourceLanguage,
-        targetLanguage
+        targetLanguage,
+        noiseSuppressionEnabled: noiseSuppression.enabled
       }), 10_000, 'saveSettings')
 
       // Resolve auto mode to concrete engine
@@ -585,7 +590,12 @@ function SettingsPanel(): React.JSX.Element {
       )}
 
       {/* Microphone Selection — always visible */}
-      <AudioSettings audio={audio} disabled={disabled} />
+      <AudioSettings
+        audio={audio}
+        disabled={disabled}
+        noiseSuppressionEnabled={noiseSuppression.enabled}
+        onNoiseSuppressionChange={noiseSuppression.setEnabled}
+      />
 
       {/* Current config summary — always visible */}
       <div style={{

--- a/src/renderer/components/settings/AudioSettings.tsx
+++ b/src/renderer/components/settings/AudioSettings.tsx
@@ -6,9 +6,12 @@ import type { UseAudioCaptureReturn } from '../../hooks/useAudioCapture'
 interface AudioSettingsProps {
   audio: UseAudioCaptureReturn
   disabled: boolean
+  /** #313: Noise suppression enabled state */
+  noiseSuppressionEnabled: boolean
+  onNoiseSuppressionChange: (enabled: boolean) => void
 }
 
-export function AudioSettings({ audio, disabled }: AudioSettingsProps): React.JSX.Element {
+export function AudioSettings({ audio, disabled, noiseSuppressionEnabled, onNoiseSuppressionChange }: AudioSettingsProps): React.JSX.Element {
   return (
     <Section label="Microphone">
       <select
@@ -36,6 +39,25 @@ export function AudioSettings({ audio, disabled }: AudioSettingsProps): React.JS
           }}
         />
       </div>
+      {/* #313: Noise suppression toggle */}
+      <label style={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: '8px',
+        marginTop: '8px',
+        fontSize: '13px',
+        color: '#94a3b8',
+        cursor: disabled ? 'default' : 'pointer'
+      }}>
+        <input
+          type="checkbox"
+          checked={noiseSuppressionEnabled}
+          onChange={(e) => onNoiseSuppressionChange(e.target.checked)}
+          disabled={disabled}
+          aria-label="Enable noise suppression"
+        />
+        <span>Noise suppression (DeepFilterNet3)</span>
+      </label>
       {audio.permissionError && (
         <div style={{ marginTop: '6px', fontSize: '12px', color: '#ef4444' }}>
           {audio.permissionError}

--- a/src/renderer/hooks/useAudioCapture.ts
+++ b/src/renderer/hooks/useAudioCapture.ts
@@ -24,10 +24,16 @@ export interface UseAudioCaptureReturn {
   onSpeechSegmentEnd: (callback: (finalBuffer: Float32Array) => void) => () => void
 }
 
+/** Optional noise suppression preprocessor injected from the parent component */
+export interface NoiseSuppressionProcessor {
+  processStream: (stream: MediaStream) => Promise<MediaStream>
+  destroy: () => Promise<void>
+}
+
 const STREAMING_INTERVAL_MS = 2000
 const SAMPLE_RATE = 16000
 
-export function useAudioCapture(): UseAudioCaptureReturn {
+export function useAudioCapture(noiseSuppression?: NoiseSuppressionProcessor): UseAudioCaptureReturn {
   const [devices, setDevices] = useState<AudioDevice[]>([])
   const [selectedDevice, setSelectedDevice] = useState<string>('')
   const [isCapturing, setIsCapturing] = useState(false)
@@ -135,15 +141,23 @@ export function useAudioCapture(): UseAudioCaptureReturn {
     const deviceId = selectedDevice
     const vad = await MicVAD.new({
       getStream: async () => {
-        return navigator.mediaDevices.getUserMedia({
+        // #313: Request 48 kHz when DeepFilterNet3 is active (it requires 48 kHz);
+        // VAD resamples internally to 16 kHz regardless.
+        const idealSampleRate = noiseSuppression ? 48000 : 16000
+        const rawStream = await navigator.mediaDevices.getUserMedia({
           audio: {
             deviceId: deviceId ? { exact: deviceId } : undefined,
             channelCount: 1,
-            sampleRate: { ideal: 16000 },
+            sampleRate: { ideal: idealSampleRate },
             echoCancellation: true,
-            noiseSuppression: true
+            noiseSuppression: !noiseSuppression // disable browser NS when DeepFilterNet3 is active
           }
         })
+        // #313: Apply DeepFilterNet3 noise suppression before VAD
+        if (noiseSuppression) {
+          return noiseSuppression.processStream(rawStream)
+        }
+        return rawStream
       },
       // Override with more sensitive thresholds for real-time translation
       positiveSpeechThreshold: 0.3,
@@ -224,6 +238,8 @@ export function useAudioCapture(): UseAudioCaptureReturn {
       vadRef.current.destroy()
       vadRef.current = null
     }
+    // #313: Release DeepFilterNet3 resources
+    noiseSuppression?.destroy().catch((err) => console.warn('[audio-capture] Noise suppression cleanup error:', err))
     isSpeakingRef.current = false
     rollingBufferRef.current = []
     rollingBufferIndexRef.current = 0
@@ -231,7 +247,7 @@ export function useAudioCapture(): UseAudioCaptureReturn {
     setIsCapturing(false)
     setVolume(0)
     console.log('[audio-capture] VAD stopped')
-  }, [stopStreamingTimer])
+  }, [stopStreamingTimer, noiseSuppression])
 
   const onAudioChunk = useCallback((callback: (chunk: Float32Array) => void) => {
     chunkCallbackRef.current = callback

--- a/src/renderer/hooks/useNoiseSuppression.test.ts
+++ b/src/renderer/hooks/useNoiseSuppression.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// Mock DeepFilterNet3Core as a class since it requires browser APIs (AudioContext, WASM)
+vi.mock('deepfilternet3-noise-filter', () => ({
+  DeepFilterNet3Core: class MockDeepFilterNet3Core {
+    initialize = vi.fn().mockResolvedValue(undefined)
+    createAudioWorkletNode = vi.fn().mockResolvedValue({
+      connect: vi.fn().mockReturnValue({ connect: vi.fn() }),
+      disconnect: vi.fn()
+    })
+    setSuppressionLevel = vi.fn()
+    setNoiseSuppressionEnabled = vi.fn()
+    destroy = vi.fn()
+    isReady = vi.fn().mockReturnValue(true)
+  }
+}))
+
+describe('useNoiseSuppression module', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('exports useNoiseSuppression hook', async () => {
+    const mod = await import('./useNoiseSuppression')
+    expect(mod.useNoiseSuppression).toBeDefined()
+    expect(typeof mod.useNoiseSuppression).toBe('function')
+  })
+
+  it('DeepFilterNet3Core can be instantiated with config', async () => {
+    const { DeepFilterNet3Core } = await import('deepfilternet3-noise-filter')
+    const core = new DeepFilterNet3Core({
+      sampleRate: 48000,
+      noiseReductionLevel: 60
+    })
+    expect(core).toBeDefined()
+    expect(core.initialize).toBeDefined()
+    expect(core.createAudioWorkletNode).toBeDefined()
+    expect(core.setSuppressionLevel).toBeDefined()
+    expect(core.destroy).toBeDefined()
+  })
+
+  it('DeepFilterNet3Core initialize resolves without error', async () => {
+    const { DeepFilterNet3Core } = await import('deepfilternet3-noise-filter')
+    const core = new DeepFilterNet3Core({ sampleRate: 48000 })
+    await expect(core.initialize()).resolves.toBeUndefined()
+  })
+})

--- a/src/renderer/hooks/useNoiseSuppression.ts
+++ b/src/renderer/hooks/useNoiseSuppression.ts
@@ -1,0 +1,152 @@
+import { useCallback, useRef, useState } from 'react'
+import { DeepFilterNet3Core } from 'deepfilternet3-noise-filter'
+
+/**
+ * DeepFilterNet3 noise suppression hook.
+ *
+ * Wraps a raw MediaStream through a DeepFilterNet3 AudioWorklet processor
+ * that runs at 48 kHz.  The returned `processStream` inserts the worklet
+ * between the mic source and the VAD consumer so that STT only sees
+ * cleaned audio.
+ *
+ * Design decisions:
+ *  - 48 kHz AudioContext required by DeepFilterNet3 WASM; VAD resamples
+ *    internally to 16 kHz so this is transparent to downstream consumers.
+ *  - Assets (WASM + model) are loaded from the default CDN on first init.
+ *  - Suppression level defaults to 60 (0–100 scale).
+ */
+
+/** Default suppression level (0–100). 60 provides good balance of noise removal vs. speech distortion. */
+const DEFAULT_SUPPRESSION_LEVEL = 60
+
+export interface UseNoiseSuppressionReturn {
+  /** Whether noise suppression is enabled */
+  enabled: boolean
+  /** Toggle noise suppression on/off */
+  setEnabled: (enabled: boolean) => void
+  /** Current suppression level (0–100) */
+  suppressionLevel: number
+  /** Update suppression level */
+  setSuppressionLevel: (level: number) => void
+  /** Whether the processor is initialized and ready */
+  isReady: boolean
+  /**
+   * Process a raw MediaStream through DeepFilterNet3.
+   * Returns a new MediaStream with noise-suppressed audio.
+   * If suppression is disabled, returns the original stream unchanged.
+   */
+  processStream: (stream: MediaStream) => Promise<MediaStream>
+  /** Release all resources */
+  destroy: () => Promise<void>
+}
+
+export function useNoiseSuppression(): UseNoiseSuppressionReturn {
+  const [enabled, setEnabled] = useState(false)
+  const [suppressionLevel, setSuppressionLevel] = useState(DEFAULT_SUPPRESSION_LEVEL)
+  const [isReady, setIsReady] = useState(false)
+
+  const coreRef = useRef<DeepFilterNet3Core | null>(null)
+  const audioCtxRef = useRef<AudioContext | null>(null)
+  const workletNodeRef = useRef<AudioWorkletNode | null>(null)
+  const sourceNodeRef = useRef<MediaStreamAudioSourceNode | null>(null)
+  const destNodeRef = useRef<MediaStreamAudioDestinationNode | null>(null)
+
+  const destroy = useCallback(async () => {
+    try {
+      workletNodeRef.current?.disconnect()
+    } catch { /* ignore */ }
+    try {
+      sourceNodeRef.current?.disconnect()
+    } catch { /* ignore */ }
+
+    if (coreRef.current) {
+      try { coreRef.current.destroy() } catch { /* ignore */ }
+      coreRef.current = null
+    }
+
+    if (audioCtxRef.current && audioCtxRef.current.state !== 'closed') {
+      try { await audioCtxRef.current.close() } catch { /* ignore */ }
+    }
+
+    audioCtxRef.current = null
+    workletNodeRef.current = null
+    sourceNodeRef.current = null
+    destNodeRef.current = null
+    setIsReady(false)
+  }, [])
+
+  const processStream = useCallback(async (stream: MediaStream): Promise<MediaStream> => {
+    if (!enabled) return stream
+
+    // Tear down previous graph if any
+    await destroy()
+
+    try {
+      // DeepFilterNet3 requires 48 kHz
+      const audioTrack = stream.getAudioTracks()[0]
+      const trackSettings = audioTrack.getSettings()
+      const sampleRate = trackSettings.sampleRate || 48000
+
+      const ctx = new AudioContext({ sampleRate })
+      audioCtxRef.current = ctx
+
+      const core = new DeepFilterNet3Core({
+        sampleRate: ctx.sampleRate,
+        noiseReductionLevel: suppressionLevel
+      })
+      await core.initialize()
+      coreRef.current = core
+
+      const node = await core.createAudioWorkletNode(ctx)
+      workletNodeRef.current = node
+
+      const source = ctx.createMediaStreamSource(stream)
+      sourceNodeRef.current = source
+
+      const dest = ctx.createMediaStreamDestination()
+      destNodeRef.current = dest
+
+      source.connect(node).connect(dest)
+
+      core.setSuppressionLevel(suppressionLevel)
+      core.setNoiseSuppressionEnabled(true)
+
+      setIsReady(true)
+      console.log('[noise-suppression] DeepFilterNet3 initialized at', ctx.sampleRate, 'Hz')
+
+      return dest.stream
+    } catch (err) {
+      console.error('[noise-suppression] Failed to initialize DeepFilterNet3:', err)
+      // Fallback: return original stream so capture still works
+      await destroy()
+      return stream
+    }
+  }, [enabled, suppressionLevel, destroy])
+
+  // Update suppression level on the live processor
+  const updateSuppressionLevel = useCallback((level: number) => {
+    const clamped = Math.max(0, Math.min(100, level))
+    setSuppressionLevel(clamped)
+    if (coreRef.current) {
+      coreRef.current.setSuppressionLevel(clamped)
+    }
+  }, [])
+
+  // Update enabled state on the live processor
+  const updateEnabled = useCallback((value: boolean) => {
+    setEnabled(value)
+    if (coreRef.current) {
+      coreRef.current.setNoiseSuppressionEnabled(value)
+    }
+  }, [])
+
+  return {
+    enabled,
+    setEnabled: updateEnabled,
+    suppressionLevel,
+    setSuppressionLevel: updateSuppressionLevel,
+    isReady,
+    processStream,
+    destroy
+  }
+}


### PR DESCRIPTION
## Summary
- Integrate DeepFilterNet3 WASM as a noise suppression preprocessing step before VAD/STT in the renderer audio pipeline
- New `useNoiseSuppression` hook wraps `DeepFilterNet3Core` AudioWorklet at 48 kHz (VAD resamples internally to 16 kHz)
- Toggle in Audio Settings to enable/disable; setting persisted via electron-store
- Graceful fallback: if DeepFilterNet3 init fails, original stream is used

## Changes
- `src/renderer/hooks/useNoiseSuppression.ts` — new hook wrapping DeepFilterNet3Core lifecycle
- `src/renderer/hooks/useAudioCapture.ts` — accepts optional `NoiseSuppressionProcessor`, inserts into `getStream` callback
- `src/renderer/components/settings/AudioSettings.tsx` — noise suppression checkbox
- `src/renderer/components/SettingsPanel.tsx` — wires hook + persists setting
- `src/main/store.ts` — `noiseSuppressionEnabled` setting (default: false)
- `src/renderer/hooks/useNoiseSuppression.test.ts` — unit tests

## Test plan
- [ ] Enable noise suppression toggle, start session — verify DeepFilterNet3 initializes at 48 kHz
- [ ] Verify STT accuracy improves with background noise (fan, keyboard)
- [ ] Verify latency stays under 20ms additional overhead
- [ ] Disable toggle — verify browser-native noiseSuppression is used instead
- [ ] Test fallback: block CDN assets — verify capture works without noise suppression

Closes #313