### PR TITLE
Improve runtime: Python 3.12 fallback, timing logs, VAD tuning

### DIFF
--- a/src/engines/stt/MlxWhisperEngine.ts
+++ b/src/engines/stt/MlxWhisperEngine.ts
@@ -116,11 +116,13 @@ function findPython3WithMlxWhisper(): string {
     } catch { /* mlx_whisper not installed in this venv */ }
   }
 
-  // Fall back to system python3
-  try {
-    execSync('python3 -c "import mlx_whisper"', { stdio: 'ignore', timeout: 5000 })
-    return 'python3'
-  } catch { /* not available */ }
+  // Try versioned python binaries (prefer 3.12/3.13 over 3.14 due to native extension compatibility)
+  for (const bin of ['python3.12', 'python3.13', 'python3']) {
+    try {
+      execSync(`${bin} -c "import mlx_whisper"`, { stdio: 'ignore', timeout: 5000 })
+      return bin
+    } catch { /* not available or mlx_whisper not installed */ }
+  }
 
   throw new Error('mlx-whisper not found')
 }

--- a/src/engines/translator/OpusMTTranslator.ts
+++ b/src/engines/translator/OpusMTTranslator.ts
@@ -61,6 +61,10 @@ export class OpusMTTranslator implements TranslatorEngine {
     if (!text.trim()) return ''
     if (from === to) return text
 
+    // Filter too-short input that causes hallucinations
+    const trimmed = text.trim()
+    if (trimmed.length < 3) return ''
+
     const pipe = from === 'ja' ? this.jaToEn : this.enToJa
     if (!pipe) {
       console.error(`[opus-mt] Pipeline not initialized for ${from}→${to}`)
@@ -68,7 +72,15 @@ export class OpusMTTranslator implements TranslatorEngine {
     }
 
     const result = await pipe(text)
-    return result[0]?.translation_text || ''
+    const translated = result[0]?.translation_text || ''
+
+    // Detect hallucination: if output is much longer than input, likely garbage
+    if (translated.length > trimmed.length * 5 && trimmed.length < 20) {
+      console.warn(`[opus-mt] Hallucination detected: "${trimmed}" → "${translated.substring(0, 50)}..." (filtered)`)
+      return ''
+    }
+
+    return translated
   }
 
   async dispose(): Promise<void> {

--- a/src/main/audio-handlers.ts
+++ b/src/main/audio-handlers.ts
@@ -60,11 +60,14 @@ export function registerAudioHandlers(ctx: AppContext): void {
     const chunk = toValidAudioChunk(audioData)
     if (!chunk) return null
 
+    const t0 = performance.now()
     try {
-      return await ctx.pipeline.process(chunk, 16000)
+      const result = await ctx.pipeline.process(chunk, 16000)
+      const elapsed = (performance.now() - t0).toFixed(0)
+      if (result) log.info(`process-audio: ${elapsed}ms, ${(chunk.length / 16000).toFixed(1)}s audio`)
+      return result
     } catch (err) {
       log.error('Pipeline error:', err)
-      // #43: propagate error to renderer
       const message = sanitizeErrorMessage(err instanceof Error ? err.message : String(err))
       ctx.mainWindow?.webContents.send('status-update', `Processing error: ${message}`)
       return null
@@ -78,8 +81,12 @@ export function registerAudioHandlers(ctx: AppContext): void {
     const chunk = toValidAudioChunk(audioData)
     if (!chunk) return null
 
+    const t0 = performance.now()
     try {
-      return await ctx.pipeline.processStreaming(chunk, 16000)
+      const result = await ctx.pipeline.processStreaming(chunk, 16000)
+      const elapsed = (performance.now() - t0).toFixed(0)
+      if (result) log.info(`streaming: ${elapsed}ms, ${(chunk.length / 16000).toFixed(1)}s audio`)
+      return result
     } catch (err) {
       log.error('Streaming pipeline error:', err)
       return null
@@ -93,8 +100,12 @@ export function registerAudioHandlers(ctx: AppContext): void {
     const chunk = toValidAudioChunk(audioData)
     if (!chunk) return null
 
+    const t0 = performance.now()
     try {
-      return await ctx.pipeline.finalizeStreaming(chunk, 16000)
+      const result = await ctx.pipeline.finalizeStreaming(chunk, 16000)
+      const elapsed = (performance.now() - t0).toFixed(0)
+      if (result) log.info(`finalize: ${elapsed}ms, ${(chunk.length / 16000).toFixed(1)}s audio`)
+      return result
     } catch (err) {
       log.error('Finalize streaming error:', err)
       return null

--- a/src/pipeline/TranslationPipeline.ts
+++ b/src/pipeline/TranslationPipeline.ts
@@ -378,8 +378,14 @@ export class TranslationPipeline extends EventEmitter {
   ): Promise<TranslationResult | null> {
     if (!this.sttEngine) return null
 
+    const t0 = performance.now()
     const sttResult = await this.sttEngine.processAudio(audioChunk, sampleRate)
-    if (!sttResult || !sttResult.isFinal || !sttResult.text.trim()) return null
+    const sttMs = (performance.now() - t0).toFixed(0)
+    if (!sttResult || !sttResult.isFinal || !sttResult.text.trim()) {
+      console.log(`[pipeline] STT: ${sttMs}ms → (no result)`)
+      return null
+    }
+    console.log(`[pipeline] STT: ${sttMs}ms → "${sttResult.text}" [${sttResult.language}]`)
 
     const targetLang = this.resolveTargetLanguage(sttResult.language)
 
@@ -389,6 +395,7 @@ export class TranslationPipeline extends EventEmitter {
     }
 
     try {
+      const t1 = performance.now()
       const speakerId = sttResult.speakerId ?? this.speakerTracker.update(Date.now())
       const glossary = this.glossary.length > 0 ? this.glossary : undefined
       const translated = await this.translator.translate(
@@ -397,6 +404,8 @@ export class TranslationPipeline extends EventEmitter {
         targetLang,
         this.contextBuffer.getContext(glossary, speakerId)
       )
+      const translateMs = (performance.now() - t1).toFixed(0)
+      console.log(`[pipeline] Translate: ${translateMs}ms → "${translated}"`)
 
       this.contextBuffer.add(sttResult.text, translated, speakerId)
 
@@ -467,14 +476,18 @@ export class TranslationPipeline extends EventEmitter {
     this.processingCount++
     this.streamingLock = true
     try {
+      const t0 = performance.now()
       const sttResult = await this.sttEngine.processAudio(audioBuffer, sampleRate)
+      const sttMs = (performance.now() - t0).toFixed(0)
       if (!sttResult || !sttResult.text.trim()) {
+        console.log(`[pipeline:stream] STT: ${sttMs}ms → (no result, ${(audioBuffer.length / sampleRate).toFixed(1)}s audio)`)
         // Reset agreement on silence to prevent stale state accumulation (#75)
         this.agreement.reset()
         this.lastTranslatedConfirmed = ''
         this.simulMtPreviousOutput = ''
         return null
       }
+      console.log(`[pipeline:stream] STT: ${sttMs}ms → "${sttResult.text}" [${sttResult.language}]`)
 
       const agreement = this.agreement.update(sttResult.text)
       const targetLang = this.resolveTargetLanguage(sttResult.language)

--- a/src/renderer/hooks/useAudioCapture.ts
+++ b/src/renderer/hooks/useAudioCapture.ts
@@ -30,7 +30,7 @@ export interface NoiseSuppressionProcessor {
   destroy: () => Promise<void>
 }
 
-const STREAMING_INTERVAL_MS = 2000
+const STREAMING_INTERVAL_MS = 1000
 const SAMPLE_RATE = 16000
 
 export function useAudioCapture(noiseSuppression?: NoiseSuppressionProcessor): UseAudioCaptureReturn {
@@ -160,10 +160,10 @@ export function useAudioCapture(noiseSuppression?: NoiseSuppressionProcessor): U
         return rawStream
       },
       // Override with more sensitive thresholds for real-time translation
-      positiveSpeechThreshold: 0.3,
-      negativeSpeechThreshold: 0.15,
-      redemptionMs: 1400,
-      minSpeechMs: 400,
+      positiveSpeechThreshold: 0.25,
+      negativeSpeechThreshold: 0.1,
+      redemptionMs: 800,
+      minSpeechMs: 250,
       // ScriptProcessor for Electron compatibility
       processorType: 'ScriptProcessor',
       // Serve ONNX model and WASM from public/vad/
@@ -178,7 +178,7 @@ export function useAudioCapture(noiseSuppression?: NoiseSuppressionProcessor): U
 
         // #53: accumulate frames in circular buffer during speech
         if (isSpeakingRef.current) {
-          const maxFrames = Math.floor((30 * SAMPLE_RATE) / frame.length)
+          const maxFrames = Math.floor((5 * SAMPLE_RATE) / frame.length)
           const buf = rollingBufferRef.current
           if (buf.length < maxFrames && !rollingBufferFullRef.current) {
             buf.push(new Float32Array(frame))


### PR DESCRIPTION
## Summary
- MlxWhisperEngine: prefer python3.12/3.13 to avoid Python 3.14 tiktoken SEGV
- OpusMTTranslator: hallucination filter for short inputs
- Pipeline timing logs: STT and translate latency visible in console
- VAD: faster speech detection, 1s streaming interval, 5s max rolling buffer