### PR TITLE
Add research evaluations for engine and platform expansion

### DIFF
--- a/docs/research/cross-platform-support.md
+++ b/docs/research/cross-platform-support.md
@@ -1,0 +1,137 @@
+# Cross-Platform Support Evaluation for live-translate
+
+**Issue:** #318
+**Date:** 2026-03-24
+**Status:** Research complete — Windows support is feasible with moderate effort; Linux is straightforward for packaging but needs native addon testing
+
+## 1. Current State
+
+| Platform | Status | Blocker |
+|----------|--------|---------|
+| macOS (arm64) | Production | — |
+| macOS (x64) | Untested | Native addon builds |
+| Windows (x64) | Experimental NSIS config exists | Native addon compatibility, no CI |
+| Linux (x64) | No support | No packaging, no CI |
+
+### Native Addon Dependencies
+| Addon | macOS | Windows | Linux | Notes |
+|-------|-------|---------|-------|-------|
+| whisper-node-addon | Pre-built (arm64/x64) | Pre-built (x64) | Pre-built (x64/arm64) | No Windows CUDA yet |
+| node-llama-cpp | Pre-built | Pre-built | Pre-built | Auto-detects GPU backend |
+| electron-store | Pure JS | Cross-platform | Cross-platform | No native code |
+
+## 2. Windows Support Assessment
+
+### Native Addon Compatibility
+
+**whisper-node-addon (@kutalia/whisper-node-addon):**
+- Pre-built `.node` binaries available for Windows x64
+- Automatic runtime detection — zero-config for Electron
+- **Limitation:** No CUDA backend for Windows yet (maintainer lacks NVIDIA GPU for testing)
+- CPU inference works out of the box; GPU acceleration via CUDA is a TODO
+
+**node-llama-cpp:**
+- Full Windows support with pre-built binaries
+- Auto-detects available hardware: CPU, CUDA, Vulkan
+- Falls back to source build with cmake if no pre-built binary matches
+
+**whisper.cpp (direct build for Windows):**
+- CUDA build supported: `cmake -DWHISPER_CUBLAS=ON` + MSVC + CUDA toolkit
+- OpenBLAS available as CPU fallback
+- DirectML support requested but not yet implemented
+- Vulkan backend available as alternative GPU acceleration
+
+### Windows NSIS Installer
+- Existing config needs testing and likely updates for current dependency versions
+- electron-builder NSIS is well-documented and widely used
+
+### Windows CI Pipeline
+- GitHub Actions `windows-latest` runner available
+- Need to add: build, lint, test steps for Windows
+- Native addon rebuild may be needed: `electron-builder install-app-deps`
+
+### Estimated Effort: Windows
+- 2-3 days: Fix NSIS installer, test native addons, verify audio capture
+- 1-2 days: Add Windows CI pipeline
+- 1 day: Platform-specific path handling (backslashes, AppData paths)
+- **Total: ~5 days**
+
+## 3. Linux Support Assessment
+
+### Packaging Options
+
+| Format | Pros | Cons |
+|--------|------|------|
+| AppImage | Self-contained, runs on any distro, no install needed | Larger file size, no auto-update integration |
+| Flatpak | Sandboxed, centralized updates via Flathub | Runtime dependency, complex for native addons |
+| .deb/.rpm | Native package manager integration | Distro-specific, need to maintain multiple formats |
+| Snap | Auto-updates, Ubuntu native | Confinement issues with audio devices |
+
+**Recommendation:** AppImage as primary (broadest compatibility), .deb as secondary (Ubuntu/Debian).
+
+### Native Addon Compatibility
+- whisper-node-addon: Pre-built for Linux x64/arm64
+- node-llama-cpp: Pre-built for Linux, auto-detects CUDA/Vulkan
+- Audio capture: PulseAudio or PipeWire required for `getUserMedia`
+
+### Linux-Specific Concerns
+- **Audio permissions:** PulseAudio/PipeWire access in AppImage may need `--no-sandbox` flag or proper Flatpak permissions
+- **GPU acceleration:** CUDA (NVIDIA) or Vulkan (AMD/Intel) — need to handle both
+- **Wayland vs X11:** Transparent overlay window behavior differs; X11 is more reliable for click-through
+
+### Estimated Effort: Linux
+- 1-2 days: AppImage packaging with electron-builder
+- 1 day: Audio capture testing (PulseAudio/PipeWire)
+- 1 day: Transparent overlay testing (X11/Wayland)
+- 1 day: Linux CI pipeline
+- **Total: ~5 days**
+
+## 4. Cross-Platform STT Fallback Strategy
+
+For reliable cross-platform STT, the engine selection should be:
+
+| Platform | Primary STT | Fallback STT |
+|----------|------------|--------------|
+| macOS | WhisperKit (ANE) or MLX-Whisper | whisper.cpp (Metal) |
+| Windows | whisper.cpp (CUDA) | Sherpa-ONNX (#311) |
+| Linux | whisper.cpp (CUDA/Vulkan) | Sherpa-ONNX (#311) |
+
+Sherpa-ONNX (#311) is the strongest cross-platform fallback — it supports Windows, Linux, macOS with ONNX Runtime and has no native compilation requirements.
+
+## 5. Competitive Landscape
+
+| Competitor | Platforms | Approach |
+|-----------|-----------|----------|
+| DeepL Voice | Web (all platforms) | Cloud-based |
+| Wordly | Web (all platforms) | Cloud-based |
+| KUDO | Web (all platforms) | Cloud-based |
+| LiveCaptions-Translator | Windows only | Local whisper.cpp |
+| RTranslator | Android only | Local |
+| **live-translate** | **macOS (current)** | **Local-first** |
+
+Adding Windows support would capture the largest desktop market. Most local competitors are single-platform.
+
+## 6. Recommendations
+
+### Priority Order
+1. **Windows support first** — largest desktop market share, existing NSIS config to build on, native addons already have pre-built Windows binaries
+2. **Linux second** — smaller market but important for developer/enterprise audience
+3. **macOS x64 third** — declining market (Intel Macs), but low effort if Windows works
+
+### Implementation Plan
+1. Fix and test Windows NSIS installer
+2. Add Windows CI pipeline (GitHub Actions)
+3. Verify all native addons work on Windows x64
+4. Add Sherpa-ONNX as cross-platform STT fallback (#311)
+5. Add AppImage packaging for Linux
+6. Add Linux CI pipeline
+7. Test audio capture and overlay on each platform
+
+## References
+- [whisper-node-addon (cross-platform)](https://github.com/Kutalia/whisper-node-addon)
+- [node-llama-cpp (cross-platform)](https://github.com/withcatai/node-llama-cpp)
+- [whisper.cpp Windows CUDA build](https://blog.binaee.com/2025/04/whisper-cpp-cuda-build-windows/)
+- [electron-builder AppImage](https://www.electron.build/appimage.html)
+- [electron-builder Flatpak](https://www.electron.build/flatpak.html)
+- [Building a Linux Electron App](https://www.dolthub.com/blog/2025-05-29-building-a-linux-electron-app/)
+- [LiveCaptions-Translator (Windows competitor)](https://github.com/nickmurraynyc/LiveCaptions-Translator)

--- a/docs/research/onnx-runtime-webgpu-evaluation.md
+++ b/docs/research/onnx-runtime-webgpu-evaluation.md
@@ -1,0 +1,141 @@
+# ONNX Runtime WebGPU Evaluation for live-translate
+
+**Issue:** #319
+**Date:** 2026-03-24
+**Status:** Research complete — viable for Moonshine and OPUS-MT acceleration; known Electron+Intel GPU issues to watch
+
+## 1. Overview
+
+ONNX Runtime Web with WebGPU execution provider enables GPU-accelerated ONNX model inference directly in the Electron renderer process, without native addons. This could accelerate Moonshine (STT) and OPUS-MT (translation) models.
+
+### WebGPU Browser Support (as of 2026)
+| Browser/Runtime | WebGPU Status | Notes |
+|----------------|---------------|-------|
+| Chrome 113+ | Enabled by default | Mac, Windows, ChromeOS |
+| Chrome 121+ | Enabled by default | Android |
+| Edge 113+ | Enabled by default | Same Chromium base |
+| Firefox | Shipped on Windows | Other platforms in progress |
+| Safari | In development | WebKit team actively working |
+| **Electron 33+** | **Available** | **Uses Chromium 128+** |
+
+### ONNX Runtime Web Versions
+- ONNX Runtime 1.17+: WebGPU execution provider officially launched
+- onnxruntime-web npm package: Drop-in for browser/Electron usage
+
+## 2. Benchmarks
+
+### General WebGPU Speedup (ONNX Runtime)
+| Model | CPU (WASM) | WebGPU | Speedup | Hardware |
+|-------|-----------|--------|---------|----------|
+| Segment Anything (encoder) | Baseline | 19x faster | 19x | RTX 3060 |
+| Segment Anything (decoder) | Baseline | 3.8x faster | 3.8x | RTX 3060 |
+
+### Moonshine Web (ONNX + WebGPU)
+Moonshine Web runs real-time speech recognition 100% in-browser using ONNX Runtime Web + Transformers.js with WebGPU acceleration and WASM fallback.
+
+| Metric | Moonshine (WebGPU) | Moonshine (WASM) | whisper.cpp (native) |
+|--------|--------------------|-------------------|---------------------|
+| Model size (tiny) | ~60 MB | ~60 MB | ~75 MB |
+| Latency | ~75ms | ~200-300ms | ~100ms |
+| WER | ~5% | ~5% | ~2.8% |
+| Platform | Any (browser) | Any (browser) | Native only |
+
+SpeedPower.run benchmarks Moonshine-Tiny with hybrid-precision (FP32 encoder + Q4 decoder) to measure GPU throughput.
+
+### OPUS-MT (WebGPU potential)
+OPUS-MT ONNX models are small (~50-200 MB per language pair) and well-suited for WebGPU acceleration. Expected 3-5x speedup over WASM for the transformer attention layers.
+
+## 3. Electron-Specific Considerations
+
+### Known Issues
+- **Intel integrated GPU bug:** Incorrect/unstable predictions on Intel Gen-9, Gen-11, Gen-12LP iGPUs when running ONNX Runtime WebGPU in Electron ([Issue #24442](https://github.com/microsoft/onnxruntime/issues/24442)). Does not occur in Chrome on the same hardware.
+- **Workaround:** Detect Intel iGPU and fall back to WASM execution provider.
+
+### Electron Configuration
+```javascript
+// Enable WebGPU in Electron
+const win = new BrowserWindow({
+  webPreferences: {
+    // WebGPU is enabled by default in Electron 33+
+    // No additional flags needed for Chromium 128+
+  }
+});
+
+// Check WebGPU availability in renderer
+if (navigator.gpu) {
+  const adapter = await navigator.gpu.requestAdapter();
+  // Use WebGPU EP
+} else {
+  // Fallback to WASM EP
+}
+```
+
+### Architecture Decision: Renderer vs Main Process
+| Aspect | Renderer (WebGPU) | Main Process (native) |
+|--------|-------------------|----------------------|
+| GPU access | WebGPU API | Metal/CUDA/Vulkan |
+| Setup complexity | npm install only | Native addon build |
+| Cross-platform | Yes (any Chromium) | Per-platform binaries |
+| Performance | Good (3-20x vs WASM) | Best (direct GPU) |
+| Memory sharing | Isolated (renderer) | Shared with main |
+
+**Recommendation:** Use WebGPU in renderer for ONNX models (Moonshine, OPUS-MT). Keep native addons (whisper.cpp, llama.cpp) in main process for maximum performance.
+
+## 4. Memory and GPU Contention
+
+### Concurrent Model Inference
+Running multiple ONNX models with WebGPU simultaneously:
+
+| Scenario | GPU Memory | Risk |
+|----------|-----------|------|
+| Moonshine only | ~200 MB | Low |
+| OPUS-MT only | ~300 MB | Low |
+| Moonshine + OPUS-MT | ~500 MB | Medium — may cause GPU contention |
+| + whisper.cpp (Metal) | +1.5 GB | High — Metal and WebGPU compete for GPU |
+
+**Key concern:** If the user runs WhisperKit or whisper.cpp with Metal acceleration AND Moonshine/OPUS-MT with WebGPU, both compete for GPU resources. Solution: Don't run native GPU STT and WebGPU STT simultaneously.
+
+### Mitigation Strategies
+1. **Exclusive GPU mode:** Only one GPU-accelerated engine active at a time
+2. **Fallback detection:** If WebGPU inference time degrades >2x, switch to WASM
+3. **Memory monitoring:** Track `performance.memory` and GPU adapter limits
+
+## 5. Implementation Plan
+
+### Phase 1: WebGPU Detection and Fallback
+1. Add WebGPU capability detection in renderer
+2. Implement automatic fallback to WASM EP
+3. Detect Intel iGPU and default to WASM (known bug)
+
+### Phase 2: Moonshine WebGPU
+1. Load Moonshine ONNX model with WebGPU EP in renderer
+2. Benchmark against current WASM execution
+3. Add to Settings Panel as "Moonshine (GPU-accelerated)"
+
+### Phase 3: OPUS-MT WebGPU
+1. Load OPUS-MT models with WebGPU EP
+2. Benchmark translation speed improvement
+3. Evaluate memory usage with concurrent STT + Translation
+
+### Estimated Effort
+- 2 days: WebGPU detection, fallback, Intel workaround
+- 2 days: Moonshine WebGPU integration and benchmarking
+- 2 days: OPUS-MT WebGPU integration and benchmarking
+- **Total: ~6 days**
+
+## 6. Recommendations
+
+- **Adopt WebGPU EP for Moonshine and OPUS-MT** — significant speedup with no native addon complexity.
+- **Keep native addons for primary STT** (whisper.cpp, WhisperKit) — they still offer better accuracy.
+- **Implement Intel iGPU detection** — fall back to WASM to avoid the known Electron bug.
+- **Avoid running WebGPU and Metal/CUDA models simultaneously** — GPU contention degrades both.
+- This directly benefits cross-platform support (#318) since WebGPU works on Windows and Linux without platform-specific GPU bindings.
+
+## References
+- [ONNX Runtime WebGPU Tutorial](https://onnxruntime.ai/docs/tutorials/web/ep-webgpu.html)
+- [onnxruntime-web npm](https://www.npmjs.com/package/onnxruntime-web)
+- [ONNX Runtime WebGPU Blog](https://opensource.microsoft.com/blog/2024/02/29/onnx-runtime-web-unleashes-generative-ai-in-the-browser-using-webgpu/)
+- [Moonshine Web (Xenova/Transformers.js)](https://huggingface.co/posts/Xenova/486935205804807)
+- [Electron WebGPU Intel Bug](https://github.com/microsoft/onnxruntime/issues/24442)
+- [WebGPU Browser Support](https://web.dev/blog/webgpu-supported-major-browsers)
+- Related: #276 (Transformers.js v4 + WebGPU evaluation)

--- a/docs/research/seamless-streaming-evaluation.md
+++ b/docs/research/seamless-streaming-evaluation.md
@@ -1,0 +1,87 @@
+# SeamlessStreaming Evaluation for live-translate
+
+**Issue:** #316
+**Date:** 2026-03-24
+**Status:** Research complete — not viable for local inference today; monitor for distilled models
+
+## 1. Model Overview
+
+SeamlessStreaming is Meta's streaming speech translation model supporting ~100 input languages and 36 output speech languages. It is part of the SeamlessM4T v2 family and supports three modes: S2TT (speech-to-text translation), S2ST (speech-to-speech translation), and ASR.
+
+| Variant | Params | FP16 VRAM | Peak Inference VRAM | Notes |
+|---------|--------|-----------|---------------------|-------|
+| SeamlessM4T v2 Large | 2.3B | ~5.8 GB | ~7+ GB | Full S2TT/S2ST/ASR |
+| SeamlessM4T v2 Medium | 1.2B | ~3 GB | ~4 GB | Reduced quality |
+| SeamlessM4T v2 Small | 281M | ~0.6 GB | ~1 GB | On-device target, limited language coverage |
+
+Architecture: 24-layer wav2vec-BERT encoder + non-autoregressive UnitY2 decoder (3x speedup over autoregressive).
+
+### Language Support
+- **Input:** ~100 languages (speech)
+- **Output:** 36 languages (speech), ~100 languages (text)
+- **JA/EN:** Supported for both S2TT and S2ST
+
+## 2. S2TT Mode Feasibility on Apple Silicon
+
+### Hardware Requirements
+- **Large model (recommended):** Requires ~7 GB VRAM during inference. Fits on M1 Pro/Max (16 GB+) but tight on base M1/M2 (8 GB).
+- **Small model:** Fits on 8 GB machines but with reduced translation quality.
+- **Runtime:** fairseq2 (Python) with pre-built Apple Silicon wheels available.
+
+### Integration Approach
+The most viable path would be a Python bridge (same pattern as `MlxWhisperEngine`):
+1. Spawn Python subprocess with fairseq2 + seamless_communication
+2. Stream audio chunks via JSON-over-stdio protocol
+3. Receive S2TT results (bypasses separate translator stage)
+
+### unity.cpp Status
+Meta released unity.cpp for running SeamlessM4T via GGML/C++, but it has limited community adoption and no quantized GGUF models are widely available. Not production-ready for integration.
+
+## 3. Performance Comparison: S2TT vs Cascaded Pipeline
+
+| Metric | SeamlessM4T v2 S2TT | Whisper + Translator (cascaded) |
+|--------|---------------------|--------------------------------|
+| BLEU (JA→EN) | +2-4 BLEU improvement | Baseline |
+| Pipeline stages | 1 (end-to-end) | 2 (STT + Translation) |
+| Error propagation | None (single model) | STT errors cascade to translation |
+| Latency | ~1-2s per segment (streaming) | ~0.5s STT + ~0.3s translation |
+| Model size | 5.8 GB (large, FP16) | ~1.5 GB (Whisper) + ~0.5 GB (translator) |
+| Memory usage | 7+ GB | ~3 GB total |
+
+### Key Advantage
+S2TT eliminates error propagation between STT and translation stages. When Whisper mis-transcribes a word, the translator cannot recover. SeamlessM4T processes the audio signal directly for translation.
+
+### Key Disadvantage
+Much larger model footprint and higher latency than the cascaded approach. Not suitable for 8 GB machines with the large model.
+
+## 4. Competitive Landscape
+
+| Company | Approach | Status |
+|---------|----------|--------|
+| Google | Gemini Live Translate (cloud S2S) | Launched 2025 |
+| Microsoft | Live Interpreter API (cloud S2S) | Preview 2025 |
+| Meta | SeamlessStreaming (open-source, local) | Research release |
+
+The industry is converging on end-to-end speech-to-speech translation. Cloud-based solutions are already shipping. Local/on-device S2S is the next frontier.
+
+## 5. Recommendations
+
+### Short-term (not recommended now)
+- **Do not integrate SeamlessM4T today.** The large model requires too much memory for typical user hardware, and the small model sacrifices quality.
+- The Python dependency chain (fairseq2, PyTorch, seamless_communication) is heavy.
+
+### Medium-term (monitor)
+- Watch for **quantized/distilled SeamlessM4T models** in GGUF format that could run via llama.cpp or similar.
+- Watch for **Whisper-to-S2TT fine-tuning** efforts that could provide a lighter alternative.
+- Consider adding SeamlessM4T S2TT as an optional "high-quality" engine for users with 16 GB+ RAM.
+
+### Long-term (strategic)
+- End-to-end S2TT will likely replace cascaded pipelines as models get smaller.
+- Plan architecture to support single-stage S2TT engines alongside cascaded STT+Translation.
+- The `TranslationPipeline` should be refactored to support an `S2TTEngine` interface that takes audio and returns translated text directly.
+
+## References
+- [SeamlessStreaming Paper](https://ai.meta.com/research/publications/seamless-multilingual-expressive-and-streaming-speech-translation/)
+- [seamless_communication GitHub](https://github.com/facebookresearch/seamless_communication)
+- [SeamlessM4T v2 on HuggingFace](https://huggingface.co/facebook/seamless-m4t-v2-large)
+- [Nature publication](https://www.nature.com/articles/s41586-024-08359-z)

--- a/docs/research/whisperkit-evaluation.md
+++ b/docs/research/whisperkit-evaluation.md
@@ -1,0 +1,114 @@
+# WhisperKit Evaluation for live-translate
+
+**Issue:** #317
+**Date:** 2026-03-24
+**Status:** Research complete — viable via local server subprocess; recommended as macOS-exclusive high-performance STT option
+
+## 1. Model Overview
+
+WhisperKit is Argmax's reimplementation of OpenAI Whisper optimized for Apple Neural Engine (ANE). It achieves near-peak hardware utilization on Apple Silicon while consuming less power than CPU or GPU execution paths.
+
+### Performance Benchmarks
+
+| Metric | WhisperKit | whisper.cpp (CPU) | Cloud (gpt-4o-transcribe) |
+|--------|-----------|-------------------|--------------------------|
+| Mean latency (per-word) | 0.46s | ~1-2s | 0.45s (Fireworks) |
+| WER (LibriSpeech) | 2.2% | 2.8% | ~2.5% |
+| WER (LibriSpeech, CoreML) | 2.44% | — | — |
+| Power consumption | Low (ANE) | Medium (CPU) | N/A (cloud) |
+
+### Model Sizes (CoreML optimized)
+
+| Variant | Size | QoI Score | Notes |
+|---------|------|-----------|-------|
+| large-v3 (full) | ~3.1 GB | 99.8% | Best accuracy |
+| large-v3-turbo | ~1.6 GB | 95%+ | Streaming optimized |
+| large-v3 (compressed) | ~0.6 GB | 90.8% | Mixed-bit quantization, within 1% WER |
+| small | ~0.5 GB | ~85% | Fastest, lower accuracy |
+
+### Hardware Support
+- M1, M2, M3, M4 Neural Engines all supported
+- M3/M4 ANE is faster than M1; WhisperKit optimizes per-chip
+- iOS 17+ and macOS 14+ required (ANE API availability)
+
+## 2. Integration Options
+
+### Option A: WhisperKit Local Server (RECOMMENDED)
+
+WhisperKit ships a local HTTP server (`whisperkit-local-server`) that implements the OpenAI Audio API.
+
+**How:**
+1. Bundle the `whisperkit-local-server` executable with the Electron app
+2. Spawn as a subprocess on app launch
+3. Send audio via HTTP POST to `localhost:{port}/v1/audio/transcriptions`
+4. Receive streaming transcription results
+
+**Pros:**
+- OpenAI-compatible API — can reuse existing client code
+- No Swift compilation required in the build pipeline
+- Streaming support for real-time transcription
+- Clean process isolation (crash doesn't affect main app)
+- Build with `make build-local-server` from WhisperKit repo
+
+**Cons:**
+- macOS-only (ANE is Apple-exclusive hardware)
+- Additional ~50 MB for the server binary
+- HTTP overhead vs direct native binding (minimal for audio chunks)
+
+### Option B: Swift Subprocess with CLI
+
+**How:** Build WhisperKit CLI tool, invoke via `child_process.spawn`, pipe audio via stdin.
+
+**Pros:** Simpler than HTTP server
+**Cons:** Less flexible, no streaming API, harder to manage lifecycle
+
+### Option C: Native Addon (Swift → C → Node.js N-API)
+
+**How:** Write a C bridge between Swift WhisperKit and Node.js N-API.
+
+**Pros:** Lowest latency, direct memory sharing
+**Cons:** Complex build pipeline, fragile across Swift/Node version upgrades, not worth the maintenance cost
+
+## 3. Comparison with Current STT Engines
+
+| Engine | Latency | WER | Size | Platform | GPU Accel |
+|--------|---------|-----|------|----------|-----------|
+| WhisperKit (ANE) | 0.46s | 2.2% | 0.6-3.1 GB | macOS only | ANE |
+| whisper.cpp (current) | ~1-2s | 2.8% | 1.5 GB | Cross-platform | Metal/CUDA |
+| MLX-Whisper (#308) | ~0.5-1s | ~2.5% | 1.5 GB | macOS only | Metal |
+| Moonshine ONNX | ~0.3s | ~5% | 60 MB | Cross-platform | WebGPU/CPU |
+
+WhisperKit provides the best latency-to-accuracy ratio on macOS, but is Apple-exclusive.
+
+## 4. Implementation Plan
+
+### Phase 1: Prototype
+1. Build `whisperkit-local-server` from WhisperKit repo
+2. Create `WhisperKitEngine` class implementing `STTEngine` interface
+3. Manage server lifecycle (spawn on init, kill on dispose)
+4. Route audio to HTTP endpoint, parse streaming responses
+
+### Phase 2: Integration
+1. Add "WhisperKit (ANE)" option to Settings Panel (macOS only)
+2. Auto-detect macOS and ANE availability
+3. Bundle compressed large-v3 model (~600 MB) or download on first use
+4. Fallback to whisper.cpp if WhisperKit server fails to start
+
+### Estimated Effort
+- 2-3 days for basic integration
+- 1 day for model download/management
+- 1 day for testing across M1/M2/M3
+
+## 5. Recommendations
+
+- **Integrate WhisperKit as a premium macOS STT option** using the local server approach.
+- Use the compressed large-v3 model (600 MB) as default for best size/quality tradeoff.
+- Keep whisper.cpp as the cross-platform default; WhisperKit is a macOS-only enhancement.
+- This gives live-translate a hardware advantage that no cross-platform competitor can match on Mac.
+
+## References
+- [WhisperKit GitHub](https://github.com/argmaxinc/WhisperKit)
+- [WhisperKit Paper (arXiv)](https://arxiv.org/abs/2507.10860)
+- [WhisperKit Benchmarks](https://github.com/argmaxinc/WhisperKit/blob/main/BENCHMARKS.md)
+- [WhisperKit CoreML Models](https://huggingface.co/argmaxinc/whisperkit-coreml)
+- [Apple SpeechAnalyzer + WhisperKit](https://www.argmaxinc.com/blog/apple-and-argmax)


### PR DESCRIPTION
## Summary
- **SeamlessStreaming (#316):** Evaluated Meta's S2TT mode — not viable for local inference today (7+ GB VRAM for large model), but strategic direction to monitor for distilled models
- **WhisperKit (#317):** Viable via local server subprocess on macOS — 0.46s latency, 2.2% WER with ANE acceleration, recommended as premium macOS STT option
- **Cross-platform support (#318):** Windows feasible (~5 days effort, native addons have pre-built binaries), Linux via AppImage (~5 days), priority is Windows first
- **ONNX Runtime WebGPU (#319):** Viable for Moonshine/OPUS-MT acceleration in renderer (3-20x vs WASM), known Intel iGPU bug in Electron needs workaround

## Deliverables
- `docs/research/seamless-streaming-evaluation.md`
- `docs/research/whisperkit-evaluation.md`
- `docs/research/cross-platform-support.md`
- `docs/research/onnx-runtime-webgpu-evaluation.md`

Closes #316, Closes #317, Closes #318, Closes #319