### PR TITLE
Fix OPUS-MT hallucination on short/ambiguous Japanese input

### DIFF
--- a/src/engines/translator/OpusMTTranslator.ts
+++ b/src/engines/translator/OpusMTTranslator.ts
@@ -1,6 +1,7 @@
 import { app } from 'electron'
 import { join } from 'path'
 import type { TranslatorEngine, Language } from '../types'
+import { isHallucination } from './hallucination-filter'
 
 // Dynamic import for ESM-only @huggingface/transformers
 type TranslationPipeline = ((text: string) => Promise<Array<{ translation_text: string }>>) & {
@@ -74,9 +75,8 @@ export class OpusMTTranslator implements TranslatorEngine {
     const result = await pipe(text)
     const translated = result[0]?.translation_text || ''
 
-    // Detect hallucination: if output is much longer than input, likely garbage
-    if (translated.length > trimmed.length * 5 && trimmed.length < 20) {
-      console.warn(`[opus-mt] Hallucination detected: "${trimmed}" → "${translated.substring(0, 50)}..." (filtered)`)
+    if (isHallucination(trimmed, translated, from, to)) {
+      console.warn(`[opus-mt] Hallucination detected: "${trimmed}" → "${translated.substring(0, 80)}..." (filtered)`)
       return ''
     }
 

--- a/src/engines/translator/hallucination-filter.test.ts
+++ b/src/engines/translator/hallucination-filter.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from 'vitest'
+import { isHallucination } from './hallucination-filter'
+
+describe('isHallucination', () => {
+  describe('length ratio', () => {
+    it('rejects output 3x longer than short input (< 10 chars)', () => {
+      // 4 chars input, 13 chars output = 3.25x
+      expect(isHallucination('おやかだ', 'a'.repeat(13), 'ja', 'en')).toBe(true)
+    })
+
+    it('allows reasonable length output for short input', () => {
+      expect(isHallucination('こんにちは', 'Hello', 'ja', 'en')).toBe(false)
+    })
+
+    it('allows longer output for longer input', () => {
+      const input = '今日の会議は午後三時から始まります'
+      const output = 'The meeting starts at 3pm today'
+      expect(isHallucination(input, output, 'ja', 'en')).toBe(false)
+    })
+  })
+
+  describe('script mismatch', () => {
+    it('rejects CJK-heavy output for JA→EN translation', () => {
+      expect(isHallucination('テスト', '漢字漢字漢字', 'ja', 'en')).toBe(true)
+    })
+
+    it('allows mostly-ASCII output for JA→EN', () => {
+      expect(isHallucination('テスト', 'test', 'ja', 'en')).toBe(false)
+    })
+
+    it('rejects all-ASCII output for EN→JA', () => {
+      expect(isHallucination('hello world', 'some random english', 'en', 'ja')).toBe(true)
+    })
+
+    it('allows CJK output for EN→JA', () => {
+      expect(isHallucination('hello', 'こんにちは', 'en', 'ja')).toBe(false)
+    })
+  })
+
+  describe('repetition detection', () => {
+    it('rejects word-level repetition', () => {
+      expect(isHallucination('テスト', 'word word word word word', 'ja', 'en')).toBe(true)
+    })
+
+    it('rejects substring repetition', () => {
+      expect(isHallucination('テスト', 'abcabcabcabc', 'ja', 'en')).toBe(true)
+    })
+
+    it('allows normal text with some repeated words', () => {
+      expect(isHallucination('彼は走って走った', 'He ran and ran', 'ja', 'en')).toBe(false)
+    })
+  })
+
+  describe('excessive punctuation', () => {
+    it('rejects output that is mostly punctuation', () => {
+      expect(isHallucination('テスト', '...---...!!!', 'ja', 'en')).toBe(true)
+    })
+
+    it('allows normal text with some punctuation', () => {
+      expect(isHallucination('元気ですか', 'How are you?', 'ja', 'en')).toBe(false)
+    })
+  })
+
+  describe('real-world hallucination examples', () => {
+    it('rejects nonsensical long output from short corrupt input', () => {
+      // Short garbage input producing long output
+      expect(isHallucination('おやかだ', 'The parent is also a child of the gods.', 'ja', 'en')).toBe(true)
+    })
+
+    it('returns false for empty output', () => {
+      expect(isHallucination('テスト', '', 'ja', 'en')).toBe(false)
+    })
+  })
+})

--- a/src/engines/translator/hallucination-filter.ts
+++ b/src/engines/translator/hallucination-filter.ts
@@ -1,0 +1,138 @@
+import type { Language } from '../types'
+
+// CJK Unicode ranges: Hiragana, Katakana, CJK Unified Ideographs, CJK Extension A/B, halfwidth katakana
+const CJK_REGEX = /[\u3000-\u30FF\u4E00-\u9FFF\u3400-\u4DBF\uF900-\uFAFF\uFF65-\uFF9F]/g
+// ASCII letters (basic Latin)
+const ASCII_LETTER_REGEX = /[A-Za-z]/g
+
+/**
+ * Detect whether OPUS-MT output is likely a hallucination.
+ * Checks multiple heuristics and returns true if any fire.
+ */
+export function isHallucination(
+  input: string,
+  output: string,
+  from: Language,
+  to: Language
+): boolean {
+  if (!output.trim()) return false
+
+  // 1. Length ratio check — tightened from 5x to 3x for short inputs
+  if (hasExcessiveLengthRatio(input, output)) return true
+
+  // 2. Character-class mismatch — output should match target language script
+  if (hasScriptMismatch(output, to)) return true
+
+  // 3. Repetition detection — hallucinated outputs often repeat phrases
+  if (hasRepetition(output)) return true
+
+  // 4. Excessive punctuation or special characters
+  if (hasExcessivePunctuation(output)) return true
+
+  return false
+}
+
+/**
+ * Check if output length is disproportionately long relative to input.
+ * Short inputs (< 10 chars) use a stricter 3x ratio.
+ * Medium inputs (< 30 chars) use 4x. Longer inputs use 5x.
+ */
+function hasExcessiveLengthRatio(input: string, output: string): boolean {
+  const inLen = input.length
+  const outLen = output.length
+
+  let maxRatio: number
+  if (inLen < 10) {
+    maxRatio = 3
+  } else if (inLen < 30) {
+    maxRatio = 4
+  } else {
+    maxRatio = 5
+  }
+
+  return outLen > inLen * maxRatio
+}
+
+/**
+ * Check if the output contains unexpected script for the target language.
+ * JA→EN: output should be mostly ASCII (allow small % of non-ASCII for names/loanwords)
+ * EN→JA: output should contain CJK characters
+ */
+function hasScriptMismatch(output: string, targetLang: Language): boolean {
+  const trimmed = output.trim()
+  if (trimmed.length === 0) return false
+
+  if (targetLang === 'en') {
+    // For English output, at least 70% should be ASCII letters, digits, spaces, or common punctuation
+    const asciiCount = (trimmed.match(/[\x20-\x7E]/g) || []).length
+    const ratio = asciiCount / trimmed.length
+    // If less than 60% ASCII, likely garbage
+    return ratio < 0.6
+  }
+
+  if (targetLang === 'ja') {
+    // For Japanese output, should contain at least some CJK characters
+    const cjkCount = (trimmed.match(CJK_REGEX) || []).length
+    // If no CJK at all in a non-trivial output, suspicious
+    return trimmed.length > 3 && cjkCount === 0
+  }
+
+  return false
+}
+
+/**
+ * Detect repetitive patterns in output — a common OPUS-MT hallucination symptom.
+ * Looks for repeated n-grams (words or character sequences).
+ */
+function hasRepetition(output: string): boolean {
+  const trimmed = output.trim()
+
+  // Word-level repetition: split into words, check if any word repeats 4+ times
+  const words = trimmed.toLowerCase().split(/\s+/).filter(Boolean)
+  if (words.length >= 4) {
+    const counts = new Map<string, number>()
+    for (const w of words) {
+      counts.set(w, (counts.get(w) || 0) + 1)
+    }
+    for (const [word, count] of counts) {
+      // Skip very short words (articles, prepositions) — they naturally repeat
+      if (word.length <= 2) continue
+      if (count >= 4 && count / words.length >= 0.4) return true
+    }
+  }
+
+  // Substring repetition: check if a substring (3-20 chars) repeats 3+ times consecutively
+  for (let len = 3; len <= Math.min(20, Math.floor(trimmed.length / 3)); len++) {
+    const pattern = trimmed.substring(0, len)
+    let repeats = 0
+    let pos = 0
+    while (pos + len <= trimmed.length) {
+      if (trimmed.substring(pos, pos + len) === pattern) {
+        repeats++
+        pos += len
+      } else {
+        break
+      }
+    }
+    if (repeats >= 3) return true
+  }
+
+  return false
+}
+
+/**
+ * Check if output is mostly punctuation/symbols — another hallucination indicator.
+ */
+function hasExcessivePunctuation(output: string): boolean {
+  const trimmed = output.trim()
+  if (trimmed.length < 3) return false
+
+  // Count alphanumeric + CJK chars
+  const meaningful =
+    (trimmed.match(ASCII_LETTER_REGEX) || []).length +
+    (trimmed.match(CJK_REGEX) || []).length +
+    (trimmed.match(/\d/g) || []).length
+
+  // If less than 30% meaningful characters, it's mostly symbols/punctuation
+  return meaningful / trimmed.length < 0.3
+}

--- a/src/pipeline/whisper-filter.test.ts
+++ b/src/pipeline/whisper-filter.test.ts
@@ -30,6 +30,31 @@ describe('filterWhisperHallucination', () => {
     expect(filterWhisperHallucination('  ---  ')).toBeNull()
   })
 
+  it('filters garbage Japanese fragments', () => {
+    // Short nonsensical kana (common STT errors)
+    expect(filterWhisperHallucination('おやかだ')).toBeNull()
+    expect(filterWhisperHallucination('かへえ')).toBeNull()
+    expect(filterWhisperHallucination('ぱぴ')).toBeNull()
+    // Single kana
+    expect(filterWhisperHallucination('あ')).toBeNull()
+  })
+
+  it('passes valid short Japanese through', () => {
+    expect(filterWhisperHallucination('はい')).toBe('はい')
+    expect(filterWhisperHallucination('そう')).toBe('そう')
+    expect(filterWhisperHallucination('なるほど')).toBe('なるほど')
+  })
+
+  it('passes valid longer Japanese through', () => {
+    expect(filterWhisperHallucination('今日の議題について')).toBe('今日の議題について')
+    expect(filterWhisperHallucination('会議を始めましょう')).toBe('会議を始めましょう')
+  })
+
+  it('filters mostly non-linguistic text', () => {
+    expect(filterWhisperHallucination('###$$$%%%')).toBeNull()
+    expect(filterWhisperHallucination('~!@#$%')).toBeNull()
+  })
+
   it('passes valid text through', () => {
     expect(filterWhisperHallucination('The meeting starts at 3pm')).toBe('The meeting starts at 3pm')
     expect(filterWhisperHallucination('今日の議題について')).toBe('今日の議題について')

--- a/src/pipeline/whisper-filter.ts
+++ b/src/pipeline/whisper-filter.ts
@@ -51,7 +51,71 @@ export function filterWhisperHallucination(text: string): string | null {
   // Filter text that is only punctuation or special characters
   if (/^[\s.,!?…。、！？・\-—]+$/.test(trimmed)) return null
 
+  // Filter single-kana or nonsensical short Japanese fragments (common STT garbage)
+  // These are typically misheard syllables that produce hallucinations in OPUS-MT
+  if (isGarbageJapanese(trimmed)) {
+    console.debug(`[whisper-filter] Filtered garbage Japanese: "${trimmed}"`)
+    return null
+  }
+
+  // Filter text that is mostly non-linguistic characters
+  if (isMostlyNonLinguistic(trimmed)) {
+    console.debug(`[whisper-filter] Filtered non-linguistic: "${trimmed}"`)
+    return null
+  }
+
   return trimmed
+}
+
+/**
+ * Detects short, likely-garbage Japanese text from STT errors.
+ * Patterns: isolated kana fragments, single kanji with particles, etc.
+ */
+function isGarbageJapanese(text: string): boolean {
+  // Only apply to short text (up to ~6 chars) that is Japanese
+  if (text.length > 8) return false
+  const hasJapanese = /[\u3040-\u30FF\u4E00-\u9FFF]/.test(text)
+  if (!hasJapanese) return false
+
+  // Common standalone Japanese words that are valid even when short
+  const commonWords = [
+    'はい', 'いいえ', 'うん', 'ええ', 'そう', 'まあ', 'ねえ',
+    'おはよう', 'すみません', 'ごめん', 'どうも', 'なるほど',
+    'よし', 'えっと', 'あのう', 'まじ', 'やば', 'うそ', 'へえ',
+    'ほら', 'さあ', 'もう', 'ねえ', 'だめ', 'いや', 'おい'
+  ]
+  if (commonWords.includes(text)) return false
+
+  // Pure hiragana/katakana text ≤ 4 chars is likely a STT fragment
+  // (real speech rarely produces isolated 1-4 kana without kanji or longer phrases)
+  const pureKana = /^[\u3040-\u30FF\u3000-\u303F\s]+$/.test(text)
+  if (pureKana && text.replace(/\s/g, '').length <= 4) return true
+
+  // Mixed but very short (≤ 3 chars) with unusual character combinations
+  // e.g., "おやかだ", "親もかへえ" — these are too short to be meaningful sentences
+  if (text.length <= 5) {
+    // Check if it contains archaic/uncommon kana combinations
+    // Heuristic: if the text has no common particles/endings in a grammatical position, suspect garbage
+    const commonEndings = /[。？！ます。です。した。って。ない。ある。いる。する。なる。れる。ている]$/
+    const commonPatterns = /^(これ|それ|あれ|この|その|あの|ここ|そこ|あそこ|今|私|僕|俺|彼|彼女)/
+    if (!commonEndings.test(text) && !commonPatterns.test(text)) {
+      // Very short Japanese without recognizable grammar — likely garbage
+      // (common standalone words already excluded above)
+      return true
+    }
+  }
+
+  return false
+}
+
+/**
+ * Checks if text is mostly non-linguistic (symbols, random chars, etc.)
+ */
+function isMostlyNonLinguistic(text: string): boolean {
+  if (text.length < 3) return false
+  // Count meaningful characters: letters (any script), digits
+  const meaningful = (text.match(/[\p{L}\p{N}]/gu) || []).length
+  return meaningful / text.length < 0.4
 }
 
 /**


### PR DESCRIPTION
## Description

Strengthens hallucination detection at two levels to address garbage OPUS-MT output from short/corrupted Japanese input:

**Translator-level (`hallucination-filter.ts` — new module):**
- Tiered length ratio check (3x for short input, 4x for medium, 5x for long — was flat 5x)
- Script mismatch detection (JA→EN output must be mostly ASCII; EN→JA must contain CJK)
- Repetition detection (word-level and substring-level)
- Excessive punctuation/symbol detection

**STT-level (`whisper-filter.ts`):**
- Filter garbage Japanese fragments: pure kana ≤4 chars, short text without recognizable grammar
- Common-word allowlist (はい, そう, なるほど, etc.) to avoid false positives
- Non-linguistic character filter (mostly symbols/punctuation)

Closes #362