### PR TITLE
Add STT benchmark suite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,5 @@ logs/
 src/renderer/public/vad/
 benchmark/results/
 benchmark/models/
+benchmark/testset/stt/audio/
 *.tsbuildinfo

--- a/benchmark/package.json
+++ b/benchmark/package.json
@@ -8,7 +8,16 @@
     "bench": "tsx --expose-gc run.ts",
     "bench:google": "tsx --expose-gc run.ts --engines google",
     "bench:opus": "tsx --expose-gc run.ts --engines opus-mt",
-    "bench:gemma": "tsx --expose-gc run.ts --engines translate-gemma"
+    "bench:gemma": "tsx --expose-gc run.ts --engines translate-gemma",
+    "bench:stt": "tsx --expose-gc run.ts --stt",
+    "bench:stt:whisper-local": "tsx --expose-gc run.ts --stt --engines whisper-local",
+    "bench:stt:mlx-whisper": "tsx --expose-gc run.ts --stt --engines mlx-whisper",
+    "bench:stt:lightning-whisper": "tsx --expose-gc run.ts --stt --engines lightning-whisper",
+    "bench:stt:moonshine": "tsx --expose-gc run.ts --stt --engines moonshine",
+    "bench:stt:sensevoice": "tsx --expose-gc run.ts --stt --engines sensevoice",
+    "bench:stt:qwen-asr": "tsx --expose-gc run.ts --stt --engines qwen-asr",
+    "bench:stt:sherpa-onnx": "tsx --expose-gc run.ts --stt --engines sherpa-onnx",
+    "generate:stt-testset": "bash scripts/generate-stt-testset.sh"
   },
   "dependencies": {
     "@huggingface/transformers": "^3.8.0",

--- a/benchmark/run.ts
+++ b/benchmark/run.ts
@@ -1,27 +1,64 @@
 import type { BenchmarkEngine, Direction } from './src/types.js'
+import type { STTBenchmarkEngine } from './src/stt-types.js'
 import { runBenchmark } from './src/runner.js'
 import { writeReports } from './src/report.js'
+import { runSTTBenchmark } from './src/stt-runner.js'
+import { writeSTTReports } from './src/stt-report.js'
 
 const AVAILABLE_ENGINES = ['google', 'opus-mt', 'translate-gemma', 'translate-gemma-cpu'] as const
 type EngineId = (typeof AVAILABLE_ENGINES)[number]
 
-function parseArgs(): { engines: EngineId[]; directions: Direction[] } {
+const AVAILABLE_STT_ENGINES = [
+  'whisper-local',
+  'mlx-whisper',
+  'lightning-whisper',
+  'moonshine',
+  'sensevoice',
+  'qwen-asr',
+  'sherpa-onnx'
+] as const
+type STTEngineId = (typeof AVAILABLE_STT_ENGINES)[number]
+
+interface ParsedArgs {
+  mode: 'translation' | 'stt'
+  engines: EngineId[]
+  sttEngines: STTEngineId[]
+  directions: Direction[]
+}
+
+function parseArgs(): ParsedArgs {
   const args = process.argv.slice(2)
+  let mode: 'translation' | 'stt' = 'translation'
   let engines: EngineId[] = []
+  let sttEngines: STTEngineId[] = []
   let directions: Direction[] = ['ja-en', 'en-ja']
 
   for (let i = 0; i < args.length; i++) {
     const arg = args[i]
-    if (arg === '--engines' && args[i + 1]) {
-      engines = args[i + 1]!.split(',').map((e) => {
-        const trimmed = e.trim() as EngineId
-        if (!AVAILABLE_ENGINES.includes(trimmed)) {
-          console.error(`Unknown engine: ${trimmed}`)
-          console.error(`Available: ${AVAILABLE_ENGINES.join(', ')}`)
-          process.exit(1)
-        }
-        return trimmed
-      })
+    if (arg === '--stt') {
+      mode = 'stt'
+    } else if (arg === '--engines' && args[i + 1]) {
+      if (mode === 'stt') {
+        sttEngines = args[i + 1]!.split(',').map((e) => {
+          const trimmed = e.trim() as STTEngineId
+          if (!AVAILABLE_STT_ENGINES.includes(trimmed)) {
+            console.error(`Unknown STT engine: ${trimmed}`)
+            console.error(`Available: ${AVAILABLE_STT_ENGINES.join(', ')}`)
+            process.exit(1)
+          }
+          return trimmed
+        })
+      } else {
+        engines = args[i + 1]!.split(',').map((e) => {
+          const trimmed = e.trim() as EngineId
+          if (!AVAILABLE_ENGINES.includes(trimmed)) {
+            console.error(`Unknown engine: ${trimmed}`)
+            console.error(`Available: ${AVAILABLE_ENGINES.join(', ')}`)
+            process.exit(1)
+          }
+          return trimmed
+        })
+      }
       i++
     } else if (arg === '--direction' && args[i + 1]) {
       directions = [args[i + 1]! as Direction]
@@ -29,19 +66,28 @@ function parseArgs(): { engines: EngineId[]; directions: Direction[] } {
     } else if (arg === '--help' || arg === '-h') {
       console.log('Usage: npx tsx --expose-gc run.ts [options]')
       console.log('')
-      console.log('Options:')
+      console.log('Translation benchmark options:')
       console.log(`  --engines <list>     Comma-separated engines (${AVAILABLE_ENGINES.join(', ')})`)
       console.log('  --direction <dir>    ja-en or en-ja (default: both)')
+      console.log('')
+      console.log('STT benchmark options:')
+      console.log('  --stt                Run STT benchmark instead of translation')
+      console.log(`  --engines <list>     Comma-separated STT engines (${AVAILABLE_STT_ENGINES.join(', ')})`)
+      console.log('')
       console.log('  --help               Show this help')
       process.exit(0)
     }
   }
 
-  if (engines.length === 0) {
+  if (mode === 'translation' && engines.length === 0) {
     engines = ['google', 'opus-mt', 'translate-gemma', 'translate-gemma-cpu']
   }
 
-  return { engines, directions }
+  if (mode === 'stt' && sttEngines.length === 0) {
+    sttEngines = [...AVAILABLE_STT_ENGINES]
+  }
+
+  return { mode, engines, sttEngines, directions }
 }
 
 async function createEngine(id: EngineId): Promise<BenchmarkEngine> {
@@ -65,9 +111,40 @@ async function createEngine(id: EngineId): Promise<BenchmarkEngine> {
   }
 }
 
-async function main(): Promise<void> {
-  const { engines: engineIds, directions } = parseArgs()
+async function createSTTEngine(id: STTEngineId): Promise<STTBenchmarkEngine> {
+  switch (id) {
+    case 'whisper-local': {
+      const { WhisperLocalBench } = await import('./src/stt-engines/whisper-local.js')
+      return new WhisperLocalBench()
+    }
+    case 'mlx-whisper': {
+      const { MlxWhisperBench } = await import('./src/stt-engines/mlx-whisper.js')
+      return new MlxWhisperBench()
+    }
+    case 'lightning-whisper': {
+      const { LightningWhisperBench } = await import('./src/stt-engines/lightning-whisper.js')
+      return new LightningWhisperBench()
+    }
+    case 'moonshine': {
+      const { MoonshineBench } = await import('./src/stt-engines/moonshine.js')
+      return new MoonshineBench()
+    }
+    case 'sensevoice': {
+      const { SenseVoiceBench } = await import('./src/stt-engines/sensevoice.js')
+      return new SenseVoiceBench()
+    }
+    case 'qwen-asr': {
+      const { QwenASRBench } = await import('./src/stt-engines/qwen-asr.js')
+      return new QwenASRBench()
+    }
+    case 'sherpa-onnx': {
+      const { SherpaOnnxBench } = await import('./src/stt-engines/sherpa-onnx.js')
+      return new SherpaOnnxBench()
+    }
+  }
+}
 
+async function runTranslation(engineIds: EngineId[], directions: Direction[]): Promise<void> {
   console.log('=== Translation Quality Benchmark ===')
   console.log(`Engines: ${engineIds.join(', ')}`)
   console.log(`Directions: ${directions.join(', ')}`)
@@ -89,8 +166,41 @@ async function main(): Promise<void> {
 
   const result = await runBenchmark(engines, directions)
   const outputDir = writeReports(result)
-
   console.log(`\nDone. Results written to ${outputDir}`)
+}
+
+async function runSTT(engineIds: STTEngineId[]): Promise<void> {
+  console.log('=== STT Benchmark ===')
+  console.log(`Engines: ${engineIds.join(', ')}`)
+  console.log('')
+
+  const engines: STTBenchmarkEngine[] = []
+  for (const id of engineIds) {
+    try {
+      engines.push(await createSTTEngine(id))
+    } catch (err) {
+      console.error(`[main] Failed to create STT engine '${id}':`, err)
+    }
+  }
+
+  if (engines.length === 0) {
+    console.error('No STT engines available. Exiting.')
+    process.exit(1)
+  }
+
+  const result = await runSTTBenchmark(engines)
+  const outputDir = writeSTTReports(result)
+  console.log(`\nDone. Results written to ${outputDir}`)
+}
+
+async function main(): Promise<void> {
+  const parsed = parseArgs()
+
+  if (parsed.mode === 'stt') {
+    await runSTT(parsed.sttEngines)
+  } else {
+    await runTranslation(parsed.engines, parsed.directions)
+  }
 }
 
 main().catch((err) => {

--- a/benchmark/scripts/generate-stt-testset.sh
+++ b/benchmark/scripts/generate-stt-testset.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+# Generate STT test audio files using macOS `say` command.
+# Produces 20 JA and 20 EN WAV files at 16kHz mono with a JSONL manifest.
+#
+# Usage: ./benchmark/scripts/generate-stt-testset.sh
+# Requires: macOS with `say` and `afconvert` commands
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+OUTPUT_DIR="$SCRIPT_DIR/../testset/stt"
+MANIFEST="$OUTPUT_DIR/manifest.jsonl"
+
+mkdir -p "$OUTPUT_DIR/audio"
+
+# Clear previous manifest
+> "$MANIFEST"
+
+# Helper: generate a WAV file from text using macOS TTS
+# Args: $1=id $2=text $3=language $4=voice $5=domain
+generate() {
+  local id="$1"
+  local text="$2"
+  local lang="$3"
+  local voice="$4"
+  local domain="$5"
+  local aiff_path="$OUTPUT_DIR/audio/${id}.aiff"
+  local wav_path="$OUTPUT_DIR/audio/${id}.wav"
+
+  echo "  Generating: $id ($lang)"
+
+  # Generate AIFF with macOS say
+  say -v "$voice" -o "$aiff_path" "$text"
+
+  # Convert to 16kHz mono 16-bit PCM WAV
+  afconvert -f WAVE -d LEI16@16000 -c 1 "$aiff_path" "$wav_path"
+
+  # Remove intermediate AIFF
+  rm -f "$aiff_path"
+
+  # Append to manifest
+  printf '{"id":"%s","audio_path":"audio/%s.wav","reference_text":"%s","language":"%s","domain":"%s"}\n' \
+    "$id" "$id" "$(echo "$text" | sed 's/"/\\"/g')" "$lang" "$domain" >> "$MANIFEST"
+}
+
+echo "=== Generating Japanese test audio ==="
+
+# JA casual sentences
+generate "ja-casual-01" "おはようございます。" "ja" "Kyoko" "casual"
+generate "ja-casual-02" "ありがとうございます。" "ja" "Kyoko" "casual"
+generate "ja-casual-03" "今日はいい天気ですね。" "ja" "Kyoko" "casual"
+generate "ja-casual-04" "お腹がすきました。" "ja" "Kyoko" "casual"
+generate "ja-casual-05" "お元気ですか。" "ja" "Kyoko" "casual"
+
+# JA business sentences
+generate "ja-business-01" "本日の会議は午後三時から始まります。" "ja" "Kyoko" "business"
+generate "ja-business-02" "先日のご提案について確認させてください。" "ja" "Kyoko" "business"
+generate "ja-business-03" "来月の売上目標は前年比百二十パーセントです。" "ja" "Kyoko" "business"
+generate "ja-business-04" "プロジェクトの進捗を報告いたします。" "ja" "Kyoko" "business"
+generate "ja-business-05" "契約書の内容をご確認ください。" "ja" "Kyoko" "business"
+
+# JA technical sentences
+generate "ja-technical-01" "このシステムはマイクロサービスアーキテクチャを採用しています。" "ja" "Kyoko" "technical"
+generate "ja-technical-02" "データベースのインデックスを再構築する必要があります。" "ja" "Kyoko" "technical"
+generate "ja-technical-03" "エーピーアイのレスポンスタイムが遅延しています。" "ja" "Kyoko" "technical"
+generate "ja-technical-04" "テスト環境にデプロイが完了しました。" "ja" "Kyoko" "technical"
+generate "ja-technical-05" "メモリリークの原因を特定しました。" "ja" "Kyoko" "technical"
+
+# JA longer sentences
+generate "ja-long-01" "昨日の夜、友達と一緒にレストランで晩ご飯を食べましたが、料理がとてもおいしかったです。" "ja" "Kyoko" "casual"
+generate "ja-long-02" "この新しいソフトウェアを導入することで、業務効率を大幅に改善できると考えています。" "ja" "Kyoko" "business"
+generate "ja-long-03" "機械学習モデルの精度を向上させるために、より多くのトレーニングデータが必要です。" "ja" "Kyoko" "technical"
+generate "ja-long-04" "東京駅から新幹線に乗って、大阪まで約二時間半で到着します。" "ja" "Kyoko" "casual"
+generate "ja-long-05" "セキュリティパッチを適用した後、全てのサービスを再起動してください。" "ja" "Kyoko" "technical"
+
+echo ""
+echo "=== Generating English test audio ==="
+
+# EN casual sentences
+generate "en-casual-01" "Good morning, how are you today?" "en" "Samantha" "casual"
+generate "en-casual-02" "Thank you very much for your help." "en" "Samantha" "casual"
+generate "en-casual-03" "The weather is really nice today." "en" "Samantha" "casual"
+generate "en-casual-04" "I'm looking forward to the weekend." "en" "Samantha" "casual"
+generate "en-casual-05" "Let's grab lunch together sometime." "en" "Samantha" "casual"
+
+# EN business sentences
+generate "en-business-01" "The quarterly earnings report will be released next week." "en" "Samantha" "business"
+generate "en-business-02" "We need to schedule a follow-up meeting with the client." "en" "Samantha" "business"
+generate "en-business-03" "Our revenue increased by fifteen percent this quarter." "en" "Samantha" "business"
+generate "en-business-04" "Please review the updated proposal and share your feedback." "en" "Samantha" "business"
+generate "en-business-05" "The project deadline has been extended to the end of March." "en" "Samantha" "business"
+
+# EN technical sentences
+generate "en-technical-01" "The application uses a microservices architecture with Docker containers." "en" "Samantha" "technical"
+generate "en-technical-02" "We need to rebuild the database indexes to improve query performance." "en" "Samantha" "technical"
+generate "en-technical-03" "The API response time has increased significantly since the last deployment." "en" "Samantha" "technical"
+generate "en-technical-04" "The continuous integration pipeline is failing due to a dependency conflict." "en" "Samantha" "technical"
+generate "en-technical-05" "We identified a memory leak in the event handler module." "en" "Samantha" "technical"
+
+# EN longer sentences
+generate "en-long-01" "Last night I went out to dinner with some friends at a new Italian restaurant, and the food was absolutely delicious." "en" "Samantha" "casual"
+generate "en-long-02" "By implementing this new software solution, we expect to significantly improve our operational efficiency and reduce costs." "en" "Samantha" "business"
+generate "en-long-03" "To improve the accuracy of our machine learning model, we need to collect more diverse training data from multiple sources." "en" "Samantha" "technical"
+generate "en-long-04" "The train from Tokyo Station to Osaka takes approximately two and a half hours on the bullet train." "en" "Samantha" "casual"
+generate "en-long-05" "After applying the security patches, please restart all services and verify that the system is functioning correctly." "en" "Samantha" "technical"
+
+echo ""
+echo "=== Generation complete ==="
+echo "Audio files: $OUTPUT_DIR/audio/"
+echo "Manifest: $MANIFEST"
+echo "Total: $(wc -l < "$MANIFEST") entries"

--- a/benchmark/src/stt-engines/bridge-utils.ts
+++ b/benchmark/src/stt-engines/bridge-utils.ts
@@ -1,0 +1,194 @@
+import { spawn, type ChildProcess } from 'child_process'
+import { execSync } from 'child_process'
+import { existsSync } from 'fs'
+import { homedir } from 'os'
+import { join, dirname } from 'path'
+import { fileURLToPath } from 'url'
+
+/** Default timeout for bridge init (120s for model download) */
+export const BRIDGE_INIT_TIMEOUT_MS = 120_000
+/** Default timeout for transcription (30s) */
+export const BRIDGE_TRANSCRIBE_TIMEOUT_MS = 30_000
+
+/**
+ * Lightweight subprocess bridge for benchmark engines.
+ * Communicates with Python bridges via JSON-over-stdio.
+ * This is a standalone implementation (not dependent on Electron SubprocessBridge).
+ */
+export class BenchmarkBridge {
+  private process: ChildProcess | null = null
+  private pendingRequests = new Map<
+    number,
+    { resolve: (data: Record<string, unknown>) => void; reject: (err: Error) => void; timer: ReturnType<typeof setTimeout> }
+  >()
+  private nextRequestId = 0
+  private buffer = ''
+  private logPrefix: string
+
+  constructor(logPrefix: string) {
+    this.logPrefix = logPrefix
+  }
+
+  get isRunning(): boolean {
+    return this.process !== null
+  }
+
+  /**
+   * Spawn the bridge process and send an init command.
+   */
+  async start(
+    command: string,
+    args: string[],
+    initMessage: Record<string, unknown>,
+    initTimeout = BRIDGE_INIT_TIMEOUT_MS
+  ): Promise<void> {
+    if (this.process) return
+
+    this.process = spawn(command, args, { stdio: ['pipe', 'pipe', 'pipe'] })
+
+    this.process.stdout!.on('data', (data: Buffer) => {
+      this.buffer += data.toString()
+      const lines = this.buffer.split('\n')
+      this.buffer = lines.pop() ?? ''
+
+      for (const line of lines) {
+        if (!line.trim()) continue
+        try {
+          const msg = JSON.parse(line)
+          const reqId = msg._reqId as number | undefined
+          if (reqId !== undefined && this.pendingRequests.has(reqId)) {
+            const pending = this.pendingRequests.get(reqId)!
+            this.pendingRequests.delete(reqId)
+            clearTimeout(pending.timer)
+            pending.resolve(msg)
+          }
+        } catch {
+          // Ignore non-JSON output (e.g. model download progress)
+        }
+      }
+    })
+
+    this.process.stderr!.on('data', (data: Buffer) => {
+      const text = data.toString().trim()
+      if (text) {
+        console.warn(`${this.logPrefix} stderr:`, text.slice(0, 200))
+      }
+    })
+
+    this.process.on('exit', (code) => {
+      console.log(`${this.logPrefix} process exited with code ${code}`)
+      this.process = null
+      // Reject all pending requests
+      for (const [, pending] of this.pendingRequests) {
+        clearTimeout(pending.timer)
+        pending.reject(new Error('Bridge process exited'))
+      }
+      this.pendingRequests.clear()
+    })
+
+    // Send init command
+    const result = await this.sendCommand(initMessage, initTimeout)
+    if (result.error) {
+      await this.stop()
+      throw new Error(`${this.logPrefix} init failed: ${result.error}`)
+    }
+  }
+
+  /**
+   * Send a JSON command and wait for a response.
+   */
+  sendCommand(
+    cmd: Record<string, unknown>,
+    timeout = BRIDGE_TRANSCRIBE_TIMEOUT_MS
+  ): Promise<Record<string, unknown>> {
+    return new Promise((resolve, reject) => {
+      if (!this.process?.stdin) {
+        reject(new Error('Bridge process not running'))
+        return
+      }
+
+      const reqId = this.nextRequestId++ % 0xffffff
+      const timer = setTimeout(() => {
+        this.pendingRequests.delete(reqId)
+        reject(new Error('Bridge command timed out'))
+      }, timeout)
+
+      this.pendingRequests.set(reqId, { resolve, reject, timer })
+
+      this.process.stdin.write(JSON.stringify({ ...cmd, _reqId: reqId }) + '\n')
+    })
+  }
+
+  /**
+   * Gracefully stop the bridge process.
+   */
+  async stop(): Promise<void> {
+    if (!this.process) return
+
+    try {
+      this.process.stdin?.write(JSON.stringify({ action: 'dispose' }) + '\n')
+      await new Promise((resolve) => setTimeout(resolve, 500))
+    } catch {
+      // Ignore write errors during shutdown
+    }
+
+    try {
+      this.process.kill()
+    } catch {
+      // Already dead
+    }
+
+    this.process = null
+
+    for (const [, pending] of this.pendingRequests) {
+      clearTimeout(pending.timer)
+      pending.reject(new Error('Bridge disposed'))
+    }
+    this.pendingRequests.clear()
+  }
+}
+
+/**
+ * Find a Python 3 executable that has a specific module installed.
+ * Searches common venv locations, then falls back to system python3.
+ */
+export function findPython3WithModule(moduleName: string, extraVenvDirs: string[] = []): string {
+  const venvPaths = [
+    ...extraVenvDirs.map((d) => join(homedir(), d, 'bin', 'python3')),
+    join(homedir(), 'mlx-env', 'bin', 'python3'),
+    join(homedir(), '.venv', 'bin', 'python3'),
+    join(homedir(), 'venv', 'bin', 'python3')
+  ]
+
+  for (const p of venvPaths) {
+    if (!existsSync(p)) continue
+    try {
+      execSync(`${p} -c "import ${moduleName}"`, { stdio: 'ignore', timeout: 5000 })
+      return p
+    } catch {
+      // Module not installed in this venv
+    }
+  }
+
+  // Fall back to system python3
+  try {
+    execSync(`python3 -c "import ${moduleName}"`, { stdio: 'ignore', timeout: 5000 })
+    return 'python3'
+  } catch {
+    // Not available
+  }
+
+  throw new Error(`Python 3 with ${moduleName} not found`)
+}
+
+/** Get the path to a resource bridge script */
+export function getBridgePath(scriptName: string): string {
+  // In benchmark context, resources are at the project root
+  return join(getProjectRoot(), 'resources', scriptName)
+}
+
+/** Get the project root directory */
+export function getProjectRoot(): string {
+  const dir = dirname(fileURLToPath(import.meta.url))
+  return join(dir, '..', '..')
+}

--- a/benchmark/src/stt-engines/lightning-whisper.ts
+++ b/benchmark/src/stt-engines/lightning-whisper.ts
@@ -1,0 +1,53 @@
+import type { STTBenchmarkEngine } from '../stt-types.js'
+import { BenchmarkBridge, findPython3WithModule, getBridgePath } from './bridge-utils.js'
+
+/**
+ * Lightning Whisper MLX benchmark engine.
+ * ~10x faster than whisper.cpp on Apple Silicon via optimized MLX kernels.
+ */
+export class LightningWhisperBench implements STTBenchmarkEngine {
+  readonly id = 'lightning-whisper'
+  readonly label = 'Lightning Whisper MLX'
+
+  private bridge = new BenchmarkBridge('[lightning-whisper]')
+  private model: string
+
+  constructor(model = 'distil-large-v3') {
+    this.model = model
+  }
+
+  async initialize(): Promise<void> {
+    if (this.bridge.isRunning) return
+
+    const python3 = findPython3WithModule('lightning_whisper_mlx', [
+      'mlx-env',
+      'lightning-whisper-env'
+    ])
+    console.log(`[lightning-whisper] Using Python: ${python3}`)
+
+    await this.bridge.start(
+      python3,
+      [getBridgePath('lightning-whisper-bridge.py')],
+      { action: 'init', model: this.model, batch_size: 12, quant: null }
+    )
+    console.log('[lightning-whisper] Ready')
+  }
+
+  async transcribe(audioPath: string, _language?: string): Promise<string> {
+    const result = await this.bridge.sendCommand({
+      action: 'transcribe',
+      audio_path: audioPath,
+      sample_rate: 16000
+    })
+
+    if (result.error) {
+      throw new Error(`Transcription error: ${result.error}`)
+    }
+
+    return ((result.text as string) ?? '').trim()
+  }
+
+  async dispose(): Promise<void> {
+    await this.bridge.stop()
+  }
+}

--- a/benchmark/src/stt-engines/mlx-whisper.ts
+++ b/benchmark/src/stt-engines/mlx-whisper.ts
@@ -1,0 +1,50 @@
+import type { STTBenchmarkEngine } from '../stt-types.js'
+import { BenchmarkBridge, findPython3WithModule, getBridgePath } from './bridge-utils.js'
+
+/**
+ * MLX Whisper benchmark engine.
+ * Uses the mlx-whisper Python bridge for Apple Silicon optimized inference.
+ */
+export class MlxWhisperBench implements STTBenchmarkEngine {
+  readonly id = 'mlx-whisper'
+  readonly label = 'mlx-whisper (Apple Silicon)'
+
+  private bridge = new BenchmarkBridge('[mlx-whisper]')
+  private model: string
+
+  constructor(model = 'mlx-community/whisper-large-v3-turbo') {
+    this.model = model
+  }
+
+  async initialize(): Promise<void> {
+    if (this.bridge.isRunning) return
+
+    const python3 = findPython3WithModule('mlx_whisper', ['mlx-env'])
+    console.log(`[mlx-whisper] Using Python: ${python3}`)
+
+    await this.bridge.start(
+      python3,
+      [getBridgePath('mlx-whisper-bridge.py')],
+      { action: 'init', model: this.model }
+    )
+    console.log('[mlx-whisper] Ready')
+  }
+
+  async transcribe(audioPath: string, _language?: string): Promise<string> {
+    const result = await this.bridge.sendCommand({
+      action: 'transcribe',
+      audio_path: audioPath,
+      sample_rate: 16000
+    })
+
+    if (result.error) {
+      throw new Error(`Transcription error: ${result.error}`)
+    }
+
+    return ((result.text as string) ?? '').trim()
+  }
+
+  async dispose(): Promise<void> {
+    await this.bridge.stop()
+  }
+}

--- a/benchmark/src/stt-engines/moonshine.ts
+++ b/benchmark/src/stt-engines/moonshine.ts
@@ -1,0 +1,79 @@
+import { readFileSync } from 'fs'
+import { join, dirname } from 'path'
+import { fileURLToPath } from 'url'
+import type { STTBenchmarkEngine } from '../stt-types.js'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const MODELS_DIR = join(__dirname, '..', '..', 'models', 'moonshine')
+
+/** Minimal interface for HuggingFace ASR pipeline */
+interface ASRPipeline {
+  (audio: Float32Array, options: { sampling_rate: number }): Promise<{ text?: string }>
+  dispose(): Promise<void>
+}
+
+/**
+ * Moonshine benchmark engine using @huggingface/transformers.
+ * Runs in-process with ONNX runtime — no Python dependency.
+ */
+export class MoonshineBench implements STTBenchmarkEngine {
+  readonly id = 'moonshine'
+  readonly label = 'Moonshine (HuggingFace)'
+
+  private pipeline: ASRPipeline | null = null
+  private modelId: string
+
+  constructor(modelId = 'onnx-community/moonshine-base-ONNX') {
+    this.modelId = modelId
+  }
+
+  async initialize(): Promise<void> {
+    if (this.pipeline) return
+
+    console.log(`[moonshine] Loading model: ${this.modelId}`)
+    const { pipeline, env } = await import('@huggingface/transformers')
+    env.cacheDir = MODELS_DIR
+
+    this.pipeline = (await pipeline('automatic-speech-recognition', this.modelId, {
+      dtype: 'q8'
+    })) as unknown as ASRPipeline
+
+    console.log('[moonshine] Model loaded')
+  }
+
+  async transcribe(audioPath: string, _language?: string): Promise<string> {
+    if (!this.pipeline) throw new Error('Engine not initialized')
+
+    const pcm = readWavAsPcm(audioPath)
+    const result = await this.pipeline(pcm, { sampling_rate: 16000 })
+    return (result?.text ?? '').trim()
+  }
+
+  async dispose(): Promise<void> {
+    try {
+      await this.pipeline?.dispose()
+    } catch (err) {
+      console.error('[moonshine] Error during disposal:', err)
+    }
+    this.pipeline = null
+  }
+}
+
+/** Read a WAV file and return Float32Array of PCM samples */
+function readWavAsPcm(wavPath: string): Float32Array {
+  const buffer = readFileSync(wavPath)
+  const dataOffset = 44
+  const bitsPerSample = buffer.readUInt16LE(34)
+  const numSamples = (buffer.length - dataOffset) / (bitsPerSample / 8)
+
+  const samples = new Float32Array(numSamples)
+  for (let i = 0; i < numSamples; i++) {
+    if (bitsPerSample === 16) {
+      samples[i] = buffer.readInt16LE(dataOffset + i * 2) / 32768.0
+    } else if (bitsPerSample === 32) {
+      samples[i] = buffer.readFloatLE(dataOffset + i * 4)
+    }
+  }
+
+  return samples
+}

--- a/benchmark/src/stt-engines/qwen-asr.ts
+++ b/benchmark/src/stt-engines/qwen-asr.ts
@@ -1,0 +1,67 @@
+import type { STTBenchmarkEngine } from '../stt-types.js'
+import { BenchmarkBridge, findPython3WithModule, getBridgePath } from './bridge-utils.js'
+
+/**
+ * Qwen3-ASR benchmark engine.
+ * Supports 52 languages/dialects with SOTA accuracy.
+ * Uses the qwen-asr Python bridge.
+ */
+export class QwenASRBench implements STTBenchmarkEngine {
+  readonly id = 'qwen-asr'
+  readonly label: string
+
+  private bridge = new BenchmarkBridge('[qwen-asr]')
+  private modelId: string
+
+  constructor(variant: '0.6b' | '1.7b' = '0.6b') {
+    const models: Record<string, { modelId: string; label: string }> = {
+      '0.6b': { modelId: 'Qwen/Qwen3-ASR-0.6B', label: 'Qwen3-ASR (0.6B)' },
+      '1.7b': { modelId: 'Qwen/Qwen3-ASR-1.7B', label: 'Qwen3-ASR (1.7B)' }
+    }
+    const config = models[variant]!
+    this.modelId = config.modelId
+    this.label = config.label
+  }
+
+  async initialize(): Promise<void> {
+    if (this.bridge.isRunning) return
+
+    const python3 = findPython3WithModule('qwen_asr', ['qwen-asr-env'])
+    console.log(`[qwen-asr] Using Python: ${python3}`)
+
+    // Check if bridge script exists; qwen-asr-bridge.py may not exist yet
+    const { existsSync } = await import('fs')
+    const bridgePath = getBridgePath('qwen-asr-bridge.py')
+    if (!existsSync(bridgePath)) {
+      throw new Error(
+        `Bridge script not found: ${bridgePath}. ` +
+        `Qwen3-ASR bridge is not yet implemented in resources/.`
+      )
+    }
+
+    await this.bridge.start(
+      python3,
+      [bridgePath],
+      { action: 'init', model: this.modelId }
+    )
+    console.log(`[qwen-asr] Ready`)
+  }
+
+  async transcribe(audioPath: string, _language?: string): Promise<string> {
+    const result = await this.bridge.sendCommand({
+      action: 'transcribe',
+      audio_path: audioPath,
+      sample_rate: 16000
+    })
+
+    if (result.error) {
+      throw new Error(`Transcription error: ${result.error}`)
+    }
+
+    return ((result.text as string) ?? '').trim()
+  }
+
+  async dispose(): Promise<void> {
+    await this.bridge.stop()
+  }
+}

--- a/benchmark/src/stt-engines/sensevoice.ts
+++ b/benchmark/src/stt-engines/sensevoice.ts
@@ -1,0 +1,54 @@
+import type { STTBenchmarkEngine } from '../stt-types.js'
+import { BenchmarkBridge, findPython3WithModule, getBridgePath } from './bridge-utils.js'
+
+/**
+ * SenseVoice benchmark engine.
+ * CJK-optimized STT with up to 15x faster inference than Whisper.
+ * Uses the FunASR Python bridge.
+ */
+export class SenseVoiceBench implements STTBenchmarkEngine {
+  readonly id = 'sensevoice'
+  readonly label = 'SenseVoice (FunASR)'
+
+  private bridge = new BenchmarkBridge('[sensevoice]')
+  private model: string
+
+  constructor(model = 'FunAudioLLM/SenseVoiceSmall') {
+    this.model = model
+  }
+
+  async initialize(): Promise<void> {
+    if (this.bridge.isRunning) return
+
+    const python3 = findPython3WithModule('funasr', [
+      'sensevoice-env',
+      'funasr-env'
+    ])
+    console.log(`[sensevoice] Using Python: ${python3}`)
+
+    await this.bridge.start(
+      python3,
+      [getBridgePath('sensevoice-bridge.py')],
+      { action: 'init', model: this.model }
+    )
+    console.log('[sensevoice] Ready')
+  }
+
+  async transcribe(audioPath: string, _language?: string): Promise<string> {
+    const result = await this.bridge.sendCommand({
+      action: 'transcribe',
+      audio_path: audioPath,
+      sample_rate: 16000
+    })
+
+    if (result.error) {
+      throw new Error(`Transcription error: ${result.error}`)
+    }
+
+    return ((result.text as string) ?? '').trim()
+  }
+
+  async dispose(): Promise<void> {
+    await this.bridge.stop()
+  }
+}

--- a/benchmark/src/stt-engines/sherpa-onnx.ts
+++ b/benchmark/src/stt-engines/sherpa-onnx.ts
@@ -1,0 +1,157 @@
+import { readFileSync, existsSync } from 'fs'
+import { join } from 'path'
+import { homedir } from 'os'
+import type { STTBenchmarkEngine } from '../stt-types.js'
+
+/** Sherpa-ONNX result interface */
+interface SherpaOnnxResult {
+  text: string
+  lang?: string
+}
+
+/** Sherpa-ONNX module interface */
+interface SherpaOnnxModule {
+  OfflineRecognizer: new (config: Record<string, unknown>) => SherpaOnnxRecognizer
+}
+
+interface SherpaOnnxRecognizer {
+  createStream(): SherpaOnnxStream
+  decode(stream: SherpaOnnxStream): void
+  getResult(stream: SherpaOnnxStream): SherpaOnnxResult
+}
+
+interface SherpaOnnxStream {
+  acceptWaveform(params: { sampleRate: number; samples: Float32Array }): void
+}
+
+/** Supported model keys */
+type SherpaModelKey = 'whisper-tiny' | 'whisper-base' | 'sensevoice-small' | 'paraformer-zh'
+
+const MODEL_CONFIGS: Record<SherpaModelKey, {
+  type: 'whisper' | 'sensevoice' | 'paraformer'
+  dirName: string
+  label: string
+}> = {
+  'whisper-tiny': { type: 'whisper', dirName: 'sherpa-onnx-whisper-tiny', label: 'Whisper Tiny' },
+  'whisper-base': { type: 'whisper', dirName: 'sherpa-onnx-whisper-base', label: 'Whisper Base' },
+  'sensevoice-small': { type: 'sensevoice', dirName: 'sherpa-onnx-sense-voice-zh-en-ja-ko-yue-2024-07-17', label: 'SenseVoice Small' },
+  'paraformer-zh': { type: 'paraformer', dirName: 'sherpa-onnx-paraformer-zh-2023-09-14', label: 'Paraformer (Chinese)' }
+}
+
+/**
+ * Sherpa-ONNX benchmark engine using native Node.js addon.
+ * No Python dependency — runs entirely in-process via ONNX runtime.
+ */
+export class SherpaOnnxBench implements STTBenchmarkEngine {
+  readonly id = 'sherpa-onnx'
+  readonly label: string
+
+  private recognizer: SherpaOnnxRecognizer | null = null
+  private modelKey: SherpaModelKey
+
+  constructor(modelKey: SherpaModelKey = 'whisper-base') {
+    this.modelKey = modelKey
+    const config = MODEL_CONFIGS[this.modelKey]
+    this.label = `Sherpa-ONNX (${config.label})`
+  }
+
+  async initialize(): Promise<void> {
+    if (this.recognizer) return
+
+    const modelConfig = MODEL_CONFIGS[this.modelKey]
+
+    // Look for models in userData or common locations
+    const modelsRoots = [
+      join(homedir(), 'Library', 'Application Support', 'live-translate', 'models', 'sherpa-onnx'),
+      join(homedir(), '.cache', 'sherpa-onnx')
+    ]
+
+    let modelDir: string | null = null
+    for (const root of modelsRoots) {
+      const candidate = join(root, modelConfig.dirName)
+      if (existsSync(candidate)) {
+        modelDir = candidate
+        break
+      }
+    }
+
+    if (!modelDir) {
+      throw new Error(
+        `[sherpa-onnx] Model directory not found for ${modelConfig.dirName}. ` +
+        `Download from https://github.com/k2-fsa/sherpa-onnx/releases`
+      )
+    }
+
+    // Dynamic require for the optional native addon
+    let sherpaOnnx: SherpaOnnxModule
+    try {
+      sherpaOnnx = (await import('sherpa-onnx-node')).default as unknown as SherpaOnnxModule
+    } catch (err) {
+      throw new Error(
+        `[sherpa-onnx] Failed to load sherpa-onnx-node. Install with: npm install sherpa-onnx-node. ` +
+        `Error: ${err instanceof Error ? err.message : err}`
+      )
+    }
+
+    const tokensPath = join(modelDir, 'tokens.txt')
+    const config: Record<string, unknown> = {
+      featConfig: { sampleRate: 16000, featureDim: 80 },
+      modelConfig: {
+        tokens: tokensPath,
+        numThreads: 2,
+        provider: 'cpu',
+        debug: 0,
+        ...(modelConfig.type === 'whisper'
+          ? { whisper: { encoder: join(modelDir, 'encoder.onnx'), decoder: join(modelDir, 'decoder.onnx') } }
+          : modelConfig.type === 'sensevoice'
+            ? { senseVoice: { model: join(modelDir, 'model.onnx') } }
+            : { paraformer: { model: join(modelDir, 'model.int8.onnx') } })
+      }
+    }
+
+    try {
+      this.recognizer = new sherpaOnnx.OfflineRecognizer(config)
+    } catch (err) {
+      throw new Error(
+        `[sherpa-onnx] Failed to create recognizer: ${err instanceof Error ? err.message : err}`
+      )
+    }
+
+    console.log(`[sherpa-onnx] ${modelConfig.label} ready`)
+  }
+
+  async transcribe(audioPath: string, _language?: string): Promise<string> {
+    if (!this.recognizer) throw new Error('Engine not initialized')
+
+    const pcm = readWavAsPcm(audioPath)
+    const stream = this.recognizer.createStream()
+    stream.acceptWaveform({ sampleRate: 16000, samples: pcm })
+    this.recognizer.decode(stream)
+    const result = this.recognizer.getResult(stream)
+
+    return (result.text ?? '').trim()
+  }
+
+  async dispose(): Promise<void> {
+    this.recognizer = null
+  }
+}
+
+/** Read a WAV file and return Float32Array of PCM samples */
+function readWavAsPcm(wavPath: string): Float32Array {
+  const buffer = readFileSync(wavPath)
+  const dataOffset = 44
+  const bitsPerSample = buffer.readUInt16LE(34)
+  const numSamples = (buffer.length - dataOffset) / (bitsPerSample / 8)
+
+  const samples = new Float32Array(numSamples)
+  for (let i = 0; i < numSamples; i++) {
+    if (bitsPerSample === 16) {
+      samples[i] = buffer.readInt16LE(dataOffset + i * 2) / 32768.0
+    } else if (bitsPerSample === 32) {
+      samples[i] = buffer.readFloatLE(dataOffset + i * 4)
+    }
+  }
+
+  return samples
+}

--- a/benchmark/src/stt-engines/whisper-local.ts
+++ b/benchmark/src/stt-engines/whisper-local.ts
@@ -1,0 +1,112 @@
+import type { STTBenchmarkEngine } from '../stt-types.js'
+
+/**
+ * Whisper Local benchmark engine using whisper-node-addon (native).
+ *
+ * Note: whisper-node-addon requires native bindings that may only work
+ * inside the Electron context. This engine attempts a direct require()
+ * but will fail gracefully if the addon is not available.
+ */
+export class WhisperLocalBench implements STTBenchmarkEngine {
+  readonly id = 'whisper-local'
+  readonly label = 'Whisper Local (native)'
+
+  private whisperModule: {
+    transcribe: (opts: Record<string, unknown>) => Promise<{ transcription: string[][] | string[] }>
+  } | null = null
+  private modelPath = ''
+
+  async initialize(): Promise<void> {
+    if (this.whisperModule) return
+
+    try {
+      // whisper-node-addon is a native addon — may not be available outside Electron
+      this.whisperModule = await import('@kutalia/whisper-node-addon')
+    } catch (err) {
+      throw new Error(
+        `whisper-node-addon not available. This engine requires the native addon. ` +
+        `Error: ${err instanceof Error ? err.message : err}`
+      )
+    }
+
+    // Find model path — check common locations
+    const { existsSync } = await import('fs')
+    const { join } = await import('path')
+    const { homedir } = await import('os')
+
+    const candidates = [
+      join(homedir(), 'Library', 'Application Support', 'live-translate', 'models', 'ggml-large-v3-turbo.bin'),
+      join(homedir(), 'Library', 'Application Support', 'live-translate', 'models', 'ggml-kotoba-whisper-v2.0.bin'),
+      join(homedir(), '.cache', 'whisper', 'ggml-large-v3-turbo.bin'),
+      join(homedir(), '.cache', 'whisper', 'ggml-base.bin')
+    ]
+
+    for (const p of candidates) {
+      if (existsSync(p)) {
+        this.modelPath = p
+        console.log(`[whisper-local] Using model: ${p}`)
+        return
+      }
+    }
+
+    throw new Error(
+      'Whisper model not found. Download a ggml model to ~/Library/Application Support/live-translate/models/'
+    )
+  }
+
+  async transcribe(audioPath: string, _language?: string): Promise<string> {
+    if (!this.whisperModule || !this.modelPath) {
+      throw new Error('Engine not initialized')
+    }
+
+    // Read WAV file and extract PCM samples
+    const pcmf32 = await readWavAsPcm(audioPath)
+
+    const result = await this.whisperModule.transcribe({
+      model: this.modelPath,
+      pcmf32,
+      language: 'auto',
+      vad: false,
+      no_timestamps: true,
+      no_prints: true
+    })
+
+    return extractText(result.transcription)
+  }
+
+  async dispose(): Promise<void> {
+    this.whisperModule = null
+    this.modelPath = ''
+  }
+}
+
+/** Read a WAV file and return Float32Array of samples */
+async function readWavAsPcm(wavPath: string): Promise<Float32Array> {
+  const { readFileSync } = await import('fs')
+  const buffer = readFileSync(wavPath)
+
+  // Parse WAV header
+  const dataOffset = 44 // Standard WAV header size
+  const bitsPerSample = buffer.readUInt16LE(34)
+  const numSamples = (buffer.length - dataOffset) / (bitsPerSample / 8)
+
+  const samples = new Float32Array(numSamples)
+  for (let i = 0; i < numSamples; i++) {
+    if (bitsPerSample === 16) {
+      samples[i] = buffer.readInt16LE(dataOffset + i * 2) / 32768.0
+    } else if (bitsPerSample === 32) {
+      samples[i] = buffer.readFloatLE(dataOffset + i * 4)
+    }
+  }
+
+  return samples
+}
+
+/** Extract text from whisper-node-addon transcription result */
+function extractText(transcription: string[][] | string[]): string {
+  if (!transcription || transcription.length === 0) return ''
+  if (Array.isArray(transcription[0])) {
+    return (transcription as string[][]).map((seg) => seg[seg.length - 1] || '').join(' ').trim()
+  }
+  return (transcription as string[]).join(' ').trim()
+}

--- a/benchmark/src/stt-report.ts
+++ b/benchmark/src/stt-report.ts
@@ -1,0 +1,185 @@
+import { mkdirSync, writeFileSync } from 'fs'
+import { join, dirname } from 'path'
+import { fileURLToPath } from 'url'
+import type { STTBenchmarkResult, STTEngineSummary, WERResult } from './stt-types.js'
+import { computeWER, aggregateWER } from './wer.js'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const RESULTS_DIR = join(__dirname, '..', 'results')
+
+function fmt(n: number, decimals = 0): string {
+  return n.toFixed(decimals)
+}
+
+function fmtPct(n: number): string {
+  return (n * 100).toFixed(1) + '%'
+}
+
+function buildSummaryTable(summaries: STTEngineSummary[]): string {
+  const header =
+    '| Engine | Avg Latency | Median | P95 | WER | Peak RSS | Errors |'
+  const sep = '|---|---|---|---|---|---|---|'
+  const rows = summaries.map((s) => {
+    return (
+      `| ${s.engineLabel} | ${fmt(s.latency.avg)}ms | ${fmt(s.latency.median)}ms` +
+      ` | ${fmt(s.latency.p95)}ms | ${fmtPct(s.wer.wer)} | ${fmt(s.peakRssMB / 1024, 2)}GB | ${s.errors} |`
+    )
+  })
+  return [header, sep, ...rows].join('\n')
+}
+
+function buildLanguageBreakdownTable(summaries: STTEngineSummary[]): string {
+  // Collect all languages
+  const languages = new Set<string>()
+  for (const s of summaries) {
+    for (const lang of Object.keys(s.werByLanguage)) {
+      languages.add(lang)
+    }
+  }
+
+  const langList = [...languages].sort()
+  const werHeaders = langList.map((l) => `WER (${l.toUpperCase()})`)
+  const latHeaders = langList.map((l) => `Latency (${l.toUpperCase()})`)
+
+  const header = `| Engine | ${werHeaders.join(' | ')} | ${latHeaders.join(' | ')} |`
+  const sep = `|---|${langList.map(() => '---').join('|')}|${langList.map(() => '---').join('|')}|`
+
+  const rows = summaries.map((s) => {
+    const werCells = langList.map((lang) => {
+      const w = s.werByLanguage[lang]
+      return w ? fmtPct(w.wer) : 'N/A'
+    })
+    const latCells = langList.map((lang) => {
+      const langResults = s.results.filter((r) => r.language === lang && !r.error)
+      if (langResults.length === 0) return 'N/A'
+      const avg = langResults.reduce((acc, r) => acc + r.latencyMs, 0) / langResults.length
+      return `${fmt(avg)}ms`
+    })
+    return `| ${s.engineLabel} | ${werCells.join(' | ')} | ${latCells.join(' | ')} |`
+  })
+
+  return [header, sep, ...rows].join('\n')
+}
+
+function buildDomainBreakdownTable(summaries: STTEngineSummary[]): string {
+  const domains = new Set<string>()
+  for (const s of summaries) {
+    for (const r of s.results) {
+      domains.add(r.domain)
+    }
+  }
+
+  const domainList = [...domains].sort()
+  const header = `| Engine | ${domainList.map((d) => `WER (${d})`).join(' | ')} | ${domainList.map((d) => `Latency (${d})`).join(' | ')} |`
+  const sep = `|---|${domainList.map(() => '---').join('|')}|${domainList.map(() => '---').join('|')}|`
+
+  const rows = summaries.map((s) => {
+    const werCells = domainList.map((domain) => {
+      const domainResults = s.results.filter((r) => r.domain === domain && !r.error)
+      if (domainResults.length === 0) return 'N/A'
+      const wers = domainResults.map((r) => computeWER(r.reference, r.output, r.language))
+      const agg = aggregateWER(wers)
+      return fmtPct(agg.wer)
+    })
+    const latCells = domainList.map((domain) => {
+      const domainResults = s.results.filter((r) => r.domain === domain && !r.error)
+      if (domainResults.length === 0) return 'N/A'
+      const avg = domainResults.reduce((acc, r) => acc + r.latencyMs, 0) / domainResults.length
+      return `${fmt(avg)}ms`
+    })
+    return `| ${s.engineLabel} | ${werCells.join(' | ')} | ${latCells.join(' | ')} |`
+  })
+
+  return [header, sep, ...rows].join('\n')
+}
+
+function buildGoNoGoTable(summaries: STTEngineSummary[]): string {
+  const LATENCY_THRESHOLD_MS = 3000 // 3s for STT (audio files may be several seconds long)
+  const WER_THRESHOLD = 0.30 // 30% WER
+  const MEMORY_THRESHOLD_MB = 4 * 1024 // 4GB
+
+  const header = `| Criteria | ${summaries.map((s) => s.engineLabel).join(' | ')} |`
+  const sep = `|---|${summaries.map(() => '---').join('|')}|`
+
+  const latencyRow = `| Latency acceptable (<3s) | ${summaries
+    .map((s) => (s.latency.avg < LATENCY_THRESHOLD_MS ? `Yes (${fmt(s.latency.avg)}ms)` : `No (${fmt(s.latency.avg)}ms)`))
+    .join(' | ')} |`
+
+  const werRow = `| WER acceptable (<30%) | ${summaries
+    .map((s) => (s.wer.wer < WER_THRESHOLD ? `Yes (${fmtPct(s.wer.wer)})` : `No (${fmtPct(s.wer.wer)})`))
+    .join(' | ')} |`
+
+  const memoryRow = `| Memory acceptable (<4GB) | ${summaries
+    .map((s) => (s.peakRssMB < MEMORY_THRESHOLD_MB ? `Yes (${fmt(s.peakRssMB / 1024, 2)}GB)` : `No (${fmt(s.peakRssMB / 1024, 2)}GB)`))
+    .join(' | ')} |`
+
+  const recRow = `| Recommendation | ${summaries
+    .map((s) => {
+      const ok = s.latency.avg < LATENCY_THRESHOLD_MS && s.wer.wer < WER_THRESHOLD && s.peakRssMB < MEMORY_THRESHOLD_MB
+      return ok ? 'Go' : 'No-Go'
+    })
+    .join(' | ')} |`
+
+  return [header, sep, latencyRow, werRow, memoryRow, recRow].join('\n')
+}
+
+function buildMarkdown(result: STTBenchmarkResult): string {
+  const lines: string[] = [
+    '# STT Benchmark Results',
+    '',
+    `Run: ${result.timestamp}`,
+    '',
+    '## Summary',
+    '',
+    buildSummaryTable(result.summaries),
+    '',
+    '## WER & Latency by Language',
+    '',
+    buildLanguageBreakdownTable(result.summaries),
+    '',
+    '## WER & Latency by Domain',
+    '',
+    buildDomainBreakdownTable(result.summaries),
+    '',
+    '## Go/No-Go Recommendation',
+    '',
+    buildGoNoGoTable(result.summaries),
+    ''
+  ]
+  return lines.join('\n')
+}
+
+/** Write all STT report files to results/ directory */
+export function writeSTTReports(result: STTBenchmarkResult): string {
+  mkdirSync(RESULTS_DIR, { recursive: true })
+
+  const ts = result.timestamp.replace(/[:.]/g, '-').slice(0, 19)
+
+  // Raw JSON
+  const jsonPath = join(RESULTS_DIR, `stt-benchmark-${ts}.json`)
+  writeFileSync(jsonPath, JSON.stringify(result, null, 2))
+  console.log(`[stt-report] JSON: ${jsonPath}`)
+
+  // Markdown summary
+  const mdPath = join(RESULTS_DIR, `stt-benchmark-${ts}.md`)
+  writeFileSync(mdPath, buildMarkdown(result))
+  console.log(`[stt-report] Markdown: ${mdPath}`)
+
+  // Per-engine detailed results CSV
+  const csvPath = join(RESULTS_DIR, `stt-results-${ts}.csv`)
+  const csvHeader = 'engine,id,language,domain,reference,output,latency_ms,error'
+  const csvRows = result.summaries.flatMap((s) =>
+    s.results.map(
+      (r) =>
+        `${s.engineId},${r.id},${r.language},${r.domain},"${esc(r.reference)}","${esc(r.output)}",${r.latencyMs.toFixed(0)},${r.error ? `"${esc(r.error)}"` : ''}`
+    )
+  )
+  writeFileSync(csvPath, [csvHeader, ...csvRows].join('\n'))
+  console.log(`[stt-report] CSV: ${csvPath}`)
+
+  return RESULTS_DIR
+}
+
+function esc(s: string): string {
+  return s.replace(/"/g, '""')
+}

--- a/benchmark/src/stt-runner.ts
+++ b/benchmark/src/stt-runner.ts
@@ -1,0 +1,160 @@
+import { readFileSync } from 'fs'
+import { join, dirname } from 'path'
+import { fileURLToPath } from 'url'
+import type {
+  STTBenchmarkEngine,
+  STTBenchmarkResult,
+  STTEngineSummary,
+  STTSentenceResult,
+  STTTestEntry
+} from './stt-types.js'
+import { computeWER, aggregateWER } from './wer.js'
+import { measureLatency, snapshotMemory, tryGC, computeStats } from './metrics.js'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const TESTSET_DIR = join(__dirname, '..', 'testset', 'stt')
+const MANIFEST_PATH = join(TESTSET_DIR, 'manifest.jsonl')
+const WARMUP_COUNT = 2
+
+/** Load STT test entries from manifest JSONL */
+function loadManifest(path: string): STTTestEntry[] {
+  const content = readFileSync(path, 'utf-8')
+  return content
+    .split('\n')
+    .filter((line) => line.trim())
+    .map((line) => JSON.parse(line) as STTTestEntry)
+}
+
+/** Run a single STT engine against the full testset */
+async function runSTTEngine(
+  engine: STTBenchmarkEngine,
+  entries: STTTestEntry[],
+  testsetDir: string
+): Promise<STTEngineSummary> {
+  console.log(`\n[stt-runner] ${engine.label}: ${entries.length} audio files`)
+
+  // Initialize
+  console.log(`[stt-runner] Initializing ${engine.label}...`)
+  await engine.initialize()
+  tryGC()
+
+  let peakRss = snapshotMemory().rssMB
+
+  // Warmup (first N files, results discarded)
+  const warmupEntries = entries.slice(0, WARMUP_COUNT)
+  console.log(`[stt-runner] Warmup: ${warmupEntries.length} files`)
+  for (const entry of warmupEntries) {
+    try {
+      const audioPath = join(testsetDir, entry.audio_path)
+      await engine.transcribe(audioPath, entry.language)
+    } catch {
+      // Ignore warmup errors
+    }
+  }
+  tryGC()
+
+  // Benchmark all files
+  const results: STTSentenceResult[] = []
+  for (let i = 0; i < entries.length; i++) {
+    const entry = entries[i]!
+    const audioPath = join(testsetDir, entry.audio_path)
+    const progress = `[${i + 1}/${entries.length}]`
+
+    try {
+      const { result: output, ms } = await measureLatency(() =>
+        engine.transcribe(audioPath, entry.language)
+      )
+
+      results.push({
+        id: entry.id,
+        audioPath: entry.audio_path,
+        reference: entry.reference_text,
+        output,
+        language: entry.language,
+        domain: entry.domain,
+        latencyMs: ms
+      })
+
+      if ((i + 1) % 10 === 0) {
+        console.log(`  ${progress} ${ms.toFixed(0)}ms — "${output.slice(0, 50)}"`)
+      }
+    } catch (err) {
+      const errorMsg = err instanceof Error ? err.message : String(err)
+      console.error(`  ${progress} ERROR: ${errorMsg}`)
+      results.push({
+        id: entry.id,
+        audioPath: entry.audio_path,
+        reference: entry.reference_text,
+        output: '',
+        language: entry.language,
+        domain: entry.domain,
+        latencyMs: 0,
+        error: errorMsg
+      })
+    }
+
+    // Track peak RSS
+    const mem = snapshotMemory()
+    if (mem.rssMB > peakRss) peakRss = mem.rssMB
+  }
+
+  // Compute WER
+  const successResults = results.filter((r) => !r.error)
+  const werResults = successResults.map((r) => computeWER(r.reference, r.output, r.language))
+  const overallWER = aggregateWER(werResults)
+
+  // WER by language
+  const werByLanguage: Record<string, ReturnType<typeof aggregateWER>> = {}
+  const languages = [...new Set(entries.map((e) => e.language))]
+  for (const lang of languages) {
+    const langResults = successResults
+      .filter((r) => r.language === lang)
+      .map((r) => computeWER(r.reference, r.output, r.language))
+    werByLanguage[lang] = aggregateWER(langResults)
+  }
+
+  const latencies = successResults.map((r) => r.latencyMs)
+
+  return {
+    engineId: engine.id,
+    engineLabel: engine.label,
+    totalFiles: entries.length,
+    errors: results.filter((r) => r.error).length,
+    latency: computeStats(latencies),
+    wer: overallWER,
+    werByLanguage,
+    peakRssMB: peakRss,
+    results
+  }
+}
+
+/** Run the full STT benchmark suite */
+export async function runSTTBenchmark(
+  engines: STTBenchmarkEngine[]
+): Promise<STTBenchmarkResult> {
+  const entries = loadManifest(MANIFEST_PATH)
+  console.log(`[stt-runner] Loaded ${entries.length} test entries from manifest`)
+
+  const summaries: STTEngineSummary[] = []
+
+  for (const engine of engines) {
+    try {
+      const summary = await runSTTEngine(engine, entries, TESTSET_DIR)
+      summaries.push(summary)
+    } catch (err) {
+      console.error(`[stt-runner] Fatal error with ${engine.label}:`, err)
+    } finally {
+      try {
+        await engine.dispose()
+      } catch (err) {
+        console.error(`[stt-runner] Dispose error for ${engine.label}:`, err)
+      }
+      tryGC()
+    }
+  }
+
+  return {
+    timestamp: new Date().toISOString(),
+    summaries
+  }
+}

--- a/benchmark/src/stt-types.ts
+++ b/benchmark/src/stt-types.ts
@@ -1,0 +1,72 @@
+/** A single test entry from the STT manifest JSONL */
+export interface STTTestEntry {
+  id: string
+  audio_path: string
+  reference_text: string
+  language: 'ja' | 'en'
+  domain: 'casual' | 'business' | 'technical'
+}
+
+/** STT benchmark engine interface — Electron-independent */
+export interface STTBenchmarkEngine {
+  readonly id: string
+  readonly label: string
+
+  /** Initialize model/connection. Must be idempotent. */
+  initialize(): Promise<void>
+
+  /** Transcribe a WAV file and return the recognized text. */
+  transcribe(audioPath: string, language?: string): Promise<string>
+
+  /** Release resources. Safe to call even if not initialized. */
+  dispose(): Promise<void>
+}
+
+/** Result of transcribing a single audio file */
+export interface STTSentenceResult {
+  id: string
+  audioPath: string
+  reference: string
+  output: string
+  language: string
+  domain: string
+  latencyMs: number
+  error?: string
+}
+
+/** WER breakdown */
+export interface WERResult {
+  wer: number
+  substitutions: number
+  insertions: number
+  deletions: number
+  referenceLength: number
+}
+
+/** Latency statistics */
+export interface STTLatencyStats {
+  avg: number
+  median: number
+  p95: number
+  min: number
+  max: number
+}
+
+/** Summary for one STT engine run */
+export interface STTEngineSummary {
+  engineId: string
+  engineLabel: string
+  totalFiles: number
+  errors: number
+  latency: STTLatencyStats
+  wer: WERResult
+  werByLanguage: Record<string, WERResult>
+  peakRssMB: number
+  results: STTSentenceResult[]
+}
+
+/** Full STT benchmark result */
+export interface STTBenchmarkResult {
+  timestamp: string
+  summaries: STTEngineSummary[]
+}

--- a/benchmark/src/wer.ts
+++ b/benchmark/src/wer.ts
@@ -1,0 +1,144 @@
+import type { WERResult } from './stt-types.js'
+
+/**
+ * Compute Word Error Rate using Levenshtein distance.
+ * For Japanese: character-level (split by char).
+ * For English: word-level (split by whitespace).
+ */
+export function computeWER(reference: string, hypothesis: string, language: string): WERResult {
+  const refTokens = tokenize(reference, language)
+  const hypTokens = tokenize(hypothesis, language)
+
+  if (refTokens.length === 0) {
+    return {
+      wer: hypTokens.length > 0 ? 1 : 0,
+      substitutions: 0,
+      insertions: hypTokens.length,
+      deletions: 0,
+      referenceLength: 0
+    }
+  }
+
+  const { substitutions, insertions, deletions } = editDistance(refTokens, hypTokens)
+  const wer = (substitutions + insertions + deletions) / refTokens.length
+
+  return { wer, substitutions, insertions, deletions, referenceLength: refTokens.length }
+}
+
+/**
+ * Aggregate WER from multiple results.
+ * Micro-average: sum of all errors / sum of all reference lengths.
+ */
+export function aggregateWER(results: WERResult[]): WERResult {
+  if (results.length === 0) {
+    return { wer: 0, substitutions: 0, insertions: 0, deletions: 0, referenceLength: 0 }
+  }
+
+  let totalSub = 0
+  let totalIns = 0
+  let totalDel = 0
+  let totalRef = 0
+
+  for (const r of results) {
+    totalSub += r.substitutions
+    totalIns += r.insertions
+    totalDel += r.deletions
+    totalRef += r.referenceLength
+  }
+
+  return {
+    wer: totalRef > 0 ? (totalSub + totalIns + totalDel) / totalRef : 0,
+    substitutions: totalSub,
+    insertions: totalIns,
+    deletions: totalDel,
+    referenceLength: totalRef
+  }
+}
+
+/** Tokenize text based on language */
+function tokenize(text: string, language: string): string[] {
+  const normalized = text.trim().toLowerCase()
+  if (!normalized) return []
+
+  if (language === 'ja') {
+    // Character-level for Japanese (remove spaces and punctuation)
+    return [...normalized.replace(/[\s\u3000。、！？「」（）・…]/g, '')]
+  }
+
+  // Word-level for English and other languages
+  return normalized
+    .replace(/[.,!?;:'"()\-]/g, ' ')
+    .split(/\s+/)
+    .filter((w) => w.length > 0)
+}
+
+/** Compute edit distance and return S/I/D counts */
+function editDistance(ref: string[], hyp: string[]): {
+  substitutions: number
+  insertions: number
+  deletions: number
+} {
+  const n = ref.length
+  const m = hyp.length
+
+  // dp[i][j] = { cost, sub, ins, del }
+  const dp: Array<Array<{ cost: number; sub: number; ins: number; del: number }>> = []
+
+  for (let i = 0; i <= n; i++) {
+    dp[i] = []
+    for (let j = 0; j <= m; j++) {
+      dp[i]![j] = { cost: 0, sub: 0, ins: 0, del: 0 }
+    }
+  }
+
+  // Base cases
+  for (let i = 1; i <= n; i++) {
+    dp[i]![0] = { cost: i, sub: 0, ins: 0, del: i }
+  }
+  for (let j = 1; j <= m; j++) {
+    dp[0]![j] = { cost: j, sub: 0, ins: j, del: 0 }
+  }
+
+  // Fill DP table
+  for (let i = 1; i <= n; i++) {
+    for (let j = 1; j <= m; j++) {
+      const subCost = ref[i - 1] === hyp[j - 1] ? 0 : 1
+      const sub = dp[i - 1]![j - 1]!.cost + subCost
+      const del = dp[i - 1]![j]!.cost + 1
+      const ins = dp[i]![j - 1]!.cost + 1
+
+      if (sub <= del && sub <= ins) {
+        const prev = dp[i - 1]![j - 1]!
+        dp[i]![j] = {
+          cost: sub,
+          sub: prev.sub + subCost,
+          ins: prev.ins,
+          del: prev.del
+        }
+      } else if (del <= ins) {
+        const prev = dp[i - 1]![j]!
+        dp[i]![j] = {
+          cost: del,
+          sub: prev.sub,
+          ins: prev.ins,
+          del: prev.del + 1
+        }
+      } else {
+        const prev = dp[i]![j - 1]!
+        dp[i]![j] = {
+          cost: ins,
+          sub: prev.sub,
+          ins: prev.ins + 1,
+          del: prev.del
+        }
+      }
+    }
+  }
+
+  const result = dp[n]![m]!
+  return {
+    substitutions: result.sub,
+    insertions: result.ins,
+    deletions: result.del
+  }
+}


### PR DESCRIPTION
## Summary
- Add STT benchmark infrastructure with 7 engine adapters (whisper-local, mlx-whisper, lightning-whisper, moonshine, sensevoice, qwen-asr, sherpa-onnx)
- Implement WER (Word Error Rate) metric with language-aware tokenization (character-level for JA, word-level for EN)
- Add test audio generation script using macOS `say` command (20 JA + 20 EN sentences across casual/business/technical domains)
- STT runner with warmup, per-file latency measurement, and peak memory tracking
- STT report with summary table, language/domain breakdowns, and Go/No-Go recommendation
- CLI integration via `--stt` flag and per-engine npm scripts

## Test plan
- [ ] Run `npm run generate:stt-testset` to generate test audio files
- [ ] Run `npm run bench:stt:moonshine` to verify end-to-end flow with a single engine
- [ ] Run `npm run bench:stt` to benchmark all available engines
- [ ] Verify WER calculation produces expected values for exact matches (0%) and known edits
- [ ] Check generated markdown report includes all sections (summary, language breakdown, Go/No-Go)

🤖 Generated with [Claude Code](https://claude.com/claude-code)