### PR TITLE
Add benchmark implementations for all translation engines

### DIFF
--- a/benchmark/package.json
+++ b/benchmark/package.json
@@ -3,12 +3,24 @@
   "version": "0.1.0",
   "private": true,
   "type": "module",
-  "description": "Translation quality benchmark: OPUS-MT vs TranslateGemma vs Google Translate",
+  "description": "Translation quality benchmark for all translation engines",
   "scripts": {
     "bench": "tsx --expose-gc run.ts",
     "bench:google": "tsx --expose-gc run.ts --engines google",
+    "bench:deepl": "tsx --expose-gc run.ts --engines deepl",
+    "bench:microsoft": "tsx --expose-gc run.ts --engines microsoft",
+    "bench:gemini": "tsx --expose-gc run.ts --engines gemini",
     "bench:opus": "tsx --expose-gc run.ts --engines opus-mt",
-    "bench:gemma": "tsx --expose-gc run.ts --engines translate-gemma"
+    "bench:ct2-opus": "tsx --expose-gc run.ts --engines ct2-opus-mt",
+    "bench:ct2-madlad": "tsx --expose-gc run.ts --engines ct2-madlad400",
+    "bench:gemma": "tsx --expose-gc run.ts --engines translate-gemma",
+    "bench:hunyuan": "tsx --expose-gc run.ts --engines hunyuan-mt",
+    "bench:hunyuan15": "tsx --expose-gc run.ts --engines hunyuan-mt-15",
+    "bench:alma": "tsx --expose-gc run.ts --engines alma-ja",
+    "bench:gemma2jpn": "tsx --expose-gc run.ts --engines gemma2-jpn",
+    "bench:api": "tsx --expose-gc run.ts --engines google,deepl,microsoft,gemini",
+    "bench:local": "tsx --expose-gc run.ts --engines opus-mt,ct2-opus-mt,ct2-madlad400,translate-gemma,hunyuan-mt,hunyuan-mt-15,alma-ja,gemma2-jpn",
+    "bench:all": "tsx --expose-gc run.ts --engines google,deepl,microsoft,gemini,opus-mt,ct2-opus-mt,ct2-madlad400,translate-gemma,hunyuan-mt,hunyuan-mt-15,alma-ja,gemma2-jpn"
   },
   "dependencies": {
     "@huggingface/transformers": "^3.8.0",

--- a/benchmark/run.ts
+++ b/benchmark/run.ts
@@ -2,7 +2,25 @@ import type { BenchmarkEngine, Direction } from './src/types.js'
 import { runBenchmark } from './src/runner.js'
 import { writeReports } from './src/report.js'
 
-const AVAILABLE_ENGINES = ['google', 'opus-mt', 'translate-gemma', 'translate-gemma-cpu'] as const
+const AVAILABLE_ENGINES = [
+  'google',
+  'deepl',
+  'microsoft',
+  'gemini',
+  'opus-mt',
+  'ct2-opus-mt',
+  'ct2-madlad400',
+  'translate-gemma',
+  'translate-gemma-cpu',
+  'hunyuan-mt',
+  'hunyuan-mt-cpu',
+  'hunyuan-mt-15',
+  'hunyuan-mt-15-cpu',
+  'alma-ja',
+  'alma-ja-cpu',
+  'gemma2-jpn',
+  'gemma2-jpn-cpu'
+] as const
 type EngineId = (typeof AVAILABLE_ENGINES)[number]
 
 function parseArgs(): { engines: EngineId[]; directions: Direction[] } {
@@ -38,6 +56,7 @@ function parseArgs(): { engines: EngineId[]; directions: Direction[] } {
   }
 
   if (engines.length === 0) {
+    // Default: only the original engines (API keys / models may not be available for all)
     engines = ['google', 'opus-mt', 'translate-gemma', 'translate-gemma-cpu']
   }
 
@@ -50,9 +69,29 @@ async function createEngine(id: EngineId): Promise<BenchmarkEngine> {
       const { GoogleTranslateBench } = await import('./src/engines/google-translate.js')
       return new GoogleTranslateBench()
     }
+    case 'deepl': {
+      const { DeepLBench } = await import('./src/engines/deepl.js')
+      return new DeepLBench()
+    }
+    case 'microsoft': {
+      const { MicrosoftBench } = await import('./src/engines/microsoft.js')
+      return new MicrosoftBench()
+    }
+    case 'gemini': {
+      const { GeminiBench } = await import('./src/engines/gemini.js')
+      return new GeminiBench()
+    }
     case 'opus-mt': {
       const { OpusMTBench } = await import('./src/engines/opus-mt.js')
       return new OpusMTBench()
+    }
+    case 'ct2-opus-mt': {
+      const { CT2OpusMTBench } = await import('./src/engines/ct2-opus-mt.js')
+      return new CT2OpusMTBench()
+    }
+    case 'ct2-madlad400': {
+      const { CT2Madlad400Bench } = await import('./src/engines/ct2-madlad400.js')
+      return new CT2Madlad400Bench()
     }
     case 'translate-gemma': {
       const { TranslateGemmaBench } = await import('./src/engines/translate-gemma.js')
@@ -61,6 +100,38 @@ async function createEngine(id: EngineId): Promise<BenchmarkEngine> {
     case 'translate-gemma-cpu': {
       const { TranslateGemmaBench } = await import('./src/engines/translate-gemma.js')
       return new TranslateGemmaBench({ useGpu: false })
+    }
+    case 'hunyuan-mt': {
+      const { HunyuanMTBench } = await import('./src/engines/hunyuan-mt.js')
+      return new HunyuanMTBench({ useGpu: true })
+    }
+    case 'hunyuan-mt-cpu': {
+      const { HunyuanMTBench } = await import('./src/engines/hunyuan-mt.js')
+      return new HunyuanMTBench({ useGpu: false })
+    }
+    case 'hunyuan-mt-15': {
+      const { HunyuanMT15Bench } = await import('./src/engines/hunyuan-mt-15.js')
+      return new HunyuanMT15Bench({ useGpu: true })
+    }
+    case 'hunyuan-mt-15-cpu': {
+      const { HunyuanMT15Bench } = await import('./src/engines/hunyuan-mt-15.js')
+      return new HunyuanMT15Bench({ useGpu: false })
+    }
+    case 'alma-ja': {
+      const { AlmaJaBench } = await import('./src/engines/alma-ja.js')
+      return new AlmaJaBench({ useGpu: true })
+    }
+    case 'alma-ja-cpu': {
+      const { AlmaJaBench } = await import('./src/engines/alma-ja.js')
+      return new AlmaJaBench({ useGpu: false })
+    }
+    case 'gemma2-jpn': {
+      const { Gemma2JpnBench } = await import('./src/engines/gemma2-jpn.js')
+      return new Gemma2JpnBench({ useGpu: true })
+    }
+    case 'gemma2-jpn-cpu': {
+      const { Gemma2JpnBench } = await import('./src/engines/gemma2-jpn.js')
+      return new Gemma2JpnBench({ useGpu: false })
     }
   }
 }

--- a/benchmark/src/engines/alma-ja.ts
+++ b/benchmark/src/engines/alma-ja.ts
@@ -1,0 +1,100 @@
+import { join, dirname } from 'path'
+import { fileURLToPath } from 'url'
+import { existsSync } from 'fs'
+import type { BenchmarkEngine, Direction } from '../types.js'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const MODELS_DIR = join(__dirname, '..', '..', 'models')
+const DEFAULT_MODEL_FILE = 'webbigdata-ALMA-7B-Ja-V2-q4_K_M.gguf'
+
+const LANG_MAP: Record<string, string> = {
+  ja: 'Japanese',
+  en: 'English'
+}
+
+interface AlmaJaBenchOptions {
+  modelFile?: string
+  useGpu?: boolean
+}
+
+/**
+ * ALMA-7B-Ja-V2 benchmark engine via node-llama-cpp.
+ * Uses the same prompt format as the app's slm-worker.ts.
+ */
+export class AlmaJaBench implements BenchmarkEngine {
+  readonly id: string
+  readonly label: string
+
+  private modelPath: string
+  private useGpu: boolean
+  private llama: any = null
+  private model: any = null
+  private context: any = null
+
+  constructor(options?: AlmaJaBenchOptions) {
+    const modelFile = options?.modelFile ?? DEFAULT_MODEL_FILE
+    this.modelPath = join(MODELS_DIR, modelFile)
+    this.useGpu = options?.useGpu ?? true
+    this.id = this.useGpu ? 'alma-ja-gpu' : 'alma-ja-cpu'
+    this.label = this.useGpu ? 'ALMA-7B-Ja-V2 (GPU)' : 'ALMA-7B-Ja-V2 (CPU)'
+  }
+
+  async initialize(): Promise<void> {
+    if (this.context) return
+
+    if (!existsSync(this.modelPath)) {
+      throw new Error(
+        `Model file not found: ${this.modelPath}\n` +
+          'Download from HuggingFace: huggingface-cli download ' +
+          'mmnga/webbigdata-ALMA-7B-Ja-V2-gguf webbigdata-ALMA-7B-Ja-V2-q4_K_M.gguf ' +
+          `--local-dir ${MODELS_DIR}`
+      )
+    }
+
+    console.log(`[alma-ja] Loading model (GPU: ${this.useGpu})...`)
+
+    const { getLlama } = await import('node-llama-cpp')
+    this.llama = await getLlama({ gpu: this.useGpu ? 'auto' : false })
+    this.model = await this.llama.loadModel({ modelPath: this.modelPath })
+    this.context = await this.model.createContext({ contextSize: 2048 })
+
+    console.log('[alma-ja] Model loaded')
+  }
+
+  async translate(text: string, direction: Direction): Promise<string> {
+    if (!text.trim()) return ''
+    if (!this.context) {
+      throw new Error('[alma-ja] Not initialized')
+    }
+
+    const [fromCode, toCode] = direction.split('-') as [string, string]
+    const fromLang = LANG_MAP[fromCode] ?? fromCode
+    const toLang = LANG_MAP[toCode] ?? toCode
+
+    // ALMA-Ja prompt: simple translation instruction (same as slm-worker.ts for alma-ja)
+    const prompt = `Translate the following text from ${fromLang} to ${toLang}. Output only the translation, nothing else.\n\n${text}`
+
+    const { LlamaChatSession } = await import('node-llama-cpp')
+    const session = new LlamaChatSession({ contextSequence: this.context.getSequence() })
+
+    const response = await session.prompt(prompt, {
+      temperature: 0.1,
+      maxTokens: 512
+    })
+
+    session.dispose?.()
+    return response.trim()
+  }
+
+  async dispose(): Promise<void> {
+    if (this.context) {
+      await this.context.dispose?.()
+      this.context = null
+    }
+    if (this.model) {
+      await this.model.dispose?.()
+      this.model = null
+    }
+    this.llama = null
+  }
+}

--- a/benchmark/src/engines/ct2-madlad400.ts
+++ b/benchmark/src/engines/ct2-madlad400.ts
@@ -1,0 +1,151 @@
+import { spawn, type ChildProcess } from 'child_process'
+import { join, dirname } from 'path'
+import { fileURLToPath } from 'url'
+import type { BenchmarkEngine, Direction } from '../types.js'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const BRIDGE_SCRIPT = join(__dirname, '..', '..', '..', 'resources', 'ct2-madlad400-bridge.py')
+const INIT_TIMEOUT_MS = 120_000
+const TRANSLATE_TIMEOUT_MS = 30_000
+
+/**
+ * CTranslate2-accelerated Madlad-400 benchmark engine.
+ * Spawns the same Python bridge script used by the app engine.
+ */
+export class CT2Madlad400Bench implements BenchmarkEngine {
+  readonly id = 'ct2-madlad400'
+  readonly label = 'Madlad-400 (CTranslate2)'
+
+  private process: ChildProcess | null = null
+  private buffer = ''
+  private nextReqId = 0
+  private pending = new Map<
+    number,
+    { resolve: (data: Record<string, unknown>) => void; reject: (err: Error) => void; timer: ReturnType<typeof setTimeout> }
+  >()
+
+  async initialize(): Promise<void> {
+    if (this.process) return
+
+    console.log('[ct2-madlad400] Starting Python bridge...')
+    this.process = spawn('python3', [BRIDGE_SCRIPT], {
+      stdio: ['pipe', 'pipe', 'pipe']
+    })
+
+    this.process.on('error', (err) => {
+      console.error('[ct2-madlad400] Bridge failed to start:', err.message)
+      this.process = null
+    })
+
+    this.process.stdout!.on('data', (data: Buffer) => {
+      this.buffer += data.toString()
+      const lines = this.buffer.split('\n')
+      this.buffer = lines.pop() ?? ''
+
+      for (const line of lines) {
+        if (!line.trim()) continue
+        try {
+          const msg = JSON.parse(line)
+          const reqId = msg._reqId as number | undefined
+          if (reqId !== undefined && this.pending.has(reqId)) {
+            const entry = this.pending.get(reqId)!
+            this.pending.delete(reqId)
+            clearTimeout(entry.timer)
+            entry.resolve(msg)
+          }
+        } catch {
+          // Ignore non-JSON lines
+        }
+      }
+    })
+
+    this.process.stderr!.on('data', (data: Buffer) => {
+      const text = data.toString().trim()
+      if (text) console.warn('[ct2-madlad400] stderr:', text)
+    })
+
+    this.process.on('exit', (code) => {
+      console.log(`[ct2-madlad400] Bridge exited with code ${code}`)
+      this.process = null
+    })
+
+    // Send init command
+    const result = await this.sendCommand(
+      {
+        action: 'init',
+        model: 'Nextcloud-AI/madlad400-3b-mt-ct2-int8',
+        device: 'auto'
+      },
+      INIT_TIMEOUT_MS
+    )
+
+    if (result.error) {
+      throw new Error(`[ct2-madlad400] Init failed: ${result.error}`)
+    }
+
+    console.log(`[ct2-madlad400] Ready (device: ${result.device ?? 'cpu'})`)
+  }
+
+  async translate(text: string, direction: Direction): Promise<string> {
+    if (!text.trim()) return ''
+    if (!this.process) {
+      throw new Error('[ct2-madlad400] Bridge not running')
+    }
+
+    const [, to] = direction.split('-') as [string, string]
+
+    const result = await this.sendCommand(
+      { action: 'translate', text, target_lang: to },
+      TRANSLATE_TIMEOUT_MS
+    )
+
+    if (result.error) {
+      throw new Error(`[ct2-madlad400] Translation error: ${result.error}`)
+    }
+
+    return (result.translated as string) || ''
+  }
+
+  async dispose(): Promise<void> {
+    if (this.process) {
+      try {
+        this.sendCommand({ action: 'dispose' }).catch(() => {})
+        await new Promise((resolve) => setTimeout(resolve, 500))
+      } catch {
+        // Ignore
+      }
+      try {
+        this.process.kill()
+      } catch {
+        // Already exited
+      }
+      this.process = null
+    }
+    for (const [, entry] of this.pending) {
+      clearTimeout(entry.timer)
+      entry.reject(new Error('Engine disposed'))
+    }
+    this.pending.clear()
+  }
+
+  private sendCommand(
+    cmd: Record<string, unknown>,
+    timeout = TRANSLATE_TIMEOUT_MS
+  ): Promise<Record<string, unknown>> {
+    return new Promise((resolve, reject) => {
+      if (!this.process?.stdin) {
+        reject(new Error('Bridge process not running'))
+        return
+      }
+
+      const reqId = this.nextReqId++
+      const timer = setTimeout(() => {
+        this.pending.delete(reqId)
+        reject(new Error('Bridge command timed out'))
+      }, timeout)
+
+      this.pending.set(reqId, { resolve, reject, timer })
+      this.process.stdin.write(JSON.stringify({ ...cmd, _reqId: reqId }) + '\n')
+    })
+  }
+}

--- a/benchmark/src/engines/ct2-opus-mt.ts
+++ b/benchmark/src/engines/ct2-opus-mt.ts
@@ -1,0 +1,151 @@
+import { spawn, type ChildProcess } from 'child_process'
+import { join, dirname } from 'path'
+import { fileURLToPath } from 'url'
+import type { BenchmarkEngine, Direction } from '../types.js'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const BRIDGE_SCRIPT = join(__dirname, '..', '..', '..', 'resources', 'ct2-opus-mt-bridge.py')
+const INIT_TIMEOUT_MS = 120_000
+const TRANSLATE_TIMEOUT_MS = 30_000
+
+/**
+ * CTranslate2-accelerated OPUS-MT benchmark engine.
+ * Spawns the same Python bridge script used by the app engine.
+ */
+export class CT2OpusMTBench implements BenchmarkEngine {
+  readonly id = 'ct2-opus-mt'
+  readonly label = 'OPUS-MT (CTranslate2)'
+
+  private process: ChildProcess | null = null
+  private buffer = ''
+  private nextReqId = 0
+  private pending = new Map<
+    number,
+    { resolve: (data: Record<string, unknown>) => void; reject: (err: Error) => void; timer: ReturnType<typeof setTimeout> }
+  >()
+
+  async initialize(): Promise<void> {
+    if (this.process) return
+
+    console.log('[ct2-opus-mt] Starting Python bridge...')
+    this.process = spawn('python3', [BRIDGE_SCRIPT], {
+      stdio: ['pipe', 'pipe', 'pipe']
+    })
+
+    this.process.on('error', (err) => {
+      console.error('[ct2-opus-mt] Bridge failed to start:', err.message)
+      this.process = null
+    })
+
+    this.process.stdout!.on('data', (data: Buffer) => {
+      this.buffer += data.toString()
+      const lines = this.buffer.split('\n')
+      this.buffer = lines.pop() ?? ''
+
+      for (const line of lines) {
+        if (!line.trim()) continue
+        try {
+          const msg = JSON.parse(line)
+          const reqId = msg._reqId as number | undefined
+          if (reqId !== undefined && this.pending.has(reqId)) {
+            const entry = this.pending.get(reqId)!
+            this.pending.delete(reqId)
+            clearTimeout(entry.timer)
+            entry.resolve(msg)
+          }
+        } catch {
+          // Ignore non-JSON lines (e.g. progress messages)
+        }
+      }
+    })
+
+    this.process.stderr!.on('data', (data: Buffer) => {
+      const text = data.toString().trim()
+      if (text) console.warn('[ct2-opus-mt] stderr:', text)
+    })
+
+    this.process.on('exit', (code) => {
+      console.log(`[ct2-opus-mt] Bridge exited with code ${code}`)
+      this.process = null
+    })
+
+    // Send init command
+    const result = await this.sendCommand(
+      {
+        action: 'init',
+        model_ja_en: 'Helsinki-NLP/opus-mt-ja-en',
+        model_en_ja: 'Helsinki-NLP/opus-mt-en-jap',
+        device: 'auto',
+        quantization: 'int8'
+      },
+      INIT_TIMEOUT_MS
+    )
+
+    if (result.error) {
+      throw new Error(`[ct2-opus-mt] Init failed: ${result.error}`)
+    }
+
+    console.log(`[ct2-opus-mt] Ready (device: ${result.device ?? 'cpu'})`)
+  }
+
+  async translate(text: string, direction: Direction): Promise<string> {
+    if (!text.trim()) return ''
+    if (!this.process) {
+      throw new Error('[ct2-opus-mt] Bridge not running')
+    }
+
+    const result = await this.sendCommand(
+      { action: 'translate', text, direction },
+      TRANSLATE_TIMEOUT_MS
+    )
+
+    if (result.error) {
+      throw new Error(`[ct2-opus-mt] Translation error: ${result.error}`)
+    }
+
+    return (result.translated as string) || ''
+  }
+
+  async dispose(): Promise<void> {
+    if (this.process) {
+      try {
+        this.sendCommand({ action: 'dispose' }).catch(() => {})
+        await new Promise((resolve) => setTimeout(resolve, 500))
+      } catch {
+        // Ignore
+      }
+      try {
+        this.process.kill()
+      } catch {
+        // Already exited
+      }
+      this.process = null
+    }
+    for (const [, entry] of this.pending) {
+      clearTimeout(entry.timer)
+      entry.reject(new Error('Engine disposed'))
+    }
+    this.pending.clear()
+  }
+
+  private sendCommand(
+    cmd: Record<string, unknown>,
+    timeout = TRANSLATE_TIMEOUT_MS
+  ): Promise<Record<string, unknown>> {
+    return new Promise((resolve, reject) => {
+      if (!this.process?.stdin) {
+        reject(new Error('Bridge process not running'))
+        return
+      }
+
+      const reqId = this.nextReqId++
+      const timer = setTimeout(() => {
+        this.pending.delete(reqId)
+        reject(new Error('Bridge command timed out'))
+      }, timeout)
+
+      this.pending.set(reqId, { resolve, reject, timer })
+      this.process.stdin.write(JSON.stringify({ ...cmd, _reqId: reqId }) + '\n')
+    })
+  }
+}

--- a/benchmark/src/engines/deepl.ts
+++ b/benchmark/src/engines/deepl.ts
@@ -1,0 +1,75 @@
+import type { BenchmarkEngine, Direction } from '../types.js'
+
+const DEEPL_FREE_URL = 'https://api-free.deepl.com/v2/translate'
+const DEEPL_PRO_URL = 'https://api.deepl.com/v2/translate'
+const TIMEOUT_MS = 15_000
+
+/** DeepL language code mapping for benchmark directions */
+const LANG_MAP: Record<string, { source: string; target: string }> = {
+  ja: { source: 'JA', target: 'JA' },
+  en: { source: 'EN', target: 'EN-US' }
+}
+
+export class DeepLBench implements BenchmarkEngine {
+  readonly id = 'deepl'
+  readonly label = 'DeepL Translate'
+
+  private apiKey: string
+  private apiUrl: string
+
+  constructor() {
+    const key = process.env.DEEPL_API_KEY
+    if (!key) {
+      throw new Error('DEEPL_API_KEY environment variable is required')
+    }
+    this.apiKey = key
+    this.apiUrl = key.endsWith(':fx') ? DEEPL_FREE_URL : DEEPL_PRO_URL
+  }
+
+  async initialize(): Promise<void> {
+    // Validate with a test request
+    await this.translate('test', 'en-ja')
+  }
+
+  async translate(text: string, direction: Direction): Promise<string> {
+    if (!text.trim()) return ''
+
+    const [from, to] = direction.split('-') as [string, string]
+    const sourceLang = LANG_MAP[from]?.source ?? from.toUpperCase()
+    const targetLang = LANG_MAP[to]?.target ?? to.toUpperCase()
+
+    const controller = new AbortController()
+    const timeout = setTimeout(() => controller.abort(), TIMEOUT_MS)
+
+    try {
+      const response = await fetch(this.apiUrl, {
+        method: 'POST',
+        headers: {
+          Authorization: `DeepL-Auth-Key ${this.apiKey}`,
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify({
+          text: [text],
+          source_lang: sourceLang,
+          target_lang: targetLang
+        }),
+        signal: controller.signal
+      })
+
+      if (!response.ok) {
+        throw new Error(`DeepL API error: ${response.status}`)
+      }
+
+      const data = (await response.json()) as {
+        translations: Array<{ text: string }>
+      }
+      return data.translations[0]?.text || ''
+    } finally {
+      clearTimeout(timeout)
+    }
+  }
+
+  async dispose(): Promise<void> {
+    // No cleanup needed
+  }
+}

--- a/benchmark/src/engines/gemini.ts
+++ b/benchmark/src/engines/gemini.ts
@@ -1,0 +1,77 @@
+import type { BenchmarkEngine, Direction } from '../types.js'
+
+const GEMINI_API_URL =
+  'https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent'
+const TIMEOUT_MS = 15_000
+
+const LANG_MAP: Record<string, string> = {
+  ja: 'Japanese',
+  en: 'English'
+}
+
+export class GeminiBench implements BenchmarkEngine {
+  readonly id = 'gemini'
+  readonly label = 'Gemini 2.5 Flash'
+
+  private apiKey: string
+
+  constructor() {
+    const key = process.env.GEMINI_API_KEY
+    if (!key) {
+      throw new Error('GEMINI_API_KEY environment variable is required')
+    }
+    this.apiKey = key
+  }
+
+  async initialize(): Promise<void> {
+    // API key validation deferred to first real translation to avoid wasting tokens
+  }
+
+  async translate(text: string, direction: Direction): Promise<string> {
+    if (!text.trim()) return ''
+
+    const [fromCode, toCode] = direction.split('-') as [string, string]
+    const fromLang = LANG_MAP[fromCode] ?? fromCode
+    const toLang = LANG_MAP[toCode] ?? toCode
+
+    const prompt = `Translate the following ${fromLang} text to ${toLang}. Output ONLY the translated text, nothing else.\n\n${text}`
+
+    const controller = new AbortController()
+    const timeout = setTimeout(() => controller.abort(), TIMEOUT_MS)
+
+    try {
+      const response = await fetch(GEMINI_API_URL, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'x-goog-api-key': this.apiKey
+        },
+        body: JSON.stringify({
+          contents: [{ parts: [{ text: prompt }] }],
+          generationConfig: {
+            temperature: 0.1,
+            maxOutputTokens: 256
+          }
+        }),
+        signal: controller.signal
+      })
+
+      if (!response.ok) {
+        throw new Error(`Gemini API error: ${response.status}`)
+      }
+
+      const data = (await response.json()) as {
+        candidates?: Array<{
+          content?: { parts?: Array<{ text?: string }> }
+        }>
+      }
+      return data.candidates?.[0]?.content?.parts?.[0]?.text?.trim() || ''
+    } finally {
+      clearTimeout(timeout)
+    }
+  }
+
+  async dispose(): Promise<void> {
+    // No cleanup needed
+  }
+}

--- a/benchmark/src/engines/gemma2-jpn.ts
+++ b/benchmark/src/engines/gemma2-jpn.ts
@@ -1,0 +1,100 @@
+import { join, dirname } from 'path'
+import { fileURLToPath } from 'url'
+import { existsSync } from 'fs'
+import type { BenchmarkEngine, Direction } from '../types.js'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const MODELS_DIR = join(__dirname, '..', '..', 'models')
+const DEFAULT_MODEL_FILE = 'gemma-2-2b-jpn-it-translate-Q4_K_M.gguf'
+
+const LANG_MAP: Record<string, string> = {
+  ja: 'Japanese',
+  en: 'English'
+}
+
+interface Gemma2JpnBenchOptions {
+  modelFile?: string
+  useGpu?: boolean
+}
+
+/**
+ * Gemma-2-2B-JPN-IT-Translate benchmark engine via node-llama-cpp.
+ * Uses the same prompt format as the app's slm-worker.ts.
+ */
+export class Gemma2JpnBench implements BenchmarkEngine {
+  readonly id: string
+  readonly label: string
+
+  private modelPath: string
+  private useGpu: boolean
+  private llama: any = null
+  private model: any = null
+  private context: any = null
+
+  constructor(options?: Gemma2JpnBenchOptions) {
+    const modelFile = options?.modelFile ?? DEFAULT_MODEL_FILE
+    this.modelPath = join(MODELS_DIR, modelFile)
+    this.useGpu = options?.useGpu ?? true
+    this.id = this.useGpu ? 'gemma2-jpn-gpu' : 'gemma2-jpn-cpu'
+    this.label = this.useGpu ? 'Gemma-2-2B JA↔EN (GPU)' : 'Gemma-2-2B JA↔EN (CPU)'
+  }
+
+  async initialize(): Promise<void> {
+    if (this.context) return
+
+    if (!existsSync(this.modelPath)) {
+      throw new Error(
+        `Model file not found: ${this.modelPath}\n` +
+          'Download from HuggingFace: huggingface-cli download ' +
+          'mmnga/gemma-2-2b-jpn-it-translate-gguf gemma-2-2b-jpn-it-translate-Q4_K_M.gguf ' +
+          `--local-dir ${MODELS_DIR}`
+      )
+    }
+
+    console.log(`[gemma2-jpn] Loading model (GPU: ${this.useGpu})...`)
+
+    const { getLlama } = await import('node-llama-cpp')
+    this.llama = await getLlama({ gpu: this.useGpu ? 'auto' : false })
+    this.model = await this.llama.loadModel({ modelPath: this.modelPath })
+    this.context = await this.model.createContext({ contextSize: 2048 })
+
+    console.log('[gemma2-jpn] Model loaded')
+  }
+
+  async translate(text: string, direction: Direction): Promise<string> {
+    if (!text.trim()) return ''
+    if (!this.context) {
+      throw new Error('[gemma2-jpn] Not initialized')
+    }
+
+    const [fromCode, toCode] = direction.split('-') as [string, string]
+    const fromLang = LANG_MAP[fromCode] ?? fromCode
+    const toLang = LANG_MAP[toCode] ?? toCode
+
+    // Gemma-2-JPN prompt: simple translation instruction (same as slm-worker.ts for gemma2-jpn)
+    const prompt = `Translate the following text from ${fromLang} to ${toLang}. Output only the translation, nothing else.\n\n${text}`
+
+    const { LlamaChatSession } = await import('node-llama-cpp')
+    const session = new LlamaChatSession({ contextSequence: this.context.getSequence() })
+
+    const response = await session.prompt(prompt, {
+      temperature: 0.1,
+      maxTokens: 512
+    })
+
+    session.dispose?.()
+    return response.trim()
+  }
+
+  async dispose(): Promise<void> {
+    if (this.context) {
+      await this.context.dispose?.()
+      this.context = null
+    }
+    if (this.model) {
+      await this.model.dispose?.()
+      this.model = null
+    }
+    this.llama = null
+  }
+}

--- a/benchmark/src/engines/hunyuan-mt-15.ts
+++ b/benchmark/src/engines/hunyuan-mt-15.ts
@@ -1,0 +1,102 @@
+import { join, dirname } from 'path'
+import { fileURLToPath } from 'url'
+import { existsSync } from 'fs'
+import type { BenchmarkEngine, Direction } from '../types.js'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const MODELS_DIR = join(__dirname, '..', '..', 'models')
+const DEFAULT_MODEL_FILE = 'HY-MT1.5-1.8B-Q4_K_M.gguf'
+
+const LANG_MAP: Record<string, string> = {
+  ja: 'Japanese',
+  en: 'English'
+}
+
+interface HunyuanMT15BenchOptions {
+  modelFile?: string
+  useGpu?: boolean
+}
+
+/**
+ * HY-MT1.5-1.8B benchmark engine via node-llama-cpp.
+ * Uses the same prompt format as the app's slm-worker.ts.
+ */
+export class HunyuanMT15Bench implements BenchmarkEngine {
+  readonly id: string
+  readonly label: string
+
+  private modelPath: string
+  private useGpu: boolean
+  private llama: any = null
+  private model: any = null
+  private context: any = null
+
+  constructor(options?: HunyuanMT15BenchOptions) {
+    const modelFile = options?.modelFile ?? DEFAULT_MODEL_FILE
+    this.modelPath = join(MODELS_DIR, modelFile)
+    this.useGpu = options?.useGpu ?? true
+    this.id = this.useGpu ? 'hunyuan-mt-15-gpu' : 'hunyuan-mt-15-cpu'
+    this.label = this.useGpu ? 'HY-MT1.5-1.8B (GPU)' : 'HY-MT1.5-1.8B (CPU)'
+  }
+
+  async initialize(): Promise<void> {
+    if (this.context) return
+
+    if (!existsSync(this.modelPath)) {
+      throw new Error(
+        `Model file not found: ${this.modelPath}\n` +
+          'Download from HuggingFace: huggingface-cli download ' +
+          'tencent/HY-MT1.5-GGUF HY-MT1.5-1.8B-Q4_K_M.gguf ' +
+          `--local-dir ${MODELS_DIR}`
+      )
+    }
+
+    console.log(`[hunyuan-mt-15] Loading model (GPU: ${this.useGpu})...`)
+
+    const { getLlama } = await import('node-llama-cpp')
+    this.llama = await getLlama({ gpu: this.useGpu ? 'auto' : false })
+    this.model = await this.llama.loadModel({ modelPath: this.modelPath })
+    this.context = await this.model.createContext({ contextSize: 2048 })
+
+    console.log('[hunyuan-mt-15] Model loaded')
+  }
+
+  async translate(text: string, direction: Direction): Promise<string> {
+    if (!text.trim()) return ''
+    if (!this.context) {
+      throw new Error('[hunyuan-mt-15] Not initialized')
+    }
+
+    const [, toCode] = direction.split('-') as [string, string]
+    const toLang = LANG_MAP[toCode] ?? toCode
+
+    // HY-MT1.5 prompt format: for non-Chinese language pairs, use English prompt
+    const prompt = `Translate the following segment into ${toLang}, without additional explanation.\n\n${text}`
+
+    const { LlamaChatSession } = await import('node-llama-cpp')
+    const session = new LlamaChatSession({ contextSequence: this.context.getSequence() })
+
+    const response = await session.prompt(prompt, {
+      temperature: 0.7,
+      maxTokens: 512,
+      topK: 20,
+      topP: 0.6,
+      repeatPenalty: { penalty: 1.05 }
+    })
+
+    session.dispose?.()
+    return response.trim()
+  }
+
+  async dispose(): Promise<void> {
+    if (this.context) {
+      await this.context.dispose?.()
+      this.context = null
+    }
+    if (this.model) {
+      await this.model.dispose?.()
+      this.model = null
+    }
+    this.llama = null
+  }
+}

--- a/benchmark/src/engines/hunyuan-mt.ts
+++ b/benchmark/src/engines/hunyuan-mt.ts
@@ -1,0 +1,102 @@
+import { join, dirname } from 'path'
+import { fileURLToPath } from 'url'
+import { existsSync } from 'fs'
+import type { BenchmarkEngine, Direction } from '../types.js'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const MODELS_DIR = join(__dirname, '..', '..', 'models')
+const DEFAULT_MODEL_FILE = 'Hunyuan-MT-7B-q4_k_m.gguf'
+
+const LANG_MAP: Record<string, string> = {
+  ja: 'Japanese',
+  en: 'English'
+}
+
+interface HunyuanMTBenchOptions {
+  modelFile?: string
+  useGpu?: boolean
+}
+
+/**
+ * Hunyuan-MT 7B benchmark engine via node-llama-cpp.
+ * Uses the same prompt format as the app's slm-worker.ts.
+ */
+export class HunyuanMTBench implements BenchmarkEngine {
+  readonly id: string
+  readonly label: string
+
+  private modelPath: string
+  private useGpu: boolean
+  private llama: any = null
+  private model: any = null
+  private context: any = null
+
+  constructor(options?: HunyuanMTBenchOptions) {
+    const modelFile = options?.modelFile ?? DEFAULT_MODEL_FILE
+    this.modelPath = join(MODELS_DIR, modelFile)
+    this.useGpu = options?.useGpu ?? true
+    this.id = this.useGpu ? 'hunyuan-mt-gpu' : 'hunyuan-mt-cpu'
+    this.label = this.useGpu ? 'Hunyuan-MT 7B (GPU)' : 'Hunyuan-MT 7B (CPU)'
+  }
+
+  async initialize(): Promise<void> {
+    if (this.context) return
+
+    if (!existsSync(this.modelPath)) {
+      throw new Error(
+        `Model file not found: ${this.modelPath}\n` +
+          'Download from HuggingFace: huggingface-cli download ' +
+          'tencent/Hunyuan-MT-GGUF Hunyuan-MT-7B-q4_k_m.gguf ' +
+          `--local-dir ${MODELS_DIR}`
+      )
+    }
+
+    console.log(`[hunyuan-mt] Loading model (GPU: ${this.useGpu})...`)
+
+    const { getLlama } = await import('node-llama-cpp')
+    this.llama = await getLlama({ gpu: this.useGpu ? 'auto' : false })
+    this.model = await this.llama.loadModel({ modelPath: this.modelPath })
+    this.context = await this.model.createContext({ contextSize: 2048 })
+
+    console.log('[hunyuan-mt] Model loaded')
+  }
+
+  async translate(text: string, direction: Direction): Promise<string> {
+    if (!text.trim()) return ''
+    if (!this.context) {
+      throw new Error('[hunyuan-mt] Not initialized')
+    }
+
+    const [, toCode] = direction.split('-') as [string, string]
+    const toLang = LANG_MAP[toCode] ?? toCode
+
+    // Hunyuan-MT prompt format: for non-Chinese language pairs, use English prompt
+    const prompt = `Translate the following segment into ${toLang}, without additional explanation.\n\n${text}`
+
+    const { LlamaChatSession } = await import('node-llama-cpp')
+    const session = new LlamaChatSession({ contextSequence: this.context.getSequence() })
+
+    const response = await session.prompt(prompt, {
+      temperature: 0.7,
+      maxTokens: 512,
+      topK: 20,
+      topP: 0.6,
+      repeatPenalty: { penalty: 1.05 }
+    })
+
+    session.dispose?.()
+    return response.trim()
+  }
+
+  async dispose(): Promise<void> {
+    if (this.context) {
+      await this.context.dispose?.()
+      this.context = null
+    }
+    if (this.model) {
+      await this.model.dispose?.()
+      this.model = null
+    }
+    this.llama = null
+  }
+}

--- a/benchmark/src/engines/microsoft.ts
+++ b/benchmark/src/engines/microsoft.ts
@@ -1,0 +1,73 @@
+import type { BenchmarkEngine, Direction } from '../types.js'
+
+const MS_TRANSLATE_URL = 'https://api.cognitive.microsofttranslator.com/translate'
+const API_VERSION = '3.0'
+const TIMEOUT_MS = 15_000
+
+export class MicrosoftBench implements BenchmarkEngine {
+  readonly id = 'microsoft'
+  readonly label = 'Microsoft Translator'
+
+  private apiKey: string
+  private region: string
+
+  constructor() {
+    const key = process.env.AZURE_TRANSLATOR_KEY
+    if (!key) {
+      throw new Error('AZURE_TRANSLATOR_KEY environment variable is required')
+    }
+    const region = process.env.AZURE_TRANSLATOR_REGION
+    if (!region) {
+      throw new Error('AZURE_TRANSLATOR_REGION environment variable is required')
+    }
+    this.apiKey = key
+    this.region = region
+  }
+
+  async initialize(): Promise<void> {
+    // Validate with a test request
+    await this.translate('test', 'en-ja')
+  }
+
+  async translate(text: string, direction: Direction): Promise<string> {
+    if (!text.trim()) return ''
+
+    const [from, to] = direction.split('-') as [string, string]
+    const params = new URLSearchParams({
+      'api-version': API_VERSION,
+      from,
+      to
+    })
+
+    const controller = new AbortController()
+    const timeout = setTimeout(() => controller.abort(), TIMEOUT_MS)
+
+    try {
+      const response = await fetch(`${MS_TRANSLATE_URL}?${params}`, {
+        method: 'POST',
+        headers: {
+          'Ocp-Apim-Subscription-Key': this.apiKey,
+          'Ocp-Apim-Subscription-Region': this.region,
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify([{ text }]),
+        signal: controller.signal
+      })
+
+      if (!response.ok) {
+        throw new Error(`Microsoft Translator error: ${response.status}`)
+      }
+
+      const data = (await response.json()) as Array<{
+        translations: Array<{ text: string }>
+      }>
+      return data[0]?.translations[0]?.text || ''
+    } finally {
+      clearTimeout(timeout)
+    }
+  }
+
+  async dispose(): Promise<void> {
+    // No cleanup needed
+  }
+}


### PR DESCRIPTION
## Summary
- Add 9 new benchmark engine implementations covering all remaining translation engines:
  - **API engines**: DeepL (`DEEPL_API_KEY`), Microsoft Translator (`AZURE_TRANSLATOR_KEY` + `AZURE_TRANSLATOR_REGION`), Gemini 2.5 Flash (`GEMINI_API_KEY`)
  - **CTranslate2 engines**: CT2-OPUS-MT, CT2-Madlad-400 (Python subprocess bridges)
  - **LLM engines**: Hunyuan-MT 7B, HY-MT1.5-1.8B, ALMA-7B-Ja-V2, Gemma-2-2B-JPN (node-llama-cpp)
- Update `run.ts` with all engine registrations (17 total including GPU/CPU variants)
- Add per-engine npm scripts plus `bench:api`, `bench:local`, and `bench:all` convenience scripts

## Test plan
- [x] Verify all 9 new engine modules import without errors
- [ ] Run `npm run bench:api` with API keys configured
- [ ] Run `npm run bench:local` with models downloaded
- [ ] Run `npm run bench:all` for full comparison

🤖 Generated with [Claude Code](https://claude.com/claude-code)