### PR TITLE
Fix whisper-node-addon crash under concurrent streaming calls

### DIFF
--- a/src/engines/stt/WhisperLocalEngine.ts
+++ b/src/engines/stt/WhisperLocalEngine.ts
@@ -11,8 +11,10 @@ export class WhisperLocalEngine implements STTEngine {
 
   private modelPath = ''
   private onProgress?: (message: string) => void
-  private processing = false
   private modelVariant?: WhisperVariant
+
+  // Promise-based mutex — queues callers so only one transcribe() runs at a time (#363)
+  private mutex: Promise<void> = Promise.resolve()
 
   constructor(options?: { onProgress?: (message: string) => void; modelVariant?: WhisperVariant }) {
     this.onProgress = options?.onProgress
@@ -33,9 +35,20 @@ export class WhisperLocalEngine implements STTEngine {
 
   async processAudio(audioChunk: Float32Array, _sampleRate: number): Promise<STTResult | null> {
     if (!this.modelPath) return null
-    // Serialize calls — whisper-node-addon uses Metal GPU which is not thread-safe
-    if (this.processing) return null
-    this.processing = true
+
+    // Promise-based mutex — serializes all calls so whisper-node-addon's
+    // Metal GPU context is never entered concurrently (#363).
+    // Each call chains onto the previous promise, guaranteeing FIFO order.
+    let release: () => void
+    const gate = new Promise<void>((resolve) => { release = resolve })
+    const prev = this.mutex
+    this.mutex = gate
+
+    try {
+      await prev
+    } catch {
+      // Previous call's error doesn't affect us
+    }
 
     try {
       const result = await transcribe({
@@ -63,7 +76,7 @@ export class WhisperLocalEngine implements STTEngine {
       console.error('Whisper transcription error:', err)
       return null
     } finally {
-      this.processing = false
+      release!()
     }
   }
 

--- a/src/main/audio-handlers.ts
+++ b/src/main/audio-handlers.ts
@@ -53,13 +53,21 @@ function toValidAudioChunk(audioData: unknown): Float32Array | null {
 
 /** Register audio processing IPC handlers */
 export function registerAudioHandlers(ctx: AppContext): void {
+  // IPC-level concurrency flags — drop duplicate requests before they reach
+  // the pipeline to prevent concurrent native addon calls (#363)
+  let processingAudio = false
+  let processingStreaming = false
+  let processingFinalize = false
+
   // Process audio chunk from renderer
   ipcMain.handle('process-audio', async (_event, audioData: unknown) => {
     if (!ctx.pipeline?.running) return null
+    if (processingAudio) return null
 
     const chunk = toValidAudioChunk(audioData)
     if (!chunk) return null
 
+    processingAudio = true
     const t0 = performance.now()
     try {
       const result = await ctx.pipeline.process(chunk, 16000)
@@ -71,16 +79,22 @@ export function registerAudioHandlers(ctx: AppContext): void {
       const message = sanitizeErrorMessage(err instanceof Error ? err.message : String(err))
       ctx.mainWindow?.webContents.send('status-update', `Processing error: ${message}`)
       return null
+    } finally {
+      processingAudio = false
     }
   })
 
   // Process streaming audio (rolling buffer during speech)
   ipcMain.handle('process-audio-streaming', async (_event, audioData: unknown) => {
     if (!ctx.pipeline?.running) return null
+    // Drop if another streaming call is in-flight — the next interval
+    // will resend accumulated audio via the rolling buffer (#363)
+    if (processingStreaming) return null
 
     const chunk = toValidAudioChunk(audioData)
     if (!chunk) return null
 
+    processingStreaming = true
     const t0 = performance.now()
     try {
       const result = await ctx.pipeline.processStreaming(chunk, 16000)
@@ -90,16 +104,20 @@ export function registerAudioHandlers(ctx: AppContext): void {
     } catch (err) {
       log.error('Streaming pipeline error:', err)
       return null
+    } finally {
+      processingStreaming = false
     }
   })
 
   // Finalize streaming (speech segment ended)
   ipcMain.handle('finalize-streaming', async (_event, audioData: unknown) => {
     if (!ctx.pipeline?.running) return null
+    if (processingFinalize) return null
 
     const chunk = toValidAudioChunk(audioData)
     if (!chunk) return null
 
+    processingFinalize = true
     const t0 = performance.now()
     try {
       const result = await ctx.pipeline.finalizeStreaming(chunk, 16000)
@@ -109,6 +127,8 @@ export function registerAudioHandlers(ctx: AppContext): void {
     } catch (err) {
       log.error('Finalize streaming error:', err)
       return null
+    } finally {
+      processingFinalize = false
     }
   })
 }


### PR DESCRIPTION
## Summary
- Replace boolean `processing` flag in `WhisperLocalEngine` with a promise-based mutex that serializes all `transcribe()` calls, preventing concurrent entry into the native addon's Metal GPU context
- Add IPC-level concurrency guards in `audio-handlers.ts` to drop duplicate `process-audio`, `process-audio-streaming`, and `finalize-streaming` requests before they reach the pipeline
- Three layers of defense: IPC guard (drop) → pipeline streamingLock (drop) → engine mutex (queue)

Closes #363