### PR TITLE
Update docs to reflect engine selection cleanup

### DIFF
--- a/.claude/rules/engines.md
+++ b/.claude/rules/engines.md
@@ -5,12 +5,48 @@ globs: src/engines/**/*.ts, src/pipeline/**/*.ts
 
 # Engine Plugin Rules
 
+## Current Engine Landscape
+
+### STT Engines (2 primary + 3 experimental)
+
+**Primary (shown in UI):**
+| Engine | File | Notes |
+|--------|------|-------|
+| Whisper Local | `WhisperLocalEngine.ts` | Native whisper.cpp, primary default |
+| MLX Whisper | `MlxWhisperEngine.ts` | Apple Silicon, JA CER 8.1%, EN WER 3.8%, 2.9s |
+
+**Experimental (hidden from UI):**
+- SenseVoice, Qwen3-ASR, Sherpa-ONNX — under evaluation
+
+**Removed (benchmark failures):**
+- Lightning Whisper MLX — JA CER 162%
+- Moonshine — JA CER 221%
+
+### Translation Engines (5 primary + 5 experimental)
+
+**Primary (shown in UI):**
+| Engine | File | JA→EN | EN→JA | Memory | Offline |
+|--------|------|-------|-------|--------|---------|
+| OPUS-MT (fast default) | `OpusMTTranslator.ts` | 279ms | 462ms | 0.98GB | Yes |
+| Hunyuan-MT 7B (quality) | via `SLMTranslator.ts` | 3.7s | 6.3s | 4GB | Yes |
+| Google Translate | `GoogleTranslator.ts` | Fast | Fast | — | No |
+| DeepL | `DeepLTranslator.ts` | Fast | Fast | — | No |
+| Gemini | `GeminiTranslator.ts` | Fast | Fast | — | No |
+
+**Experimental (hidden from UI):**
+- TranslateGemma — 8s/sentence, too slow for real-time
+- HY-MT1.5, CT2 OPUS-MT, CT2 Madlad-400, ANE — under evaluation
+
+**Removed (benchmark failures):**
+- ALMA-Ja, Gemma-2-JPN
+
 ## Adding New Engines
 1. Create a new file in `src/engines/stt/` or `src/engines/translator/`
 2. Implement the corresponding interface from `src/engines/types.ts`
 3. Register the factory in `src/main/index.ts` → `initPipeline()`
-4. Add the engine option to `src/renderer/components/SettingsPanel.tsx`
-5. Alternatively, create a plugin in `userData/plugins/` with a `live-translate-plugin.json` manifest
+4. For primary engines: add to `src/renderer/components/SettingsPanel.tsx`
+5. For experimental engines: register but hide from UI (do not add to SettingsPanel)
+6. Alternatively, create a plugin in `userData/plugins/` with a `live-translate-plugin.json` manifest
 
 ## Interface Contracts
 - `initialize()` must be idempotent — safe to call multiple times
@@ -27,7 +63,8 @@ globs: src/engines/**/*.ts, src/pipeline/**/*.ts
 - `ContextBuffer` provides previous segments for context-aware translation
 - `SpeakerTracker` assigns speaker IDs based on silence gaps
 
-## UtilityProcess (TranslateGemma)
+## UtilityProcess (LLM Engines)
 - `SLMTranslator` is an IPC proxy to `slm-worker.ts` UtilityProcess
+- Used by Hunyuan-MT 7B (primary quality mode) and TranslateGemma (experimental)
 - Worker handles both translation and meeting summarization
 - Init handler runs first, general message handler registered after init completes

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ This file provides guidance to AI coding agents working with this repository.
 
 ## Project Overview
 
-Live Translate is a real-time speech translation overlay app for presentations and meetings. It captures microphone audio via Silero VAD, performs speech-to-text with pluggable STT engines (Whisper, mlx-whisper, Moonshine), translates via pluggable translation engines (Google, DeepL, Azure, Gemini, OPUS-MT, TranslateGemma 4B), and displays subtitles on an external display. Features GPU-accelerated offline translation, speaker diarization, meeting summaries, and a plugin system.
+Live Translate is a real-time speech translation overlay app for presentations and meetings. It captures microphone audio via Silero VAD, performs speech-to-text with pluggable STT engines (Whisper Local, MLX Whisper), translates via pluggable translation engines (OPUS-MT, Hunyuan-MT 7B, Google, DeepL, Gemini), and displays subtitles on an external display. Features GPU-accelerated offline translation, speaker diarization, meeting summaries, and a plugin system.
 
 ## Commands
 
@@ -26,12 +26,12 @@ npm install          # Install deps (postinstall fixes whisper-node-addon)
 ### Tech Stack
 - Electron + React + TypeScript
 - electron-vite (build tooling)
-- whisper-node-addon (whisper.cpp native binding)
-- mlx-whisper (Python subprocess bridge, Apple Silicon)
-- Moonshine AI (ONNX via @huggingface/transformers)
-- node-llama-cpp (TranslateGemma 4B/12B, meeting summaries, UtilityProcess)
+- whisper-node-addon (whisper.cpp native binding — primary STT)
+- mlx-whisper (Python subprocess bridge, Apple Silicon — JA CER 8.1%, EN WER 3.8%)
+- node-llama-cpp (Hunyuan-MT 7B quality translation, meeting summaries, UtilityProcess)
 - @ricky0123/vad-web (Silero VAD)
-- Multiple translation backends (Google, DeepL, Azure, Gemini, OPUS-MT, TranslateGemma)
+- Primary translation: OPUS-MT (279ms, offline), Hunyuan-MT 7B (3.7s, quality), Google, DeepL, Gemini
+- Experimental (hidden): TranslateGemma, HY-MT1.5, CT2 OPUS-MT, CT2 Madlad-400, ANE
 - Local Agreement algorithm for streaming subtitle display
 
 ### Module Structure
@@ -51,7 +51,7 @@ live-translate/
 │   ├── preload/                 # Context bridge (renderer ↔ main IPC)
 │   ├── renderer/
 │   │   ├── components/
-│   │   │   ├── SettingsPanel.tsx    # Control panel (auto + 7 engines, STT, subtitles)
+│   │   │   ├── SettingsPanel.tsx    # Control panel (5 primary engines, STT, subtitles)
 │   │   │   └── SubtitleOverlay.tsx  # Transparent subtitle window (speaker labels)
 │   │   └── hooks/
 │   │       └── useAudioCapture.ts   # Mic/virtual audio capture via Silero VAD
@@ -61,16 +61,15 @@ live-translate/
 │   │   ├── gpu-detector.ts      # GPU detection via node-llama-cpp
 │   │   ├── plugin-loader.ts     # Engine plugin manifest + loading
 │   │   ├── stt/
-│   │   │   ├── WhisperLocalEngine.ts    # whisper.cpp + hallucination filter
-│   │   │   ├── MlxWhisperEngine.ts      # mlx-whisper (Python bridge)
-│   │   │   └── MoonshineEngine.ts       # Moonshine AI (ONNX)
+│   │   │   ├── WhisperLocalEngine.ts    # whisper.cpp + hallucination filter (primary)
+│   │   │   └── MlxWhisperEngine.ts      # mlx-whisper (Apple Silicon, primary)
 │   │   └── translator/
 │   │       ├── GoogleTranslator.ts
 │   │       ├── DeepLTranslator.ts
 │   │       ├── GeminiTranslator.ts
 │   │       ├── MicrosoftTranslator.ts
 │   │       ├── OpusMTTranslator.ts
-│   │       ├── SLMTranslator.ts         # TranslateGemma 4B/12B (UtilityProcess)
+│   │       ├── SLMTranslator.ts         # LLM-based translation (UtilityProcess, experimental)
 │   │       └── ApiRotationController.ts # Multi-provider rotation
 │   ├── pipeline/
 │   │   ├── TranslationPipeline.ts  # Orchestration, streaming, auto-recovery
@@ -109,13 +108,13 @@ live-translate/
 - Only translates newly confirmed text to minimize API calls
 
 **UtilityProcess Isolation**
-- TranslateGemma 4B runs in Electron UtilityProcess via node-llama-cpp
+- LLM-based engines (Hunyuan-MT 7B, TranslateGemma) run in Electron UtilityProcess via node-llama-cpp
 - SLMTranslator acts as IPC proxy (request/response with timeout)
 - Also handles meeting summary generation
 
 **Engine Auto-Selection**
 - GPU detection via node-llama-cpp `getGpuDeviceNames()`
-- Auto mode: API rotation (if keys) → TranslateGemma (if GPU) → OPUS-MT
+- Auto mode: API rotation (if keys) → Hunyuan-MT 7B (if GPU, quality) → OPUS-MT (fast default)
 
 **Plugin System**
 - Plugins in `userData/plugins/` with `live-translate-plugin.json` manifest

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,9 +30,12 @@ Before acting, always pause and reconsider. Re-read the requirements, re-check y
 - `ScriptProcessorNode` is deprecated — migrate to `AudioWorkletNode` when stability is confirmed
 - electron-vite 2.x requires `build.lib.entry` for main/preload configs
 - Whisper model (~540MB) downloads on first launch — handle offline gracefully
-- TranslateGemma GGUF (~2.6GB) downloads with resume support and SHA256 verification
+- TranslateGemma is experimental only (8s/sentence too slow for real-time) — OPUS-MT is the fast default (279ms)
+- Hunyuan-MT 7B is quality mode only (3.7s JA→EN) — not suitable for real-time streaming
+- GGUF models (~2.6GB+) download with resume support and SHA256 verification
 - Google Cloud Translation API v2 free tier: 500K chars/month, 6000 req/min
 - node-llama-cpp runs in UtilityProcess (slm-worker.ts), not main process
+- Lightning Whisper MLX and Moonshine removed — JA CER too high (162% and 221% respectively)
 - electron-store is encrypted — API keys are not stored in plaintext
 - IPC paths must be validated against directory traversal before file operations
 

--- a/README.md
+++ b/README.md
@@ -26,13 +26,13 @@ Bidirectional JA↔EN translation with transparent subtitles overlaid on any dis
 ## Features
 
 - **Real-time translation** — Whisper STT + pluggable translation engines
-- **Local-first** — Runs entirely offline with OPUS-MT or TranslateGemma 4B (GPU)
-- **API rotation** — Combine free tiers of Google, DeepL, Azure, and Gemini (4M+ chars/month)
+- **Local-first** — Runs entirely offline with OPUS-MT (279ms) or Hunyuan-MT 7B (quality mode)
+- **API rotation** — Combine free tiers of Google, DeepL, and Gemini (4M+ chars/month)
 - **Subtitle overlay** — Transparent, always-on-top subtitles on any display
 - **Customizable subtitles** — Font size, colors, opacity, position
 - **Speaker diarization** — Speaker change detection with labels
 - **Meeting summaries** — Generate summaries via local LLM after sessions
-- **Multiple STT engines** — Whisper, mlx-whisper (Apple Silicon), Moonshine AI
+- **Multiple STT engines** — Whisper Local (whisper.cpp), MLX Whisper (Apple Silicon optimized)
 - **Streaming display** — Local Agreement algorithm for flicker-free interim results
 - **GPU auto-detection** — Automatically selects best engine for your hardware
 - **Plugin system** — Extensible engine architecture with manifest-based plugins
@@ -65,18 +65,50 @@ npm run test         # Run unit tests
 
 - macOS 13+ (Apple Silicon recommended)
 - Node.js 20+
-- For online engines: API key(s) from Google / DeepL / Azure / Gemini
+- For online engines: API key(s) from Google / DeepL / Gemini
+
+## STT Engines
+
+| Engine | JA CER | EN WER | Latency | Notes |
+|--------|--------|--------|---------|-------|
+| **Whisper Local** | — | — | Fast | Native whisper.cpp, primary default |
+| **MLX Whisper** | 8.1% | 3.8% | 2.9s | Apple Silicon optimized |
+
+<details>
+<summary>Experimental STT engines (hidden from UI)</summary>
+
+| Engine | Notes |
+|--------|-------|
+| SenseVoice | Under evaluation |
+| Qwen3-ASR | Under evaluation |
+| Sherpa-ONNX | Under evaluation |
+
+Removed: Lightning Whisper MLX (JA CER 162%), Moonshine (JA CER 221%)
+</details>
 
 ## Translation Engines
 
-| Engine | Quality | Speed | Offline | Free Tier |
-|--------|---------|-------|---------|-----------|
-| **Auto Rotation** (recommended) | Best | Fast | No | 4M+ chars/month |
-| TranslateGemma 4B | High | Medium | Yes | Unlimited |
-| OPUS-MT | Good | Fast | Yes | Unlimited |
-| Google Translate | High | Fast | No | 500K chars/month |
-| DeepL | High | Fast | No | 500K chars/month |
-| Gemini 2.5 Flash | High | Fast | No | Generous |
+| Engine | JA→EN | EN→JA | Memory | Offline | Free Tier |
+|--------|-------|-------|--------|---------|-----------|
+| **OPUS-MT** (fast default) | 279ms | 462ms | 0.98GB | Yes | Unlimited |
+| **Hunyuan-MT 7B** (quality) | 3.7s | 6.3s | 4GB | Yes | Unlimited |
+| **Google Translate** | Fast | Fast | — | No | 500K chars/month |
+| **DeepL** | Fast | Fast | — | No | 500K chars/month |
+| **Gemini 2.5 Flash** | Fast | Fast | — | No | Generous |
+
+<details>
+<summary>Experimental translation engines (hidden from UI)</summary>
+
+| Engine | Notes |
+|--------|-------|
+| TranslateGemma | 8s/sentence — too slow for real-time |
+| HY-MT1.5 | Under evaluation |
+| CT2 OPUS-MT | CTranslate2 variant |
+| CT2 Madlad-400 | CTranslate2, 450+ languages |
+| ANE | Apple Neural Engine backend |
+
+Removed: ALMA-Ja, Gemma-2-JPN
+</details>
 
 ## Usage
 
@@ -96,7 +128,7 @@ Microphone → Silero VAD → STT Engine → Translator → Subtitle Overlay
 
 - **Cascade mode**: Independent STT + Translator engines
 - **Streaming**: Local Agreement algorithm for stable interim display
-- **UtilityProcess**: TranslateGemma runs in isolated process (node-llama-cpp)
+- **UtilityProcess**: Local LLM engines run in isolated process (node-llama-cpp)
 - **Plugin system**: Drop-in engine plugins via manifest files
 
 ### Adding a Translation Engine
@@ -119,9 +151,9 @@ export class MyTranslator implements TranslatorEngine {
 
 - **Framework**: Electron + React + TypeScript
 - **Build**: electron-vite
-- **STT**: whisper.cpp, mlx-whisper, Moonshine AI
+- **STT**: whisper.cpp (native), MLX Whisper (Apple Silicon)
 - **VAD**: Silero VAD (@ricky0123/vad-web)
-- **Translation**: Google, DeepL, Azure, Gemini, OPUS-MT, TranslateGemma 4B
+- **Translation**: OPUS-MT (fast), Hunyuan-MT 7B (quality), Google, DeepL, Gemini
 - **LLM**: node-llama-cpp (meeting summaries, context-aware translation)
 - **Testing**: Vitest
 


### PR DESCRIPTION
## Summary
- Update README.md with current primary engines (2 STT + 5 translation), benchmark numbers, and experimental/removed engine details
- Update CLAUDE.md Key Gotchas with engine-specific notes (TranslateGemma too slow, Hunyuan-MT quality-only, removed engines)
- Update AGENTS.md project overview, tech stack, and module structure to reflect current engine landscape
- Update .claude/rules/engines.md with full engine inventory tables, benchmark results, and experimental/removed categorization

## Test plan
- [x] Verify `npm run typecheck` has no new errors (pre-existing errors only)
- [ ] Review all updated docs for accuracy against benchmark data