### PR TITLE
Add STT benchmark suite with WER/CER metrics

### DIFF
--- a/benchmark/package.json
+++ b/benchmark/package.json
@@ -20,7 +20,17 @@
     "bench:gemma2jpn": "tsx --expose-gc run.ts --engines gemma2-jpn",
     "bench:api": "tsx --expose-gc run.ts --engines google,deepl,microsoft,gemini",
     "bench:local": "tsx --expose-gc run.ts --engines opus-mt,ct2-opus-mt,ct2-madlad400,translate-gemma,hunyuan-mt,hunyuan-mt-15,alma-ja,gemma2-jpn",
-    "bench:all": "tsx --expose-gc run.ts --engines google,deepl,microsoft,gemini,opus-mt,ct2-opus-mt,ct2-madlad400,translate-gemma,hunyuan-mt,hunyuan-mt-15,alma-ja,gemma2-jpn"
+    "bench:all": "tsx --expose-gc run.ts --engines google,deepl,microsoft,gemini,opus-mt,ct2-opus-mt,ct2-madlad400,translate-gemma,hunyuan-mt,hunyuan-mt-15,alma-ja,gemma2-jpn",
+    "stt": "tsx --expose-gc run.ts --stt",
+    "stt:whisper": "tsx --expose-gc run.ts --stt --engines whisper-local",
+    "stt:mlx": "tsx --expose-gc run.ts --stt --engines mlx-whisper",
+    "stt:lightning": "tsx --expose-gc run.ts --stt --engines lightning-whisper",
+    "stt:moonshine": "tsx --expose-gc run.ts --stt --engines moonshine",
+    "stt:sensevoice": "tsx --expose-gc run.ts --stt --engines sensevoice",
+    "stt:qwen": "tsx --expose-gc run.ts --stt --engines qwen-asr",
+    "stt:sherpa": "tsx --expose-gc run.ts --stt --engines sherpa-onnx",
+    "stt:all": "tsx --expose-gc run.ts --stt --engines whisper-local,mlx-whisper,lightning-whisper,moonshine,sensevoice,qwen-asr,sherpa-onnx",
+    "stt:generate-testset": "bash scripts/generate-stt-testset.sh"
   },
   "dependencies": {
     "@huggingface/transformers": "^3.8.0",

--- a/benchmark/resources/moonshine-bridge.py
+++ b/benchmark/resources/moonshine-bridge.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+"""
+Python subprocess bridge for Moonshine STT (Useful Sensors).
+Communicates with the benchmark runner via JSON-over-stdio.
+
+Protocol:
+  Input (one per line):
+    {"action": "init", "model": "moonshine/base"}
+    {"action": "transcribe", "audio_path": "/tmp/audio.wav", "sample_rate": 16000}
+    {"action": "dispose"}
+  Output (one per line):
+    {"ready": true, "model": "..."}
+    {"text": "...", "language": "en"}
+    {"error": "..."}
+"""
+import sys
+import json
+
+model_instance = None
+
+_current_req_id = None
+
+
+def output(data):
+    if _current_req_id is not None:
+        data["_reqId"] = _current_req_id
+    print(json.dumps(data, ensure_ascii=False), flush=True)
+
+
+def init_model(model_name="moonshine/base"):
+    global model_instance
+    try:
+        from moonshine import transcribe as moonshine_transcribe
+
+        # Store the transcribe function — moonshine loads model on first call
+        model_instance = {"model": model_name, "transcribe": moonshine_transcribe}
+
+        output({"ready": True, "model": model_name})
+    except ImportError:
+        output({"error": "moonshine not installed. Run: pip install useful-moonshine"})
+    except Exception as e:
+        output({"error": f"Failed to initialize Moonshine: {e}"})
+
+
+def transcribe(audio_path, sample_rate=16000):
+    global model_instance
+    if model_instance is None:
+        output({"error": "Model not initialized"})
+        return
+
+    try:
+        fn = model_instance["transcribe"]
+        model = model_instance["model"]
+
+        result = fn(audio_path, model=model)
+
+        # moonshine.transcribe returns a list of strings
+        text = result[0] if isinstance(result, list) and len(result) > 0 else str(result)
+
+        output({"text": text.strip(), "language": "en"})
+    except Exception as e:
+        output({"error": f"Transcription failed: {e}"})
+
+
+def main():
+    global _current_req_id
+    for line in sys.stdin:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            msg = json.loads(line)
+            _current_req_id = msg.get("_reqId")
+            action = msg.get("action")
+
+            if action == "init":
+                init_model(msg.get("model", "moonshine/base"))
+            elif action == "transcribe":
+                transcribe(msg["audio_path"], msg.get("sample_rate", 16000))
+            elif action == "dispose":
+                output({"disposed": True})
+                sys.exit(0)
+            else:
+                output({"error": f"Unknown action: {action}"})
+        except json.JSONDecodeError:
+            _current_req_id = None
+            output({"error": "Invalid JSON"})
+        except Exception as e:
+            output({"error": str(e)})
+        finally:
+            _current_req_id = None
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmark/resources/qwen-asr-bridge.py
+++ b/benchmark/resources/qwen-asr-bridge.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+"""
+Python subprocess bridge for Qwen2-Audio ASR.
+Communicates with the benchmark runner via JSON-over-stdio.
+
+Protocol:
+  Input (one per line):
+    {"action": "init", "model": "Qwen/Qwen2-Audio-7B-Instruct"}
+    {"action": "transcribe", "audio_path": "/tmp/audio.wav", "sample_rate": 16000}
+    {"action": "dispose"}
+  Output (one per line):
+    {"ready": true, "model": "..."}
+    {"text": "...", "language": "ja"}
+    {"error": "..."}
+"""
+import sys
+import json
+
+processor = None
+model = None
+model_name_global = None
+
+_current_req_id = None
+
+
+def output(data):
+    if _current_req_id is not None:
+        data["_reqId"] = _current_req_id
+    print(json.dumps(data, ensure_ascii=False), flush=True)
+
+
+def init_model(model_name="Qwen/Qwen2-Audio-7B-Instruct"):
+    global processor, model, model_name_global
+    try:
+        import torch
+        from transformers import Qwen2AudioForConditionalGeneration, AutoProcessor
+
+        output({"status": "Loading Qwen2-Audio model..."})
+
+        # Determine device
+        device = "cpu"
+        dtype = torch.float32
+        if torch.backends.mps.is_available():
+            device = "mps"
+            dtype = torch.float16
+        elif torch.cuda.is_available():
+            device = "cuda"
+            dtype = torch.float16
+
+        processor = AutoProcessor.from_pretrained(model_name)
+        model = Qwen2AudioForConditionalGeneration.from_pretrained(
+            model_name, torch_dtype=dtype, device_map=device
+        )
+        model_name_global = model_name
+
+        output({"ready": True, "model": model_name, "device": device})
+    except ImportError:
+        output({"error": "transformers not installed. Run: pip install transformers torch"})
+    except Exception as e:
+        output({"error": f"Failed to initialize Qwen2-Audio: {e}"})
+
+
+def transcribe(audio_path, sample_rate=16000):
+    global processor, model
+    if model is None or processor is None:
+        output({"error": "Model not initialized"})
+        return
+
+    try:
+        import librosa
+        import torch
+
+        # Load audio
+        audio, sr = librosa.load(audio_path, sr=sample_rate, mono=True)
+
+        # Build conversation-style input for Qwen2-Audio
+        conversation = [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "audio", "audio_url": audio_path},
+                    {"type": "text", "text": "Transcribe this audio."},
+                ],
+            }
+        ]
+
+        text_input = processor.apply_chat_template(
+            conversation, add_generation_prompt=True, tokenize=False
+        )
+        inputs = processor(
+            text=text_input, audios=[audio], sampling_rate=sr, return_tensors="pt"
+        )
+        inputs = inputs.to(model.device)
+
+        with torch.no_grad():
+            generated_ids = model.generate(**inputs, max_new_tokens=256)
+
+        # Decode only the generated part
+        input_len = inputs.input_ids.shape[1]
+        generated_ids = generated_ids[:, input_len:]
+        text = processor.batch_decode(generated_ids, skip_special_tokens=True)[0]
+
+        output({"text": text.strip(), "language": "en"})
+    except ImportError as e:
+        output({"error": f"Missing dependency: {e}. Run: pip install librosa"})
+    except Exception as e:
+        output({"error": f"Transcription failed: {e}"})
+
+
+def main():
+    global _current_req_id
+    for line in sys.stdin:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            msg = json.loads(line)
+            _current_req_id = msg.get("_reqId")
+            action = msg.get("action")
+
+            if action == "init":
+                init_model(msg.get("model", "Qwen/Qwen2-Audio-7B-Instruct"))
+            elif action == "transcribe":
+                transcribe(msg["audio_path"], msg.get("sample_rate", 16000))
+            elif action == "dispose":
+                output({"disposed": True})
+                sys.exit(0)
+            else:
+                output({"error": f"Unknown action: {action}"})
+        except json.JSONDecodeError:
+            _current_req_id = None
+            output({"error": "Invalid JSON"})
+        except Exception as e:
+            output({"error": str(e)})
+        finally:
+            _current_req_id = None
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmark/resources/sherpa-onnx-bridge.py
+++ b/benchmark/resources/sherpa-onnx-bridge.py
@@ -1,0 +1,157 @@
+#!/usr/bin/env python3
+"""
+Python subprocess bridge for Sherpa-ONNX STT.
+Communicates with the benchmark runner via JSON-over-stdio.
+
+Protocol:
+  Input (one per line):
+    {"action": "init", "model": "sherpa-onnx-whisper-medium"}
+    {"action": "transcribe", "audio_path": "/tmp/audio.wav", "sample_rate": 16000}
+    {"action": "dispose"}
+  Output (one per line):
+    {"ready": true, "model": "..."}
+    {"text": "...", "language": "en"}
+    {"error": "..."}
+"""
+import sys
+import json
+import os
+
+recognizer = None
+
+_current_req_id = None
+
+
+def output(data):
+    if _current_req_id is not None:
+        data["_reqId"] = _current_req_id
+    print(json.dumps(data, ensure_ascii=False), flush=True)
+
+
+def init_model(model_name="sherpa-onnx-whisper-medium"):
+    global recognizer
+    try:
+        import sherpa_onnx
+
+        output({"status": f"Loading Sherpa-ONNX model: {model_name}..."})
+
+        # Sherpa-ONNX expects model files in a directory
+        # Try common model path patterns
+        model_dir = os.path.join(os.path.dirname(__file__), "..", "models", model_name)
+        if not os.path.isdir(model_dir):
+            # Fall back to home directory cache
+            model_dir = os.path.join(
+                os.path.expanduser("~"), ".cache", "sherpa-onnx", model_name
+            )
+
+        if not os.path.isdir(model_dir):
+            output(
+                {
+                    "error": f"Model directory not found: {model_dir}. "
+                    f"Download from https://github.com/k2-fsa/sherpa-onnx/releases"
+                }
+            )
+            return
+
+        # Detect model type and create recognizer
+        encoder = os.path.join(model_dir, f"{model_name}-encoder.onnx")
+        decoder = os.path.join(model_dir, f"{model_name}-decoder.onnx")
+
+        if os.path.exists(encoder) and os.path.exists(decoder):
+            # Whisper-style model
+            recognizer = sherpa_onnx.OfflineRecognizer.from_whisper(
+                encoder=encoder,
+                decoder=decoder,
+                num_threads=4,
+            )
+        else:
+            # Try int8 variants
+            encoder = os.path.join(model_dir, f"{model_name}-encoder.int8.onnx")
+            decoder = os.path.join(model_dir, f"{model_name}-decoder.int8.onnx")
+            if os.path.exists(encoder) and os.path.exists(decoder):
+                recognizer = sherpa_onnx.OfflineRecognizer.from_whisper(
+                    encoder=encoder,
+                    decoder=decoder,
+                    num_threads=4,
+                )
+            else:
+                output(
+                    {
+                        "error": f"Could not find encoder/decoder files in {model_dir}"
+                    }
+                )
+                return
+
+        output({"ready": True, "model": model_name})
+    except ImportError:
+        output({"error": "sherpa-onnx not installed. Run: pip install sherpa-onnx"})
+    except Exception as e:
+        output({"error": f"Failed to initialize Sherpa-ONNX: {e}"})
+
+
+def transcribe(audio_path, sample_rate=16000):
+    global recognizer
+    if recognizer is None:
+        output({"error": "Model not initialized"})
+        return
+
+    try:
+        import wave
+        import numpy as np
+
+        # Read WAV file
+        with wave.open(audio_path, "rb") as wf:
+            assert wf.getnchannels() == 1, "Expected mono audio"
+            assert wf.getsampwidth() == 2, "Expected 16-bit audio"
+            sr = wf.getframerate()
+            frames = wf.readframes(wf.getnframes())
+
+        samples = np.frombuffer(frames, dtype=np.int16).astype(np.float32) / 32768.0
+
+        # Resample if needed
+        if sr != sample_rate:
+            import librosa
+            samples = librosa.resample(samples, orig_sr=sr, target_sr=sample_rate)
+
+        stream = recognizer.create_stream()
+        stream.accept_waveform(sample_rate, samples)
+        recognizer.decode_stream(stream)
+
+        text = stream.result.text
+
+        output({"text": text.strip(), "language": "en"})
+    except Exception as e:
+        output({"error": f"Transcription failed: {e}"})
+
+
+def main():
+    global _current_req_id
+    for line in sys.stdin:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            msg = json.loads(line)
+            _current_req_id = msg.get("_reqId")
+            action = msg.get("action")
+
+            if action == "init":
+                init_model(msg.get("model", "sherpa-onnx-whisper-medium"))
+            elif action == "transcribe":
+                transcribe(msg["audio_path"], msg.get("sample_rate", 16000))
+            elif action == "dispose":
+                output({"disposed": True})
+                sys.exit(0)
+            else:
+                output({"error": f"Unknown action: {action}"})
+        except json.JSONDecodeError:
+            _current_req_id = None
+            output({"error": "Invalid JSON"})
+        except Exception as e:
+            output({"error": str(e)})
+        finally:
+            _current_req_id = None
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmark/run.ts
+++ b/benchmark/run.ts
@@ -1,6 +1,11 @@
 import type { BenchmarkEngine, Direction } from './src/types.js'
+import type { STTBenchmarkEngine, STTLanguage } from './src/stt-types.js'
 import { runBenchmark } from './src/runner.js'
 import { writeReports } from './src/report.js'
+import { runSTTBenchmark } from './src/stt-runner.js'
+import { writeSTTReports } from './src/stt-report.js'
+
+// ── Translation engines ──
 
 const AVAILABLE_ENGINES = [
   'google',
@@ -23,45 +28,99 @@ const AVAILABLE_ENGINES = [
 ] as const
 type EngineId = (typeof AVAILABLE_ENGINES)[number]
 
-function parseArgs(): { engines: EngineId[]; directions: Direction[] } {
+// ── STT engines ──
+
+const AVAILABLE_STT_ENGINES = [
+  'whisper-local',
+  'mlx-whisper',
+  'lightning-whisper',
+  'moonshine',
+  'sensevoice',
+  'qwen-asr',
+  'sherpa-onnx'
+] as const
+type STTEngineId = (typeof AVAILABLE_STT_ENGINES)[number]
+
+// ── Arg parsing ──
+
+interface ParsedArgs {
+  mode: 'translate' | 'stt'
+  engines: EngineId[]
+  sttEngines: STTEngineId[]
+  directions: Direction[]
+  sttLanguages: (STTLanguage | 'all')[]
+}
+
+function parseArgs(): ParsedArgs {
   const args = process.argv.slice(2)
+  let mode: 'translate' | 'stt' = 'translate'
   let engines: EngineId[] = []
+  let sttEngines: STTEngineId[] = []
   let directions: Direction[] = ['ja-en', 'en-ja']
+  let sttLanguages: (STTLanguage | 'all')[] = ['ja', 'en', 'all']
 
   for (let i = 0; i < args.length; i++) {
     const arg = args[i]
-    if (arg === '--engines' && args[i + 1]) {
-      engines = args[i + 1]!.split(',').map((e) => {
-        const trimmed = e.trim() as EngineId
-        if (!AVAILABLE_ENGINES.includes(trimmed)) {
-          console.error(`Unknown engine: ${trimmed}`)
-          console.error(`Available: ${AVAILABLE_ENGINES.join(', ')}`)
-          process.exit(1)
-        }
-        return trimmed
-      })
+    if (arg === '--stt') {
+      mode = 'stt'
+    } else if (arg === '--engines' && args[i + 1]) {
+      if (mode === 'stt') {
+        sttEngines = args[i + 1]!.split(',').map((e) => {
+          const trimmed = e.trim() as STTEngineId
+          if (!AVAILABLE_STT_ENGINES.includes(trimmed)) {
+            console.error(`Unknown STT engine: ${trimmed}`)
+            console.error(`Available: ${AVAILABLE_STT_ENGINES.join(', ')}`)
+            process.exit(1)
+          }
+          return trimmed
+        })
+      } else {
+        engines = args[i + 1]!.split(',').map((e) => {
+          const trimmed = e.trim() as EngineId
+          if (!AVAILABLE_ENGINES.includes(trimmed)) {
+            console.error(`Unknown engine: ${trimmed}`)
+            console.error(`Available: ${AVAILABLE_ENGINES.join(', ')}`)
+            process.exit(1)
+          }
+          return trimmed
+        })
+      }
       i++
     } else if (arg === '--direction' && args[i + 1]) {
       directions = [args[i + 1]! as Direction]
       i++
+    } else if (arg === '--language' && args[i + 1]) {
+      sttLanguages = [args[i + 1]! as STTLanguage | 'all']
+      i++
     } else if (arg === '--help' || arg === '-h') {
       console.log('Usage: npx tsx --expose-gc run.ts [options]')
       console.log('')
-      console.log('Options:')
+      console.log('Translation benchmark (default):')
       console.log(`  --engines <list>     Comma-separated engines (${AVAILABLE_ENGINES.join(', ')})`)
       console.log('  --direction <dir>    ja-en or en-ja (default: both)')
+      console.log('')
+      console.log('STT benchmark:')
+      console.log('  --stt                Run STT benchmark instead of translation')
+      console.log(`  --engines <list>     Comma-separated STT engines (${AVAILABLE_STT_ENGINES.join(', ')})`)
+      console.log('  --language <lang>    ja, en, or all (default: all three)')
+      console.log('')
       console.log('  --help               Show this help')
       process.exit(0)
     }
   }
 
-  if (engines.length === 0) {
-    // Default: only the original engines (API keys / models may not be available for all)
+  // Defaults
+  if (mode === 'translate' && engines.length === 0) {
     engines = ['google', 'opus-mt', 'translate-gemma', 'translate-gemma-cpu']
   }
+  if (mode === 'stt' && sttEngines.length === 0) {
+    sttEngines = ['whisper-local', 'mlx-whisper']
+  }
 
-  return { engines, directions }
+  return { mode, engines, sttEngines, directions, sttLanguages }
 }
+
+// ── Engine factories ──
 
 async function createEngine(id: EngineId): Promise<BenchmarkEngine> {
   switch (id) {
@@ -136,9 +195,45 @@ async function createEngine(id: EngineId): Promise<BenchmarkEngine> {
   }
 }
 
-async function main(): Promise<void> {
-  const { engines: engineIds, directions } = parseArgs()
+async function createSTTEngine(id: STTEngineId): Promise<STTBenchmarkEngine> {
+  switch (id) {
+    case 'whisper-local': {
+      const { WhisperLocalBench } = await import('./src/stt-engines/whisper-local.js')
+      return new WhisperLocalBench()
+    }
+    case 'mlx-whisper': {
+      const { MLXWhisperBench } = await import('./src/stt-engines/mlx-whisper.js')
+      return new MLXWhisperBench()
+    }
+    case 'lightning-whisper': {
+      const { LightningWhisperBench } = await import('./src/stt-engines/lightning-whisper.js')
+      return new LightningWhisperBench()
+    }
+    case 'moonshine': {
+      const { MoonshineBench } = await import('./src/stt-engines/moonshine.js')
+      return new MoonshineBench()
+    }
+    case 'sensevoice': {
+      const { SenseVoiceBench } = await import('./src/stt-engines/sensevoice.js')
+      return new SenseVoiceBench()
+    }
+    case 'qwen-asr': {
+      const { QwenASRBench } = await import('./src/stt-engines/qwen-asr.js')
+      return new QwenASRBench()
+    }
+    case 'sherpa-onnx': {
+      const { SherpaOnnxBench } = await import('./src/stt-engines/sherpa-onnx.js')
+      return new SherpaOnnxBench()
+    }
+  }
+}
 
+// ── Main ──
+
+async function runTranslationMode(
+  engineIds: EngineId[],
+  directions: Direction[]
+): Promise<void> {
   console.log('=== Translation Quality Benchmark ===')
   console.log(`Engines: ${engineIds.join(', ')}`)
   console.log(`Directions: ${directions.join(', ')}`)
@@ -160,8 +255,45 @@ async function main(): Promise<void> {
 
   const result = await runBenchmark(engines, directions)
   const outputDir = writeReports(result)
-
   console.log(`\nDone. Results written to ${outputDir}`)
+}
+
+async function runSTTMode(
+  engineIds: STTEngineId[],
+  languages: (STTLanguage | 'all')[]
+): Promise<void> {
+  console.log('=== STT Benchmark ===')
+  console.log(`Engines: ${engineIds.join(', ')}`)
+  console.log(`Languages: ${languages.join(', ')}`)
+  console.log('')
+
+  const engines: STTBenchmarkEngine[] = []
+  for (const id of engineIds) {
+    try {
+      engines.push(await createSTTEngine(id))
+    } catch (err) {
+      console.error(`[main] Failed to create STT engine '${id}':`, err)
+    }
+  }
+
+  if (engines.length === 0) {
+    console.error('No STT engines available. Exiting.')
+    process.exit(1)
+  }
+
+  const result = await runSTTBenchmark(engines, languages)
+  const outputDir = writeSTTReports(result)
+  console.log(`\nDone. Results written to ${outputDir}`)
+}
+
+async function main(): Promise<void> {
+  const parsed = parseArgs()
+
+  if (parsed.mode === 'stt') {
+    await runSTTMode(parsed.sttEngines, parsed.sttLanguages)
+  } else {
+    await runTranslationMode(parsed.engines, parsed.directions)
+  }
 }
 
 main().catch((err) => {

--- a/benchmark/scripts/generate-stt-testset.sh
+++ b/benchmark/scripts/generate-stt-testset.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+# Generate STT benchmark test audio files using macOS `say` command.
+# Creates 40 WAV files (20 JA, 20 EN) at 16kHz mono with a JSONL manifest.
+#
+# Usage: bash benchmark/scripts/generate-stt-testset.sh
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+BENCHMARK_DIR="$(dirname "$SCRIPT_DIR")"
+OUTPUT_DIR="${BENCHMARK_DIR}/testset/stt-audio"
+MANIFEST="${BENCHMARK_DIR}/testset/stt-manifest.jsonl"
+
+mkdir -p "$OUTPUT_DIR"
+: > "$MANIFEST"
+
+# macOS Japanese voice (Kyoko is pre-installed)
+JA_VOICE="Kyoko"
+# macOS English voice
+EN_VOICE="Samantha"
+
+# Check that `say` command is available (macOS only)
+if ! command -v say &> /dev/null; then
+  echo "ERROR: 'say' command not found. This script requires macOS."
+  exit 1
+fi
+
+# Check that sox is available for WAV conversion
+if ! command -v sox &> /dev/null; then
+  echo "ERROR: 'sox' not found. Install with: brew install sox"
+  exit 1
+fi
+
+# Helper: generate a single WAV file at 16kHz mono
+# Args: $1=id $2=text $3=language $4=domain $5=voice
+generate_audio() {
+  local id="$1"
+  local text="$2"
+  local lang="$3"
+  local domain="$4"
+  local voice="$5"
+
+  local aiff_path="${OUTPUT_DIR}/${id}.aiff"
+  local wav_path="${OUTPUT_DIR}/${id}.wav"
+
+  # Generate AIFF with macOS say
+  say -v "$voice" -o "$aiff_path" "$text"
+
+  # Convert to 16kHz mono WAV
+  sox "$aiff_path" -r 16000 -c 1 -b 16 "$wav_path"
+  rm -f "$aiff_path"
+
+  # Append to manifest
+  printf '{"id":"%s","audio_path":"stt-audio/%s.wav","reference_text":"%s","language":"%s","domain":"%s"}\n' \
+    "$id" "$id" "$(echo "$text" | sed 's/"/\\"/g')" "$lang" "$domain" >> "$MANIFEST"
+
+  echo "  Generated: ${id}.wav"
+}
+
+echo "=== Generating Japanese test audio (20 files) ==="
+
+# Japanese - casual (6)
+generate_audio "ja-casual-01" "おはようございます" "ja" "casual" "$JA_VOICE"
+generate_audio "ja-casual-02" "今日はいい天気ですね" "ja" "casual" "$JA_VOICE"
+generate_audio "ja-casual-03" "ありがとうございます" "ja" "casual" "$JA_VOICE"
+generate_audio "ja-casual-04" "昨日の映画はとても面白かったです" "ja" "casual" "$JA_VOICE"
+generate_audio "ja-casual-05" "週末に友達と買い物に行きました" "ja" "casual" "$JA_VOICE"
+generate_audio "ja-casual-06" "最近ジムに通い始めました" "ja" "casual" "$JA_VOICE"
+
+# Japanese - business (7)
+generate_audio "ja-business-01" "本日はお忙しいところありがとうございます" "ja" "business" "$JA_VOICE"
+generate_audio "ja-business-02" "来週の会議の件でご連絡いたしました" "ja" "business" "$JA_VOICE"
+generate_audio "ja-business-03" "プロジェクトの進捗について報告いたします" "ja" "business" "$JA_VOICE"
+generate_audio "ja-business-04" "ご検討のほどよろしくお願いいたします" "ja" "business" "$JA_VOICE"
+generate_audio "ja-business-05" "第三四半期の売上は前年比で二十パーセント増加しました" "ja" "business" "$JA_VOICE"
+generate_audio "ja-business-06" "新しいマーケティング戦略を提案させていただきます" "ja" "business" "$JA_VOICE"
+generate_audio "ja-business-07" "契約書の内容を確認させていただけますでしょうか" "ja" "business" "$JA_VOICE"
+
+# Japanese - technical (7)
+generate_audio "ja-technical-01" "このアプリケーションはリアルタイム音声認識を使用しています" "ja" "technical" "$JA_VOICE"
+generate_audio "ja-technical-02" "ニューラルネットワークの学習率を調整する必要があります" "ja" "technical" "$JA_VOICE"
+generate_audio "ja-technical-03" "データベースのインデックスを再構築してください" "ja" "technical" "$JA_VOICE"
+generate_audio "ja-technical-04" "メモリリークの原因を調査しています" "ja" "technical" "$JA_VOICE"
+generate_audio "ja-technical-05" "このライブラリはマルチスレッド処理に対応しています" "ja" "technical" "$JA_VOICE"
+generate_audio "ja-technical-06" "音声データは十六キロヘルツのサンプリングレートで録音されます" "ja" "technical" "$JA_VOICE"
+generate_audio "ja-technical-07" "トランスフォーマーモデルの推論速度を最適化しました" "ja" "technical" "$JA_VOICE"
+
+echo ""
+echo "=== Generating English test audio (20 files) ==="
+
+# English - casual (6)
+generate_audio "en-casual-01" "Good morning, how are you?" "en" "casual" "$EN_VOICE"
+generate_audio "en-casual-02" "The weather is really nice today" "en" "casual" "$EN_VOICE"
+generate_audio "en-casual-03" "Thank you so much for your help" "en" "casual" "$EN_VOICE"
+generate_audio "en-casual-04" "I watched a great movie last night" "en" "casual" "$EN_VOICE"
+generate_audio "en-casual-05" "Let's grab some coffee this weekend" "en" "casual" "$EN_VOICE"
+generate_audio "en-casual-06" "I just started learning Japanese" "en" "casual" "$EN_VOICE"
+
+# English - business (7)
+generate_audio "en-business-01" "Thank you for taking the time to meet with us today" "en" "business" "$EN_VOICE"
+generate_audio "en-business-02" "I would like to discuss the quarterly results" "en" "business" "$EN_VOICE"
+generate_audio "en-business-03" "We need to finalize the project timeline by Friday" "en" "business" "$EN_VOICE"
+generate_audio "en-business-04" "Our revenue increased by twenty percent year over year" "en" "business" "$EN_VOICE"
+generate_audio "en-business-05" "Please review the contract and provide your feedback" "en" "business" "$EN_VOICE"
+generate_audio "en-business-06" "The marketing team has proposed a new campaign strategy" "en" "business" "$EN_VOICE"
+generate_audio "en-business-07" "We should schedule a follow up meeting next week" "en" "business" "$EN_VOICE"
+
+# English - technical (7)
+generate_audio "en-technical-01" "This application uses real-time speech recognition" "en" "technical" "$EN_VOICE"
+generate_audio "en-technical-02" "We need to adjust the learning rate of the neural network" "en" "technical" "$EN_VOICE"
+generate_audio "en-technical-03" "Please rebuild the database indexes for better performance" "en" "technical" "$EN_VOICE"
+generate_audio "en-technical-04" "We are investigating a memory leak in the main process" "en" "technical" "$EN_VOICE"
+generate_audio "en-technical-05" "This library supports multi-threaded processing" "en" "technical" "$EN_VOICE"
+generate_audio "en-technical-06" "Audio data is recorded at a sixteen kilohertz sample rate" "en" "technical" "$EN_VOICE"
+generate_audio "en-technical-07" "We optimized the transformer model inference speed" "en" "technical" "$EN_VOICE"
+
+echo ""
+echo "=== Done ==="
+echo "Generated $(wc -l < "$MANIFEST" | tr -d ' ') audio files"
+echo "Manifest: $MANIFEST"
+echo "Audio dir: $OUTPUT_DIR"

--- a/benchmark/src/bridge-utils.ts
+++ b/benchmark/src/bridge-utils.ts
@@ -1,0 +1,143 @@
+import { spawn, type ChildProcess } from 'child_process'
+import { createInterface } from 'readline'
+
+export interface BridgeMessage {
+  [key: string]: unknown
+}
+
+/**
+ * Manages a Python subprocess bridge for STT engines.
+ * Communicates via JSON-over-stdio (same protocol as the resources/*.py bridges).
+ */
+export class PythonBridge {
+  private process: ChildProcess | null = null
+  private pendingRequests = new Map<
+    string,
+    { resolve: (data: BridgeMessage) => void; reject: (err: Error) => void }
+  >()
+  private requestCounter = 0
+  private scriptPath: string
+  private pythonBin: string
+
+  constructor(scriptPath: string, pythonBin = 'python3') {
+    this.scriptPath = scriptPath
+    this.pythonBin = pythonBin
+  }
+
+  /** Start the Python subprocess */
+  async start(): Promise<void> {
+    if (this.process) return
+
+    this.process = spawn(this.pythonBin, [this.scriptPath], {
+      stdio: ['pipe', 'pipe', 'pipe'],
+      env: { ...process.env, PYTHONUNBUFFERED: '1' }
+    })
+
+    const rl = createInterface({ input: this.process.stdout! })
+
+    rl.on('line', (line) => {
+      try {
+        const data = JSON.parse(line) as BridgeMessage
+        const reqId = data._reqId as string | undefined
+        if (reqId && this.pendingRequests.has(reqId)) {
+          const pending = this.pendingRequests.get(reqId)!
+          this.pendingRequests.delete(reqId)
+          if (data.error) {
+            pending.reject(new Error(String(data.error)))
+          } else {
+            pending.resolve(data)
+          }
+        }
+      } catch {
+        // Ignore non-JSON lines (e.g. status messages from stderr)
+      }
+    })
+
+    // Collect stderr for diagnostics
+    this.process.stderr?.on('data', (chunk: Buffer) => {
+      const msg = chunk.toString().trim()
+      if (msg) {
+        console.error(`[bridge:stderr] ${msg}`)
+      }
+    })
+
+    this.process.on('error', (err) => {
+      console.error(`[bridge] Process error: ${err.message}`)
+      this.rejectAllPending(err)
+    })
+
+    this.process.on('exit', (code) => {
+      if (code !== 0 && code !== null) {
+        console.error(`[bridge] Process exited with code ${code}`)
+      }
+      this.rejectAllPending(new Error(`Bridge process exited with code ${code}`))
+      this.process = null
+    })
+  }
+
+  /** Send a message and wait for a response */
+  async send(message: BridgeMessage, timeoutMs = 120_000): Promise<BridgeMessage> {
+    if (!this.process?.stdin?.writable) {
+      throw new Error('Bridge process not running')
+    }
+
+    const reqId = `req-${++this.requestCounter}`
+    const tagged = { ...message, _reqId: reqId }
+
+    return new Promise<BridgeMessage>((resolve, reject) => {
+      const timer = setTimeout(() => {
+        this.pendingRequests.delete(reqId)
+        reject(new Error(`Bridge request timed out after ${timeoutMs}ms`))
+      }, timeoutMs)
+
+      this.pendingRequests.set(reqId, {
+        resolve: (data) => {
+          clearTimeout(timer)
+          resolve(data)
+        },
+        reject: (err) => {
+          clearTimeout(timer)
+          reject(err)
+        }
+      })
+
+      this.process!.stdin!.write(JSON.stringify(tagged) + '\n')
+    })
+  }
+
+  /** Stop the Python subprocess gracefully */
+  async stop(): Promise<void> {
+    if (!this.process) return
+
+    try {
+      await this.send({ action: 'dispose' }, 5_000).catch(() => {
+        // Ignore dispose errors
+      })
+    } finally {
+      if (this.process && !this.process.killed) {
+        this.process.kill('SIGTERM')
+        // Give it a moment to exit gracefully
+        await new Promise<void>((resolve) => {
+          const timer = setTimeout(() => {
+            if (this.process && !this.process.killed) {
+              this.process.kill('SIGKILL')
+            }
+            resolve()
+          }, 3_000)
+          this.process!.once('exit', () => {
+            clearTimeout(timer)
+            resolve()
+          })
+        })
+      }
+      this.process = null
+    }
+  }
+
+  private rejectAllPending(err: Error): void {
+    for (const [, pending] of this.pendingRequests) {
+      pending.reject(err)
+    }
+    this.pendingRequests.clear()
+  }
+}

--- a/benchmark/src/stt-engines/lightning-whisper.ts
+++ b/benchmark/src/stt-engines/lightning-whisper.ts
@@ -1,0 +1,54 @@
+import { join, dirname } from 'path'
+import { fileURLToPath } from 'url'
+import type { STTBenchmarkEngine } from '../stt-types.js'
+import { PythonBridge } from '../bridge-utils.js'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const BRIDGE_SCRIPT = join(
+  __dirname, '..', '..', '..', 'resources', 'lightning-whisper-bridge.py'
+)
+
+/**
+ * Lightning Whisper MLX STT benchmark engine.
+ * Uses the existing resources/lightning-whisper-bridge.py via PythonBridge.
+ */
+export class LightningWhisperBench implements STTBenchmarkEngine {
+  readonly id = 'lightning-whisper'
+  readonly label = 'Lightning Whisper MLX'
+
+  private bridge: PythonBridge
+  private model: string
+  private batchSize: number
+
+  constructor(options?: { model?: string; batchSize?: number }) {
+    this.model = options?.model ?? 'distil-large-v3'
+    this.batchSize = options?.batchSize ?? 12
+    this.bridge = new PythonBridge(BRIDGE_SCRIPT)
+  }
+
+  async initialize(): Promise<void> {
+    await this.bridge.start()
+    const result = await this.bridge.send(
+      { action: 'init', model: this.model, batch_size: this.batchSize },
+      180_000
+    )
+    console.log(`[lightning-whisper] Initialized: ${JSON.stringify(result)}`)
+  }
+
+  async transcribe(audioPath: string): Promise<{ text: string; language?: string }> {
+    const result = await this.bridge.send({
+      action: 'transcribe',
+      audio_path: audioPath,
+      sample_rate: 16000
+    })
+
+    return {
+      text: String(result.text ?? ''),
+      language: result.language ? String(result.language) : undefined
+    }
+  }
+
+  async dispose(): Promise<void> {
+    await this.bridge.stop()
+  }
+}

--- a/benchmark/src/stt-engines/mlx-whisper.ts
+++ b/benchmark/src/stt-engines/mlx-whisper.ts
@@ -1,0 +1,50 @@
+import { join, dirname } from 'path'
+import { fileURLToPath } from 'url'
+import type { STTBenchmarkEngine } from '../stt-types.js'
+import { PythonBridge } from '../bridge-utils.js'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const BRIDGE_SCRIPT = join(__dirname, '..', '..', '..', 'resources', 'mlx-whisper-bridge.py')
+
+/**
+ * MLX Whisper STT benchmark engine.
+ * Uses the existing resources/mlx-whisper-bridge.py via PythonBridge.
+ */
+export class MLXWhisperBench implements STTBenchmarkEngine {
+  readonly id = 'mlx-whisper'
+  readonly label = 'MLX Whisper (Apple Silicon)'
+
+  private bridge: PythonBridge
+  private model: string
+
+  constructor(options?: { model?: string }) {
+    this.model = options?.model ?? 'mlx-community/whisper-large-v3-turbo'
+    this.bridge = new PythonBridge(BRIDGE_SCRIPT)
+  }
+
+  async initialize(): Promise<void> {
+    await this.bridge.start()
+    const result = await this.bridge.send(
+      { action: 'init', model: this.model },
+      180_000 // Model download may take time
+    )
+    console.log(`[mlx-whisper] Initialized: ${JSON.stringify(result)}`)
+  }
+
+  async transcribe(audioPath: string): Promise<{ text: string; language?: string }> {
+    const result = await this.bridge.send({
+      action: 'transcribe',
+      audio_path: audioPath,
+      sample_rate: 16000
+    })
+
+    return {
+      text: String(result.text ?? ''),
+      language: result.language ? String(result.language) : undefined
+    }
+  }
+
+  async dispose(): Promise<void> {
+    await this.bridge.stop()
+  }
+}

--- a/benchmark/src/stt-engines/moonshine.ts
+++ b/benchmark/src/stt-engines/moonshine.ts
@@ -1,0 +1,51 @@
+import { join, dirname } from 'path'
+import { fileURLToPath } from 'url'
+import type { STTBenchmarkEngine } from '../stt-types.js'
+import { PythonBridge } from '../bridge-utils.js'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const BRIDGE_SCRIPT = join(__dirname, '..', '..', 'resources', 'moonshine-bridge.py')
+
+/**
+ * Moonshine STT benchmark engine (Useful Sensors).
+ * Lightweight on-device speech recognition optimized for edge.
+ * Uses a Python bridge subprocess.
+ */
+export class MoonshineBench implements STTBenchmarkEngine {
+  readonly id = 'moonshine'
+  readonly label = 'Moonshine (Edge)'
+
+  private bridge: PythonBridge
+  private model: string
+
+  constructor(options?: { model?: string }) {
+    this.model = options?.model ?? 'moonshine/base'
+    this.bridge = new PythonBridge(BRIDGE_SCRIPT)
+  }
+
+  async initialize(): Promise<void> {
+    await this.bridge.start()
+    const result = await this.bridge.send(
+      { action: 'init', model: this.model },
+      180_000
+    )
+    console.log(`[moonshine] Initialized: ${JSON.stringify(result)}`)
+  }
+
+  async transcribe(audioPath: string): Promise<{ text: string; language?: string }> {
+    const result = await this.bridge.send({
+      action: 'transcribe',
+      audio_path: audioPath,
+      sample_rate: 16000
+    })
+
+    return {
+      text: String(result.text ?? ''),
+      language: result.language ? String(result.language) : undefined
+    }
+  }
+
+  async dispose(): Promise<void> {
+    await this.bridge.stop()
+  }
+}

--- a/benchmark/src/stt-engines/qwen-asr.ts
+++ b/benchmark/src/stt-engines/qwen-asr.ts
@@ -1,0 +1,49 @@
+import { join, dirname } from 'path'
+import { fileURLToPath } from 'url'
+import type { STTBenchmarkEngine } from '../stt-types.js'
+import { PythonBridge } from '../bridge-utils.js'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const BRIDGE_SCRIPT = join(__dirname, '..', '..', 'resources', 'qwen-asr-bridge.py')
+
+/**
+ * Qwen-ASR STT benchmark engine (Qwen2-Audio / Qwen-Audio-Chat).
+ * Uses a Python bridge subprocess for the FunASR/transformers backend.
+ */
+export class QwenASRBench implements STTBenchmarkEngine {
+  readonly id = 'qwen-asr'
+  readonly label = 'Qwen ASR'
+
+  private bridge: PythonBridge
+  private model: string
+
+  constructor(options?: { model?: string }) {
+    this.model = options?.model ?? 'Qwen/Qwen2-Audio-7B-Instruct'
+    this.bridge = new PythonBridge(BRIDGE_SCRIPT)
+  }
+
+  async initialize(): Promise<void> {
+    await this.bridge.start()
+    const result = await this.bridge.send(
+      { action: 'init', model: this.model },
+      300_000 // Large model, may take time to download
+    )
+    console.log(`[qwen-asr] Initialized: ${JSON.stringify(result)}`)
+  }
+
+  async transcribe(audioPath: string): Promise<{ text: string; language?: string }> {
+    const result = await this.bridge.send(
+      { action: 'transcribe', audio_path: audioPath, sample_rate: 16000 },
+      120_000
+    )
+
+    return {
+      text: String(result.text ?? ''),
+      language: result.language ? String(result.language) : undefined
+    }
+  }
+
+  async dispose(): Promise<void> {
+    await this.bridge.stop()
+  }
+}

--- a/benchmark/src/stt-engines/sensevoice.ts
+++ b/benchmark/src/stt-engines/sensevoice.ts
@@ -1,0 +1,50 @@
+import { join, dirname } from 'path'
+import { fileURLToPath } from 'url'
+import type { STTBenchmarkEngine } from '../stt-types.js'
+import { PythonBridge } from '../bridge-utils.js'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const BRIDGE_SCRIPT = join(__dirname, '..', '..', '..', 'resources', 'sensevoice-bridge.py')
+
+/**
+ * SenseVoice STT benchmark engine (FunASR).
+ * Uses the existing resources/sensevoice-bridge.py via PythonBridge.
+ */
+export class SenseVoiceBench implements STTBenchmarkEngine {
+  readonly id = 'sensevoice'
+  readonly label = 'SenseVoice (FunASR)'
+
+  private bridge: PythonBridge
+  private model: string
+
+  constructor(options?: { model?: string }) {
+    this.model = options?.model ?? 'FunAudioLLM/SenseVoiceSmall'
+    this.bridge = new PythonBridge(BRIDGE_SCRIPT)
+  }
+
+  async initialize(): Promise<void> {
+    await this.bridge.start()
+    const result = await this.bridge.send(
+      { action: 'init', model: this.model },
+      180_000
+    )
+    console.log(`[sensevoice] Initialized: ${JSON.stringify(result)}`)
+  }
+
+  async transcribe(audioPath: string): Promise<{ text: string; language?: string }> {
+    const result = await this.bridge.send({
+      action: 'transcribe',
+      audio_path: audioPath,
+      sample_rate: 16000
+    })
+
+    return {
+      text: String(result.text ?? ''),
+      language: result.language ? String(result.language) : undefined
+    }
+  }
+
+  async dispose(): Promise<void> {
+    await this.bridge.stop()
+  }
+}

--- a/benchmark/src/stt-engines/sherpa-onnx.ts
+++ b/benchmark/src/stt-engines/sherpa-onnx.ts
@@ -1,0 +1,51 @@
+import { join, dirname } from 'path'
+import { fileURLToPath } from 'url'
+import type { STTBenchmarkEngine } from '../stt-types.js'
+import { PythonBridge } from '../bridge-utils.js'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const BRIDGE_SCRIPT = join(__dirname, '..', '..', 'resources', 'sherpa-onnx-bridge.py')
+
+/**
+ * Sherpa-ONNX STT benchmark engine.
+ * Uses sherpa-onnx Python bindings via subprocess bridge.
+ * Optimized for low-latency on-device inference.
+ */
+export class SherpaOnnxBench implements STTBenchmarkEngine {
+  readonly id = 'sherpa-onnx'
+  readonly label = 'Sherpa-ONNX'
+
+  private bridge: PythonBridge
+  private model: string
+
+  constructor(options?: { model?: string }) {
+    this.model = options?.model ?? 'sherpa-onnx-whisper-medium'
+    this.bridge = new PythonBridge(BRIDGE_SCRIPT)
+  }
+
+  async initialize(): Promise<void> {
+    await this.bridge.start()
+    const result = await this.bridge.send(
+      { action: 'init', model: this.model },
+      180_000
+    )
+    console.log(`[sherpa-onnx] Initialized: ${JSON.stringify(result)}`)
+  }
+
+  async transcribe(audioPath: string): Promise<{ text: string; language?: string }> {
+    const result = await this.bridge.send({
+      action: 'transcribe',
+      audio_path: audioPath,
+      sample_rate: 16000
+    })
+
+    return {
+      text: String(result.text ?? ''),
+      language: result.language ? String(result.language) : undefined
+    }
+  }
+
+  async dispose(): Promise<void> {
+    await this.bridge.stop()
+  }
+}

--- a/benchmark/src/stt-engines/whisper-local.ts
+++ b/benchmark/src/stt-engines/whisper-local.ts
@@ -1,0 +1,76 @@
+import { join, dirname } from 'path'
+import { fileURLToPath } from 'url'
+import { existsSync } from 'fs'
+import { execFileSync } from 'child_process'
+import type { STTBenchmarkEngine } from '../stt-types.js'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const MODELS_DIR = join(__dirname, '..', '..', 'models')
+
+/**
+ * Local Whisper STT benchmark engine.
+ * Uses whisper.cpp CLI directly (avoids whisper-node-addon Electron dependency).
+ */
+export class WhisperLocalBench implements STTBenchmarkEngine {
+  readonly id = 'whisper-local'
+  readonly label = 'Whisper.cpp (Local)'
+
+  private modelPath: string
+  private whisperBin: string
+
+  constructor(options?: { modelPath?: string; whisperBin?: string }) {
+    this.modelPath =
+      options?.modelPath ?? join(MODELS_DIR, 'ggml-large-v3-turbo-q5_0.bin')
+    this.whisperBin = options?.whisperBin ?? 'whisper-cpp'
+  }
+
+  async initialize(): Promise<void> {
+    if (!existsSync(this.modelPath)) {
+      throw new Error(
+        `Whisper model not found: ${this.modelPath}\n` +
+          'Download from: https://huggingface.co/ggerganov/whisper.cpp/tree/main'
+      )
+    }
+
+    // Verify whisper-cpp binary is available
+    try {
+      execFileSync(this.whisperBin, ['--help'], { stdio: 'pipe', timeout: 5000 })
+    } catch {
+      throw new Error(
+        `whisper-cpp binary not found at '${this.whisperBin}'.\n` +
+          'Install: brew install whisper-cpp  OR  set whisperBin option to the binary path.'
+      )
+    }
+
+    console.log(`[whisper-local] Model: ${this.modelPath}`)
+  }
+
+  async transcribe(audioPath: string): Promise<{ text: string; language?: string }> {
+    const args = [
+      '--model', this.modelPath,
+      '--file', audioPath,
+      '--language', 'auto',
+      '--output-txt',
+      '--no-timestamps',
+      '--threads', '4'
+    ]
+
+    try {
+      const output = execFileSync(this.whisperBin, args, {
+        encoding: 'utf-8',
+        timeout: 60_000,
+        stdio: ['pipe', 'pipe', 'pipe']
+      })
+
+      const text = output.trim()
+      return { text }
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err)
+      throw new Error(`whisper-cpp failed: ${msg}`)
+    }
+  }
+
+  async dispose(): Promise<void> {
+    // No persistent state to clean up
+  }
+}

--- a/benchmark/src/stt-report.ts
+++ b/benchmark/src/stt-report.ts
@@ -1,0 +1,200 @@
+import { mkdirSync, writeFileSync } from 'fs'
+import { join, dirname } from 'path'
+import { fileURLToPath } from 'url'
+import type { STTBenchmarkResult, STTEngineSummary } from './stt-types.js'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const RESULTS_DIR = join(__dirname, '..', 'results')
+
+function fmt(n: number, decimals = 0): string {
+  return n.toFixed(decimals)
+}
+
+function pct(n: number): string {
+  return (n * 100).toFixed(1) + '%'
+}
+
+function buildSummaryTable(summaries: STTEngineSummary[]): string {
+  const header =
+    '| Engine | Language | Files | Error Rate | Avg Latency | Median | P95 | Peak RSS | Errors |'
+  const sep = '|---|---|---|---|---|---|---|---|---|'
+  const rows = summaries.map((s) => {
+    const metricLabel = s.language === 'ja' ? 'CER' : s.language === 'en' ? 'WER' : 'ER'
+    return (
+      `| ${s.engineLabel} | ${s.language.toUpperCase()} | ${s.totalFiles} ` +
+      `| ${pct(s.accuracy.errorRate)} (${metricLabel}) ` +
+      `| ${fmt(s.latency.avg)}ms | ${fmt(s.latency.median)}ms | ${fmt(s.latency.p95)}ms ` +
+      `| ${fmt(s.peakRssMB / 1024, 2)}GB | ${s.errors} |`
+    )
+  })
+  return [header, sep, ...rows].join('\n')
+}
+
+function buildDomainBreakdown(summaries: STTEngineSummary[]): string {
+  const domains = ['casual', 'business', 'technical']
+  const header = `| Engine | Language | ${domains.join(' | ')} |`
+  const sep = `|---|---|${domains.map(() => '---').join('|')}|`
+  const rows = summaries.map((s) => {
+    const cells = domains.map((d) => {
+      const matched = s.results.filter((r) => r.domain === d && !r.error)
+      if (matched.length === 0) return 'N/A'
+      const avg = matched.reduce((acc, r) => acc + r.latencyMs, 0) / matched.length
+      return `${fmt(avg)}ms`
+    })
+    return `| ${s.engineLabel} | ${s.language.toUpperCase()} | ${cells.join(' | ')} |`
+  })
+  return [header, sep, ...rows].join('\n')
+}
+
+function buildAccuracyBreakdown(summaries: STTEngineSummary[]): string {
+  const header =
+    '| Engine | Language | Substitutions | Deletions | Insertions | Ref Tokens | Error Rate |'
+  const sep = '|---|---|---|---|---|---|---|'
+  const rows = summaries.map((s) => {
+    const a = s.accuracy
+    return (
+      `| ${s.engineLabel} | ${s.language.toUpperCase()} ` +
+      `| ${a.substitutions} | ${a.deletions} | ${a.insertions} ` +
+      `| ${a.totalReferenceTokens} | ${pct(a.errorRate)} |`
+    )
+  })
+  return [header, sep, ...rows].join('\n')
+}
+
+function buildGoNoGoTable(summaries: STTEngineSummary[]): string {
+  const LATENCY_THRESHOLD = 3000 // 3s for STT (longer than translation)
+  const ERROR_RATE_THRESHOLD = 0.25 // 25% WER/CER
+  const MEMORY_THRESHOLD_MB = 4 * 1024
+
+  // Aggregate per-engine across languages
+  const engineIds = [...new Set(summaries.map((s) => s.engineId))]
+  const engineMetrics = engineIds.map((id) => {
+    const runs = summaries.filter((s) => s.engineId === id)
+    const label = runs[0]?.engineLabel ?? id
+
+    // Use "all" language if available, otherwise average across languages
+    const allRun = runs.find((r) => r.language === 'all')
+    const avgLatency = allRun
+      ? allRun.latency.avg
+      : runs.reduce((acc, r) => acc + r.latency.avg, 0) / runs.length
+    const avgErrorRate = allRun
+      ? allRun.accuracy.errorRate
+      : runs.reduce((acc, r) => acc + r.accuracy.errorRate, 0) / runs.length
+    const peakRss = Math.max(...runs.map((r) => r.peakRssMB))
+
+    const latencyOk = avgLatency < LATENCY_THRESHOLD
+    const accuracyOk = avgErrorRate < ERROR_RATE_THRESHOLD
+    const memoryOk = peakRss < MEMORY_THRESHOLD_MB
+
+    return { id, label, avgLatency, avgErrorRate, peakRss, latencyOk, accuracyOk, memoryOk }
+  })
+
+  const header = `| Criteria | ${engineMetrics.map((e) => e.label).join(' | ')} |`
+  const sep = `|---|${engineMetrics.map(() => '---').join('|')}|`
+
+  const latencyRow = `| Latency (<3s) | ${engineMetrics.map((e) => (e.latencyOk ? `Yes (${fmt(e.avgLatency)}ms)` : `No (${fmt(e.avgLatency)}ms)`)).join(' | ')} |`
+  const accuracyRow = `| Error rate (<25%) | ${engineMetrics.map((e) => (e.accuracyOk ? `Yes (${pct(e.avgErrorRate)})` : `No (${pct(e.avgErrorRate)})`)).join(' | ')} |`
+  const memoryRow = `| Memory (<4GB) | ${engineMetrics.map((e) => (e.memoryOk ? `Yes (${fmt(e.peakRss / 1024, 2)}GB)` : `No (${fmt(e.peakRss / 1024, 2)}GB)`)).join(' | ')} |`
+  const recRow = `| Recommendation | ${engineMetrics.map((e) => (e.latencyOk && e.accuracyOk && e.memoryOk ? 'Go' : 'No-Go')).join(' | ')} |`
+
+  return [header, sep, latencyRow, accuracyRow, memoryRow, recRow].join('\n')
+}
+
+function buildMarkdown(result: STTBenchmarkResult): string {
+  const lines: string[] = [
+    '# STT Benchmark Results',
+    '',
+    `Run: ${result.timestamp}`,
+    '',
+    '## Summary',
+    '',
+    buildSummaryTable(result.summaries),
+    '',
+    '## Accuracy Breakdown',
+    '',
+    buildAccuracyBreakdown(result.summaries),
+    '',
+    '## Latency by Domain',
+    '',
+    buildDomainBreakdown(result.summaries),
+    '',
+    '## Go/No-Go Recommendation',
+    '',
+    buildGoNoGoTable(result.summaries),
+    ''
+  ]
+  return lines.join('\n')
+}
+
+function buildDetailCSV(result: STTBenchmarkResult): string {
+  const engineIds = [...new Set(result.summaries.map((s) => s.engineId))]
+
+  // Collect all entry IDs
+  const allIds = new Set<string>()
+  for (const s of result.summaries) {
+    for (const r of s.results) {
+      allIds.add(r.id)
+    }
+  }
+
+  // Build output map: id -> engineId -> hypothesis
+  const outputMap = new Map<string, Map<string, string>>()
+  const refMap = new Map<string, { reference: string; language: string; domain: string }>()
+  for (const s of result.summaries) {
+    for (const r of s.results) {
+      if (!outputMap.has(r.id)) outputMap.set(r.id, new Map())
+      outputMap.get(r.id)!.set(s.engineId, r.hypothesis)
+      if (!refMap.has(r.id)) {
+        refMap.set(r.id, {
+          reference: r.reference,
+          language: r.language,
+          domain: r.domain
+        })
+      }
+    }
+  }
+
+  const hypHeaders = engineIds.map((id) => `${id}_hypothesis`)
+  const header = ['id', 'language', 'domain', 'reference', ...hypHeaders].join(',')
+
+  const rows = [...allIds].map((id) => {
+    const ref = refMap.get(id)!
+    const hypotheses = engineIds.map((eid) => {
+      const text = outputMap.get(id)?.get(eid) ?? ''
+      return `"${text.replace(/"/g, '""')}"`
+    })
+    return [
+      id,
+      ref.language,
+      ref.domain,
+      `"${ref.reference.replace(/"/g, '""')}"`,
+      ...hypotheses
+    ].join(',')
+  })
+
+  return [header, ...rows].join('\n')
+}
+
+/** Write all STT report files to results/ directory */
+export function writeSTTReports(result: STTBenchmarkResult): string {
+  mkdirSync(RESULTS_DIR, { recursive: true })
+
+  const ts = result.timestamp.replace(/[:.]/g, '-').slice(0, 19)
+
+  // Raw JSON
+  const jsonPath = join(RESULTS_DIR, `stt-benchmark-${ts}.json`)
+  writeFileSync(jsonPath, JSON.stringify(result, null, 2))
+  console.log(`[stt-report] JSON: ${jsonPath}`)
+
+  // Markdown summary
+  const mdPath = join(RESULTS_DIR, `stt-benchmark-${ts}.md`)
+  writeFileSync(mdPath, buildMarkdown(result))
+  console.log(`[stt-report] Markdown: ${mdPath}`)
+
+  // Detail CSV
+  const csvPath = join(RESULTS_DIR, `stt-detail-${ts}.csv`)
+  writeFileSync(csvPath, buildDetailCSV(result))
+  console.log(`[stt-report] Detail CSV: ${csvPath}`)
+
+  return RESULTS_DIR
+}

--- a/benchmark/src/stt-runner.ts
+++ b/benchmark/src/stt-runner.ts
@@ -1,0 +1,173 @@
+import { readFileSync } from 'fs'
+import { join, dirname, resolve } from 'path'
+import { fileURLToPath } from 'url'
+import type {
+  STTBenchmarkEngine,
+  STTBenchmarkResult,
+  STTEngineSummary,
+  STTSentenceResult,
+  STTTestEntry,
+  STTLanguage,
+  AccuracyStats
+} from './stt-types.js'
+import type { LatencyStats } from './types.js'
+import { measureLatency, snapshotMemory, tryGC, computeStats } from './metrics.js'
+import { computeErrorRate, aggregateAccuracy } from './wer.js'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const MANIFEST_PATH = join(__dirname, '..', 'testset', 'stt-manifest.jsonl')
+const WARMUP_COUNT = 2
+
+/** Load STT test manifest from JSONL file */
+function loadManifest(path: string): STTTestEntry[] {
+  const content = readFileSync(path, 'utf-8')
+  return content
+    .split('\n')
+    .filter((line) => line.trim())
+    .map((line) => JSON.parse(line) as STTTestEntry)
+}
+
+/** Resolve audio path relative to testset directory */
+function resolveAudioPath(entry: STTTestEntry): string {
+  return resolve(join(__dirname, '..', 'testset'), entry.audio_path)
+}
+
+/** Run a single STT engine against the test set for one language */
+async function runSTTEngine(
+  engine: STTBenchmarkEngine,
+  entries: STTTestEntry[],
+  language: STTLanguage | 'all'
+): Promise<STTEngineSummary> {
+  const filtered =
+    language === 'all' ? entries : entries.filter((e) => e.language === language)
+
+  console.log(
+    `\n[stt-runner] ${engine.label} (${language}): ${filtered.length} audio files`
+  )
+
+  // Initialize
+  console.log(`[stt-runner] Initializing ${engine.label}...`)
+  await engine.initialize()
+  tryGC()
+
+  let peakRss = snapshotMemory().rssMB
+
+  // Warmup
+  const warmupEntries = filtered.slice(0, WARMUP_COUNT)
+  console.log(`[stt-runner] Warmup: ${warmupEntries.length} files`)
+  for (const entry of warmupEntries) {
+    try {
+      await engine.transcribe(resolveAudioPath(entry))
+    } catch {
+      // Ignore warmup errors
+    }
+  }
+  tryGC()
+
+  // Benchmark all entries
+  const results: STTSentenceResult[] = []
+  const accuracyStats: AccuracyStats[] = []
+
+  for (let i = 0; i < filtered.length; i++) {
+    const entry = filtered[i]!
+    const progress = `[${i + 1}/${filtered.length}]`
+    const audioPath = resolveAudioPath(entry)
+
+    try {
+      const { result: transcription, ms } = await measureLatency(() =>
+        engine.transcribe(audioPath)
+      )
+
+      const hypothesis = transcription.text
+
+      // Compute error rate
+      const accuracy = computeErrorRate(entry.reference_text, hypothesis, entry.language)
+      accuracyStats.push(accuracy)
+
+      results.push({
+        id: entry.id,
+        reference: entry.reference_text,
+        hypothesis,
+        language: entry.language,
+        domain: entry.domain,
+        latencyMs: ms
+      })
+
+      if ((i + 1) % 5 === 0 || i === filtered.length - 1) {
+        const errPct = (accuracy.errorRate * 100).toFixed(1)
+        console.log(
+          `  ${progress} ${ms.toFixed(0)}ms | ER=${errPct}% | "${hypothesis.substring(0, 40)}..."`
+        )
+      }
+    } catch (err) {
+      const errorMsg = err instanceof Error ? err.message : String(err)
+      console.error(`  ${progress} ERROR: ${errorMsg}`)
+      results.push({
+        id: entry.id,
+        reference: entry.reference_text,
+        hypothesis: '',
+        language: entry.language,
+        domain: entry.domain,
+        latencyMs: 0,
+        error: errorMsg
+      })
+    }
+
+    // Track peak RSS
+    const mem = snapshotMemory()
+    if (mem.rssMB > peakRss) peakRss = mem.rssMB
+  }
+
+  const latencies = results.filter((r) => !r.error).map((r) => r.latencyMs)
+  const errors = results.filter((r) => r.error).length
+  const accuracy = aggregateAccuracy(accuracyStats)
+
+  return {
+    engineId: engine.id,
+    engineLabel: engine.label,
+    language,
+    totalFiles: filtered.length,
+    errors,
+    accuracy,
+    latency: computeStats(latencies),
+    peakRssMB: peakRss,
+    results
+  }
+}
+
+/** Run the full STT benchmark suite */
+export async function runSTTBenchmark(
+  engines: STTBenchmarkEngine[],
+  languages: (STTLanguage | 'all')[] = ['ja', 'en', 'all']
+): Promise<STTBenchmarkResult> {
+  const entries = loadManifest(MANIFEST_PATH)
+  console.log(`[stt-runner] Loaded ${entries.length} test entries from manifest`)
+
+  const summaries: STTEngineSummary[] = []
+
+  for (const engine of engines) {
+    for (const language of languages) {
+      try {
+        const summary = await runSTTEngine(engine, entries, language)
+        summaries.push(summary)
+      } catch (err) {
+        console.error(
+          `[stt-runner] Fatal error with ${engine.label} (${language}):`,
+          err
+        )
+      } finally {
+        try {
+          await engine.dispose()
+        } catch (err) {
+          console.error(`[stt-runner] Dispose error for ${engine.label}:`, err)
+        }
+        tryGC()
+      }
+    }
+  }
+
+  return {
+    timestamp: new Date().toISOString(),
+    summaries
+  }
+}

--- a/benchmark/src/stt-types.ts
+++ b/benchmark/src/stt-types.ts
@@ -1,0 +1,76 @@
+/** Language code for STT benchmark */
+export type STTLanguage = 'ja' | 'en'
+
+/** Domain category for test audio */
+export type STTDomain = 'casual' | 'business' | 'technical'
+
+/** A single entry from the STT test manifest */
+export interface STTTestEntry {
+  id: string
+  audio_path: string
+  reference_text: string
+  language: STTLanguage
+  domain: STTDomain
+}
+
+/** Result of transcribing a single audio file */
+export interface STTSentenceResult {
+  id: string
+  reference: string
+  hypothesis: string
+  language: STTLanguage
+  domain: STTDomain
+  latencyMs: number
+  error?: string
+}
+
+/** WER/CER statistics for a set of results */
+export interface AccuracyStats {
+  /** Word Error Rate (for EN) or Character Error Rate (for JA) */
+  errorRate: number
+  /** Number of substitutions */
+  substitutions: number
+  /** Number of deletions */
+  deletions: number
+  /** Number of insertions */
+  insertions: number
+  /** Total reference tokens */
+  totalReferenceTokens: number
+}
+
+/** Summary for one STT engine run */
+export interface STTEngineSummary {
+  engineId: string
+  engineLabel: string
+  language: STTLanguage | 'all'
+  totalFiles: number
+  errors: number
+  accuracy: AccuracyStats
+  latency: import('./types.js').LatencyStats
+  peakRssMB: number
+  results: STTSentenceResult[]
+}
+
+/** Full STT benchmark result */
+export interface STTBenchmarkResult {
+  timestamp: string
+  summaries: STTEngineSummary[]
+}
+
+/**
+ * Benchmark engine interface for STT.
+ * Each engine must transcribe a WAV file and return text.
+ */
+export interface STTBenchmarkEngine {
+  readonly id: string
+  readonly label: string
+
+  /** Initialize model/connection. Must be idempotent. */
+  initialize(): Promise<void>
+
+  /** Transcribe a single WAV audio file. Returns recognized text. */
+  transcribe(audioPath: string): Promise<{ text: string; language?: string }>
+
+  /** Release resources. Safe to call even if not initialized. */
+  dispose(): Promise<void>
+}

--- a/benchmark/src/wer.ts
+++ b/benchmark/src/wer.ts
@@ -1,0 +1,171 @@
+import type { AccuracyStats, STTLanguage } from './stt-types.js'
+
+/**
+ * Tokenize text for error rate calculation.
+ * - Japanese: character-level (CER) — split into individual characters, ignoring whitespace
+ * - English: word-level (WER) — split on whitespace, lowercased
+ */
+function tokenize(text: string, language: STTLanguage): string[] {
+  const normalized = text.trim()
+  if (!normalized) return []
+
+  if (language === 'ja') {
+    // Character-level: remove all whitespace, split into chars
+    return normalized.replace(/\s+/g, '').split('')
+  }
+
+  // Word-level: lowercase and split on whitespace
+  return normalized
+    .toLowerCase()
+    .replace(/[^\w\s]/g, '') // remove punctuation
+    .split(/\s+/)
+    .filter((w) => w.length > 0)
+}
+
+/**
+ * Compute the minimum edit distance (Levenshtein) between reference and hypothesis tokens.
+ * Returns substitutions, deletions, insertions, and total distance.
+ */
+function editDistance(ref: string[], hyp: string[]): {
+  distance: number
+  substitutions: number
+  deletions: number
+  insertions: number
+} {
+  const n = ref.length
+  const m = hyp.length
+
+  // dp[i][j] = { cost, sub, del, ins }
+  const dp: Array<Array<{ cost: number; sub: number; del: number; ins: number }>> = []
+
+  for (let i = 0; i <= n; i++) {
+    dp[i] = []
+    for (let j = 0; j <= m; j++) {
+      dp[i]![j] = { cost: 0, sub: 0, del: 0, ins: 0 }
+    }
+  }
+
+  // Base cases
+  for (let i = 1; i <= n; i++) {
+    dp[i]![0] = { cost: i, sub: 0, del: i, ins: 0 }
+  }
+  for (let j = 1; j <= m; j++) {
+    dp[0]![j] = { cost: j, sub: 0, del: 0, ins: j }
+  }
+
+  for (let i = 1; i <= n; i++) {
+    for (let j = 1; j <= m; j++) {
+      if (ref[i - 1] === hyp[j - 1]) {
+        // Match — no cost
+        dp[i]![j] = { ...dp[i - 1]![j - 1]! }
+      } else {
+        const subCost = dp[i - 1]![j - 1]!.cost + 1
+        const delCost = dp[i - 1]![j]!.cost + 1
+        const insCost = dp[i]![j - 1]!.cost + 1
+
+        if (subCost <= delCost && subCost <= insCost) {
+          const prev = dp[i - 1]![j - 1]!
+          dp[i]![j] = {
+            cost: subCost,
+            sub: prev.sub + 1,
+            del: prev.del,
+            ins: prev.ins
+          }
+        } else if (delCost <= insCost) {
+          const prev = dp[i - 1]![j]!
+          dp[i]![j] = {
+            cost: delCost,
+            sub: prev.sub,
+            del: prev.del + 1,
+            ins: prev.ins
+          }
+        } else {
+          const prev = dp[i]![j - 1]!
+          dp[i]![j] = {
+            cost: insCost,
+            sub: prev.sub,
+            del: prev.del,
+            ins: prev.ins + 1
+          }
+        }
+      }
+    }
+  }
+
+  const result = dp[n]![m]!
+  return {
+    distance: result.cost,
+    substitutions: result.sub,
+    deletions: result.del,
+    insertions: result.ins
+  }
+}
+
+/**
+ * Compute accuracy stats for a single reference/hypothesis pair.
+ * Uses CER for Japanese, WER for English.
+ */
+export function computeErrorRate(
+  reference: string,
+  hypothesis: string,
+  language: STTLanguage
+): AccuracyStats {
+  const refTokens = tokenize(reference, language)
+  const hypTokens = tokenize(hypothesis, language)
+
+  if (refTokens.length === 0) {
+    return {
+      errorRate: hypTokens.length > 0 ? 1.0 : 0.0,
+      substitutions: 0,
+      deletions: 0,
+      insertions: hypTokens.length,
+      totalReferenceTokens: 0
+    }
+  }
+
+  const { substitutions, deletions, insertions } = editDistance(refTokens, hypTokens)
+  const totalErrors = substitutions + deletions + insertions
+  const errorRate = totalErrors / refTokens.length
+
+  return {
+    errorRate,
+    substitutions,
+    deletions,
+    insertions,
+    totalReferenceTokens: refTokens.length
+  }
+}
+
+/**
+ * Aggregate accuracy stats from multiple results.
+ * Computes corpus-level error rate (sum of errors / sum of reference tokens).
+ */
+export function aggregateAccuracy(stats: AccuracyStats[]): AccuracyStats {
+  if (stats.length === 0) {
+    return {
+      errorRate: 0,
+      substitutions: 0,
+      deletions: 0,
+      insertions: 0,
+      totalReferenceTokens: 0
+    }
+  }
+
+  const total = stats.reduce(
+    (acc, s) => ({
+      substitutions: acc.substitutions + s.substitutions,
+      deletions: acc.deletions + s.deletions,
+      insertions: acc.insertions + s.insertions,
+      totalReferenceTokens: acc.totalReferenceTokens + s.totalReferenceTokens
+    }),
+    { substitutions: 0, deletions: 0, insertions: 0, totalReferenceTokens: 0 }
+  )
+
+  const totalErrors = total.substitutions + total.deletions + total.insertions
+  const errorRate = total.totalReferenceTokens > 0 ? totalErrors / total.totalReferenceTokens : 0
+
+  return {
+    errorRate,
+    ...total
+  }
+}

--- a/package.json
+++ b/package.json
@@ -16,7 +16,10 @@
     "test:watch": "vitest",
     "test:e2e": "playwright test",
     "lint": "eslint src/",
-    "lint:fix": "eslint src/ --fix"
+    "lint:fix": "eslint src/ --fix",
+    "bench:stt": "cd benchmark && npm run stt",
+    "bench:stt:all": "cd benchmark && npm run stt:all",
+    "bench:stt:generate": "cd benchmark && npm run stt:generate-testset"
   },
   "dependencies": {
     "@electron-toolkit/utils": "^3.0.0",


### PR DESCRIPTION
## Summary
- Add STT benchmark infrastructure parallel to the existing translation benchmark
- Support 7 STT engines: whisper-local, mlx-whisper, lightning-whisper, moonshine, sensevoice, qwen-asr, sherpa-onnx
- WER calculation (word-level for EN, character-level/CER for JA) with Levenshtein edit distance
- Test audio generation script using macOS `say` command (40 WAV files: 20 JA, 20 EN across casual/business/technical domains)
- Python bridge subprocess utility (`bridge-utils.ts`) for engines using Python backends
- Reuses existing `resources/*.py` bridge scripts (mlx-whisper, lightning-whisper, sensevoice) and adds new ones (moonshine, qwen-asr, sherpa-onnx)
- `--stt` flag on `benchmark/run.ts` to switch between translation and STT benchmarks
- Reports include accuracy breakdown (substitutions/deletions/insertions), latency stats, and Go/No-Go recommendation

## Test plan
- [ ] Run `npm run bench:stt:generate` to generate test audio files
- [ ] Run `npm run bench:stt` with at least one available engine
- [ ] Verify type-check passes: `npx tsc --project benchmark/tsconfig.json --noEmit`
- [ ] Verify `--help` shows STT options
- [ ] Verify translation benchmark still works with `npm run bench` (no regression)