### PR TITLE
Add Sherpa-ONNX STT engine for unified native Node.js speech recognition

### DIFF
--- a/src/engines/stt/SherpaOnnxEngine.ts
+++ b/src/engines/stt/SherpaOnnxEngine.ts
@@ -1,0 +1,285 @@
+import { join } from 'path'
+import { existsSync, mkdirSync } from 'fs'
+import { app } from 'electron'
+import type { STTEngine, STTResult, Language } from '../types'
+import { ALL_LANGUAGES } from '../types'
+
+/**
+ * Sherpa-ONNX recognizer result as returned by getResult().
+ * See OfflineRecognitionResult::AsJsonString() in C++ for full fields.
+ */
+interface SherpaOnnxResult {
+  text: string
+  lang?: string
+  tokens?: string[]
+  timestamps?: number[]
+}
+
+/** Minimal typings for the sherpa-onnx-node native addon */
+interface SherpaOnnxModule {
+  OfflineRecognizer: new (config: SherpaOnnxConfig) => SherpaOnnxRecognizer
+}
+
+interface SherpaOnnxRecognizer {
+  createStream(): SherpaOnnxStream
+  decode(stream: SherpaOnnxStream): void
+  getResult(stream: SherpaOnnxStream): SherpaOnnxResult
+}
+
+interface SherpaOnnxStream {
+  acceptWaveform(params: { sampleRate: number; samples: Float32Array }): void
+}
+
+interface SherpaOnnxConfig {
+  featConfig: { sampleRate: number; featureDim: number }
+  modelConfig: {
+    whisper?: { encoder: string; decoder: string }
+    senseVoice?: { model: string }
+    paraformer?: { model: string }
+    tokens: string
+    numThreads: number
+    provider: string
+    debug: number
+  }
+}
+
+/** Supported Sherpa-ONNX model types */
+export type SherpaOnnxModelType = 'whisper' | 'sensevoice' | 'paraformer'
+
+/** Configuration for a Sherpa-ONNX model */
+export interface SherpaOnnxModelConfig {
+  type: SherpaOnnxModelType
+  /** Directory name under models/sherpa-onnx/ where model files are expected */
+  dirName: string
+  /** Human-readable label */
+  label: string
+  /** Description shown in UI */
+  description: string
+}
+
+/** Available Sherpa-ONNX model presets */
+export const SHERPA_ONNX_MODELS: Record<string, SherpaOnnxModelConfig> = {
+  'whisper-tiny': {
+    type: 'whisper',
+    dirName: 'sherpa-onnx-whisper-tiny',
+    label: 'Whisper Tiny',
+    description: 'Whisper tiny.en — lightweight, English-focused (~75MB)'
+  },
+  'whisper-base': {
+    type: 'whisper',
+    dirName: 'sherpa-onnx-whisper-base',
+    label: 'Whisper Base',
+    description: 'Whisper base — multilingual, fast (~150MB)'
+  },
+  'sensevoice-small': {
+    type: 'sensevoice',
+    dirName: 'sherpa-onnx-sense-voice-zh-en-ja-ko-yue-2024-07-17',
+    label: 'SenseVoice Small',
+    description: 'SenseVoice-Small — CJK-optimized with emotion detection (~230MB)'
+  },
+  'paraformer-zh': {
+    type: 'paraformer',
+    dirName: 'sherpa-onnx-paraformer-zh-2023-09-14',
+    label: 'Paraformer (Chinese)',
+    description: 'Paraformer — fast Chinese STT (~230MB)'
+  }
+}
+
+const LOG_PREFIX = '[sherpa-onnx]'
+const MODELS_SUBDIR = 'sherpa-onnx'
+
+/**
+ * Sherpa-ONNX STT engine using native Node.js addon (no Python dependency).
+ *
+ * Sherpa-ONNX is a unified cross-platform toolkit providing STT, VAD,
+ * speaker diarization, and TTS. This engine wraps the offline (non-streaming)
+ * recognizer for batch transcription of audio chunks.
+ *
+ * Supports multiple model architectures: Whisper, SenseVoice, Paraformer.
+ *
+ * Requires: `npm install sherpa-onnx-node` and pre-downloaded model files
+ * under `userData/models/sherpa-onnx/<model-dir>/`.
+ */
+export class SherpaOnnxEngine implements STTEngine {
+  readonly id = 'sherpa-onnx'
+  readonly name: string
+  readonly isOffline = true
+
+  private recognizer: SherpaOnnxRecognizer | null = null
+  private initPromise: Promise<void> | null = null
+  private modelKey: string
+  private onProgress?: (message: string) => void
+
+  constructor(options?: {
+    modelKey?: string
+    onProgress?: (message: string) => void
+  }) {
+    this.modelKey = options?.modelKey ?? 'whisper-base'
+    this.onProgress = options?.onProgress
+    const config = SHERPA_ONNX_MODELS[this.modelKey]
+    this.name = config
+      ? `Sherpa-ONNX (${config.label})`
+      : 'Sherpa-ONNX'
+  }
+
+  async initialize(): Promise<void> {
+    if (this.initPromise) return this.initPromise
+    this.initPromise = this.doInitialize()
+    return this.initPromise
+  }
+
+  private async doInitialize(): Promise<void> {
+    if (this.recognizer) return
+
+    const modelConfig = SHERPA_ONNX_MODELS[this.modelKey]
+    if (!modelConfig) {
+      throw new Error(`${LOG_PREFIX} Unknown model key: ${this.modelKey}`)
+    }
+
+    this.onProgress?.(`Loading Sherpa-ONNX ${modelConfig.label}...`)
+
+    // Ensure models directory exists
+    const modelsRoot = join(app.getPath('userData'), 'models', MODELS_SUBDIR)
+    if (!existsSync(modelsRoot)) {
+      mkdirSync(modelsRoot, { recursive: true })
+    }
+
+    const modelDir = join(modelsRoot, modelConfig.dirName)
+    if (!existsSync(modelDir)) {
+      throw new Error(
+        `${LOG_PREFIX} Model directory not found: ${modelDir}. ` +
+        `Download the model from https://github.com/k2-fsa/sherpa-onnx/releases ` +
+        `and extract it to ${modelsRoot}/`
+      )
+    }
+
+    // Dynamic require to avoid hard dependency — sherpa-onnx-node is optional.
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    let sherpaOnnx: SherpaOnnxModule
+    try {
+      sherpaOnnx = require('sherpa-onnx-node') as SherpaOnnxModule
+    } catch (err) {
+      throw new Error(
+        `${LOG_PREFIX} Failed to load sherpa-onnx-node. ` +
+        `Install it with: npm install sherpa-onnx-node. ` +
+        `Error: ${err instanceof Error ? err.message : err}`
+      )
+    }
+
+    const config = this.buildConfig(modelConfig, modelDir)
+
+    try {
+      this.recognizer = new sherpaOnnx.OfflineRecognizer(config)
+    } catch (err) {
+      throw new Error(
+        `${LOG_PREFIX} Failed to create recognizer: ${err instanceof Error ? err.message : err}`
+      )
+    }
+
+    this.onProgress?.(`Sherpa-ONNX ${modelConfig.label} ready`)
+  }
+
+  private buildConfig(modelConfig: SherpaOnnxModelConfig, modelDir: string): SherpaOnnxConfig {
+    const tokensPath = join(modelDir, 'tokens.txt')
+    const base: SherpaOnnxConfig = {
+      featConfig: {
+        sampleRate: 16000,
+        featureDim: 80
+      },
+      modelConfig: {
+        tokens: tokensPath,
+        numThreads: 2,
+        provider: 'cpu',
+        debug: 0
+      }
+    }
+
+    switch (modelConfig.type) {
+      case 'whisper':
+        base.modelConfig.whisper = {
+          encoder: join(modelDir, 'encoder.onnx'),
+          decoder: join(modelDir, 'decoder.onnx')
+        }
+        break
+      case 'sensevoice':
+        base.modelConfig.senseVoice = {
+          model: join(modelDir, 'model.onnx')
+        }
+        break
+      case 'paraformer':
+        base.modelConfig.paraformer = {
+          model: join(modelDir, 'model.int8.onnx')
+        }
+        break
+    }
+
+    return base
+  }
+
+  async processAudio(audioChunk: Float32Array, sampleRate: number): Promise<STTResult | null> {
+    if (!this.recognizer) return null
+
+    try {
+      const stream = this.recognizer.createStream()
+      stream.acceptWaveform({ sampleRate, samples: audioChunk })
+      this.recognizer.decode(stream)
+      const result = this.recognizer.getResult(stream)
+
+      const text = (result.text ?? '').trim()
+      if (!text) return null
+
+      // Sherpa-ONNX returns a lang field (e.g., 'en', 'ja', 'zh')
+      const detectedLang = result.lang
+      const language: Language = (detectedLang && ALL_LANGUAGES.includes(detectedLang as Language))
+        ? (detectedLang as Language)
+        : this.detectLanguageFallback(text)
+
+      return {
+        text,
+        language,
+        isFinal: true,
+        timestamp: Date.now()
+      }
+    } catch (err) {
+      console.error(`${LOG_PREFIX} Transcription error:`, err)
+      return null
+    }
+  }
+
+  async dispose(): Promise<void> {
+    console.log(`${LOG_PREFIX} Disposing resources`)
+    // OfflineRecognizer is freed by GC; clear our reference
+    this.recognizer = null
+    this.initPromise = null
+  }
+
+  /**
+   * Fallback script-based language detection when the model does not
+   * provide a lang field (e.g., vanilla Whisper ONNX models).
+   */
+  private detectLanguageFallback(text: string): Language {
+    if (!text) return 'en'
+
+    const jpKana = text.match(/[\u3040-\u309F\u30A0-\u30FF]/g)
+    const jpCount = jpKana?.length ?? 0
+    if (jpCount / text.length > 0.3 && jpCount >= 2) return 'ja'
+
+    const cjk = text.match(/[\u4E00-\u9FFF\u3400-\u4DBF]/g)
+    const cjkCount = cjk?.length ?? 0
+    if (cjkCount / text.length > 0.3 && cjkCount >= 2 && jpCount === 0) return 'zh'
+
+    const ko = text.match(/[\uAC00-\uD7AF\u1100-\u11FF\u3130-\u318F]/g)
+    const koCount = ko?.length ?? 0
+    if (koCount / text.length > 0.3 && koCount >= 2) return 'ko'
+
+    const th = text.match(/[\u0E00-\u0E7F]/g)
+    const thCount = th?.length ?? 0
+    if (thCount / text.length > 0.3 && thCount >= 2) return 'th'
+
+    const ar = text.match(/[\u0600-\u06FF\u0750-\u077F]/g)
+    const arCount = ar?.length ?? 0
+    if (arCount / text.length > 0.3 && arCount >= 2) return 'ar'
+
+    return 'en'
+  }
+}

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -5,6 +5,7 @@ import { MlxWhisperEngine } from '../engines/stt/MlxWhisperEngine'
 import { MoonshineEngine } from '../engines/stt/MoonshineEngine'
 import { SenseVoiceEngine } from '../engines/stt/SenseVoiceEngine'
 import { LightningWhisperEngine } from '../engines/stt/LightningWhisperEngine'
+import { SherpaOnnxEngine } from '../engines/stt/SherpaOnnxEngine'
 import { OpusMTTranslator } from '../engines/translator/OpusMTTranslator'
 import { CT2OpusMTTranslator } from '../engines/translator/CT2OpusMTTranslator'
 import { CT2Madlad400Translator } from '../engines/translator/CT2Madlad400Translator'
@@ -60,6 +61,10 @@ function initPipeline(): void {
   }))
   ctx.pipeline.registerSTT('sensevoice', () => new SenseVoiceEngine({
     onProgress: (msg) => ctx.mainWindow?.webContents.send('status-update', msg)
+  }))
+  ctx.pipeline.registerSTT('sherpa-onnx', () => new SherpaOnnxEngine({
+    onProgress: (msg) => ctx.mainWindow?.webContents.send('status-update', msg),
+    modelKey: (store.get('sherpaOnnxModel') as string) || undefined
   }))
 
   // Register translator engines

--- a/src/main/ipc-handlers.ts
+++ b/src/main/ipc-handlers.ts
@@ -241,6 +241,7 @@ export function registerIpcHandlers(ctx: AppContext): void {
       simulMtWaitK: store.get('simulMtWaitK'),
       whisperVariant: store.get('whisperVariant'),
       moonshineVariant: store.get('moonshineVariant'),
+      sherpaOnnxModel: store.get('sherpaOnnxModel'),
       sourceLanguage: store.get('sourceLanguage'),
       targetLanguage: store.get('targetLanguage'),
       wsAudioPort: store.get('wsAudioPort')

--- a/src/main/store.ts
+++ b/src/main/store.ts
@@ -58,6 +58,8 @@ export interface AppSettings {
   whisperVariant: string
   /** Moonshine model variant for local STT: tiny (fastest) or base (recommended) */
   moonshineVariant: string
+  /** Sherpa-ONNX model key: whisper-tiny, whisper-base, sensevoice-small, paraformer-zh */
+  sherpaOnnxModel: string
   /** Source language: 'auto' for auto-detection or a specific language code */
   sourceLanguage: SourceLanguage
   /** Target language for translation output */
@@ -96,6 +98,7 @@ export const store = new Store<AppSettings>({
     simulMtWaitK: 3,
     whisperVariant: 'kotoba-v2.0',
     moonshineVariant: 'base',
+    sherpaOnnxModel: 'whisper-base',
     sourceLanguage: 'auto',
     targetLanguage: 'en',
     wsAudioPort: 9876

--- a/src/renderer/components/SettingsPanel.tsx
+++ b/src/renderer/components/SettingsPanel.tsx
@@ -515,6 +515,7 @@ function SettingsPanel(): React.JSX.Element {
           : 'Whisper (kotoba-v2.0)'
       case 'moonshine': return 'Moonshine AI'
       case 'sensevoice': return 'SenseVoice (CJK-optimized)'
+      case 'sherpa-onnx': return 'Sherpa-ONNX (unified)'
       default: return sttEngine
     }
   }

--- a/src/renderer/components/settings/STTSettings.tsx
+++ b/src/renderer/components/settings/STTSettings.tsx
@@ -42,6 +42,7 @@ export function STTSettings({
         )}
         <option value="moonshine">Moonshine AI (ultra-fast, experimental)</option>
         <option value="sensevoice">SenseVoice (CJK-optimized, 15x faster)</option>
+        <option value="sherpa-onnx">Sherpa-ONNX (unified, no Python)</option>
       </select>
       {sttEngine === 'whisper-local' && (
         <div style={{ marginTop: '8px' }}>
@@ -98,6 +99,16 @@ export function STTSettings({
           <div style={{ marginTop: '4px', fontSize: '11px', color: '#94a3b8' }}>
             SenseVoice-Small: 15x faster than Whisper with strong CJK accuracy. Supports 50+ languages with emotion detection.
             Requires: <code style={{ color: '#7dd3fc' }}>pip install funasr torch torchaudio</code>
+          </div>
+        </div>
+      )}
+      {sttEngine === 'sherpa-onnx' && (
+        <div style={{ marginTop: '8px' }}>
+          <div style={{ marginTop: '4px', fontSize: '11px', color: '#94a3b8' }}>
+            Sherpa-ONNX: unified cross-platform STT via native Node.js addon. No Python required.
+            Supports Whisper, SenseVoice, and Paraformer models via ONNX Runtime.
+            Requires: <code style={{ color: '#7dd3fc' }}>npm install sherpa-onnx-node</code> and
+            model files in <code style={{ color: '#7dd3fc' }}>userData/models/sherpa-onnx/</code>.
           </div>
         </div>
       )}

--- a/src/renderer/components/settings/shared.ts
+++ b/src/renderer/components/settings/shared.ts
@@ -27,7 +27,7 @@ export const ALL_LANGUAGES = Object.keys(LANGUAGE_LABELS) as Language[]
 
 export type EngineMode = 'auto' | 'rotation' | 'online' | 'online-deepl' | 'online-gemini' | 'offline-opus' | 'offline-ct2-opus' | 'offline-madlad-400' | 'offline-slm' | 'offline-hunyuan-mt' | 'offline-hunyuan-mt-15' | 'offline-gemma2-jpn' | 'offline-alma-ja' | 'offline-ane' | 'offline-hybrid'
 
-export type SttEngineType = 'whisper-local' | 'mlx-whisper' | 'lightning-whisper' | 'moonshine' | 'sensevoice'
+export type SttEngineType = 'whisper-local' | 'mlx-whisper' | 'lightning-whisper' | 'moonshine' | 'sensevoice' | 'sherpa-onnx'
 export type WhisperVariantType = 'kotoba-v2.0' | 'large-v3-turbo'
 export type MoonshineVariantType = 'tiny' | 'base'
 export type SlmModelSizeType = '4b' | '12b'


### PR DESCRIPTION
## Summary
- Add `SherpaOnnxEngine` STT engine using the `sherpa-onnx-node` native Node.js addon (no Python dependency)
- Supports multiple model architectures: Whisper, SenseVoice, and Paraformer via ONNX Runtime
- Register engine in pipeline, store, IPC settings, and settings UI dropdown

## Details
Sherpa-ONNX is a cross-platform toolkit that consolidates STT, VAD, speaker diarization, and TTS into a single native addon. This PR implements the STT engine integration as the first step toward replacing multiple separate libraries.

Key design decisions:
- Uses dynamic `require()` to keep sherpa-onnx-node as an optional dependency
- Model files are expected under `userData/models/sherpa-onnx/<model-dir>/` (manual download for now)
- Supports language detection via Sherpa-ONNX's built-in `lang` field with script-based fallback
- Follows existing engine patterns (idempotent init, null-safe processAudio, GC-based dispose)

## Test plan
- [x] TypeScript typecheck passes (no new errors)
- [x] All 45 existing tests pass
- [ ] Manual: install `sherpa-onnx-node`, download a model, select Sherpa-ONNX in settings, verify transcription

Closes #311