### PR TITLE
Fix benchmark engine bugs (Hunyuan-MT + Moonshine)

### DIFF
--- a/benchmark/src/engines/hunyuan-mt.ts
+++ b/benchmark/src/engines/hunyuan-mt.ts
@@ -30,6 +30,7 @@ export class HunyuanMTBench implements BenchmarkEngine {
   private llama: any = null
   private model: any = null
   private context: any = null
+  private session: any = null
 
   constructor(options?: HunyuanMTBenchOptions) {
     const modelFile = options?.modelFile ?? DEFAULT_MODEL_FILE
@@ -58,12 +59,15 @@ export class HunyuanMTBench implements BenchmarkEngine {
     this.model = await this.llama.loadModel({ modelPath: this.modelPath })
     this.context = await this.model.createContext({ contextSize: 2048 })
 
+    const { LlamaChatSession } = await import('node-llama-cpp')
+    this.session = new LlamaChatSession({ contextSequence: this.context.getSequence() })
+
     console.log('[hunyuan-mt] Model loaded')
   }
 
   async translate(text: string, direction: Direction): Promise<string> {
     if (!text.trim()) return ''
-    if (!this.context) {
+    if (!this.session) {
       throw new Error('[hunyuan-mt] Not initialized')
     }
 
@@ -73,10 +77,10 @@ export class HunyuanMTBench implements BenchmarkEngine {
     // Hunyuan-MT prompt format: for non-Chinese language pairs, use English prompt
     const prompt = `Translate the following segment into ${toLang}, without additional explanation.\n\n${text}`
 
-    const { LlamaChatSession } = await import('node-llama-cpp')
-    const session = new LlamaChatSession({ contextSequence: this.context.getSequence() })
+    // Reset session context for each independent translation
+    this.session.resetChatHistory()
 
-    const response = await session.prompt(prompt, {
+    const response = await this.session.prompt(prompt, {
       temperature: 0.7,
       maxTokens: 512,
       topK: 20,
@@ -84,11 +88,14 @@ export class HunyuanMTBench implements BenchmarkEngine {
       repeatPenalty: { penalty: 1.05 }
     })
 
-    session.dispose?.()
     return response.trim()
   }
 
   async dispose(): Promise<void> {
+    if (this.session) {
+      this.session.dispose?.()
+      this.session = null
+    }
     if (this.context) {
       await this.context.dispose?.()
       this.context = null

--- a/benchmark/src/stt-engines/moonshine.ts
+++ b/benchmark/src/stt-engines/moonshine.ts
@@ -1,51 +1,82 @@
-import { join, dirname } from 'path'
-import { fileURLToPath } from 'url'
+import { readFileSync } from 'fs'
 import type { STTBenchmarkEngine } from '../stt-types.js'
-import { PythonBridge } from '../bridge-utils.js'
-
-const __dirname = dirname(fileURLToPath(import.meta.url))
-const BRIDGE_SCRIPT = join(__dirname, '..', '..', 'resources', 'moonshine-bridge.py')
 
 /**
- * Moonshine STT benchmark engine (Useful Sensors).
- * Lightweight on-device speech recognition optimized for edge.
- * Uses a Python bridge subprocess.
+ * Moonshine STT benchmark engine using @huggingface/transformers (Node.js, no Python).
+ * Matches the app's MoonshineEngine implementation.
  */
 export class MoonshineBench implements STTBenchmarkEngine {
   readonly id = 'moonshine'
   readonly label = 'Moonshine (Edge)'
 
-  private bridge: PythonBridge
+  private pipeline: any = null
   private model: string
 
   constructor(options?: { model?: string }) {
-    this.model = options?.model ?? 'moonshine/base'
-    this.bridge = new PythonBridge(BRIDGE_SCRIPT)
+    this.model = options?.model ?? 'onnx-community/moonshine-base-ONNX'
   }
 
   async initialize(): Promise<void> {
-    await this.bridge.start()
-    const result = await this.bridge.send(
-      { action: 'init', model: this.model },
-      180_000
+    if (this.pipeline) return
+
+    console.log(`[moonshine] Loading model: ${this.model}...`)
+    const { join } = await import('path')
+    const { homedir } = await import('os')
+    const { pipeline, env } = await import('@huggingface/transformers')
+    env.cacheDir = join(homedir(), '.cache', 'huggingface', 'transformers')
+
+    this.pipeline = await pipeline(
+      'automatic-speech-recognition',
+      this.model,
+      { dtype: 'q8' }
     )
-    console.log(`[moonshine] Initialized: ${JSON.stringify(result)}`)
+    console.log('[moonshine] Model loaded')
   }
 
   async transcribe(audioPath: string): Promise<{ text: string; language?: string }> {
-    const result = await this.bridge.send({
-      action: 'transcribe',
-      audio_path: audioPath,
-      sample_rate: 16000
-    })
-
-    return {
-      text: String(result.text ?? ''),
-      language: result.language ? String(result.language) : undefined
+    if (!this.pipeline) {
+      throw new Error('[moonshine] Not initialized')
     }
+
+    // Read WAV file and extract raw PCM float32 samples
+    const wavBuffer = readFileSync(audioPath)
+    const float32Data = wavToFloat32(wavBuffer)
+
+    const result = await this.pipeline(float32Data, { sampling_rate: 16000 })
+    const text = (result as any).text ?? ''
+
+    return { text: text.trim() }
   }
 
   async dispose(): Promise<void> {
-    await this.bridge.stop()
+    if (this.pipeline) {
+      await this.pipeline.dispose?.()
+      this.pipeline = null
+    }
   }
+}
+
+/**
+ * Parse a 16-bit PCM WAV file into Float32Array.
+ * Assumes 16kHz mono WAV (standard for STT).
+ */
+function wavToFloat32(buffer: Buffer): Float32Array {
+  // Find 'data' chunk
+  let offset = 12 // skip RIFF header
+  while (offset < buffer.length - 8) {
+    const chunkId = buffer.toString('ascii', offset, offset + 4)
+    const chunkSize = buffer.readUInt32LE(offset + 4)
+    if (chunkId === 'data') {
+      const dataStart = offset + 8
+      const numSamples = chunkSize / 2 // 16-bit = 2 bytes per sample
+      const float32 = new Float32Array(numSamples)
+      for (let i = 0; i < numSamples; i++) {
+        const sample = buffer.readInt16LE(dataStart + i * 2)
+        float32[i] = sample / 32768.0
+      }
+      return float32
+    }
+    offset += 8 + chunkSize
+  }
+  throw new Error('No data chunk found in WAV file')
 }


### PR DESCRIPTION
## Summary
- Hunyuan-MT: reuse single LlamaChatSession with resetChatHistory() instead of creating new sessions (fixes "No sequences left" error)
- Moonshine: use @huggingface/transformers directly in Node.js instead of Python bridge, with proper WAV parsing and cache dir

Verified both fixes produce valid benchmark results.