### PR TITLE
Improve STT latency: shorter buffer, silence trimming, fast models

### DIFF
--- a/src/engines/model-downloader.ts
+++ b/src/engines/model-downloader.ts
@@ -9,7 +9,7 @@ export const MODEL_URL =
   'https://huggingface.co/kotoba-tech/kotoba-whisper-v2.0-ggml/resolve/main/ggml-kotoba-whisper-v2.0-q5_0.bin'
 
 /** Whisper model variant identifier */
-export type WhisperVariant = 'kotoba-v2.0' | 'large-v3-turbo'
+export type WhisperVariant = 'kotoba-v2.0' | 'large-v3-turbo' | 'base' | 'small'
 
 /** Whisper model variant configuration */
 export interface WhisperVariantConfig {
@@ -35,6 +35,20 @@ export const WHISPER_VARIANTS: Record<WhisperVariant, WhisperVariantConfig> = {
     sizeMB: 600,
     label: 'Large v3 Turbo (OpenAI)',
     description: 'Multilingual, 6x faster than large-v3, ~600MB'
+  },
+  'small': {
+    filename: 'ggml-small.bin',
+    url: 'https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-small.bin',
+    sizeMB: 466,
+    label: 'Small (Fast)',
+    description: 'Fast multilingual, lower accuracy, ~466MB'
+  },
+  'base': {
+    filename: 'ggml-base.bin',
+    url: 'https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-base.bin',
+    sizeMB: 142,
+    label: 'Base (Fastest)',
+    description: 'Fastest, lowest accuracy, ~142MB'
   }
 }
 

--- a/src/engines/stt/WhisperLocalEngine.ts
+++ b/src/engines/stt/WhisperLocalEngine.ts
@@ -19,8 +19,14 @@ export class WhisperLocalEngine implements STTEngine {
   constructor(options?: { onProgress?: (message: string) => void; modelVariant?: WhisperVariant }) {
     this.onProgress = options?.onProgress
     this.modelVariant = options?.modelVariant
-    this.name = this.modelVariant === 'large-v3-turbo'
-      ? 'Whisper Local (large-v3-turbo)'
+    const variantNames: Record<string, string> = {
+      'large-v3-turbo': 'large-v3-turbo',
+      'base': 'base',
+      'small': 'small'
+    }
+    const variantLabel = this.modelVariant ? variantNames[this.modelVariant] : null
+    this.name = variantLabel
+      ? `Whisper Local (${variantLabel})`
       : 'Whisper Local (kotoba-whisper-v2.0)'
   }
 

--- a/src/renderer/components/SettingsPanel.tsx
+++ b/src/renderer/components/SettingsPanel.tsx
@@ -449,10 +449,15 @@ function SettingsPanel(): React.JSX.Element {
   const sttDisplayName = (): string => {
     switch (sttEngine) {
       case 'mlx-whisper': return 'mlx-whisper (Apple Silicon)'
-      case 'whisper-local':
-        return whisperVariant === 'large-v3-turbo'
-          ? 'Whisper (large-v3-turbo)'
-          : 'Whisper (kotoba-v2.0)'
+      case 'whisper-local': {
+        const variantLabels: Record<string, string> = {
+          'kotoba-v2.0': 'kotoba-v2.0',
+          'large-v3-turbo': 'large-v3-turbo',
+          'small': 'small, fast',
+          'base': 'base, fastest'
+        }
+        return `Whisper (${variantLabels[whisperVariant] || whisperVariant})`
+      }
       default: return sttEngine
     }
   }

--- a/src/renderer/components/settings/STTSettings.tsx
+++ b/src/renderer/components/settings/STTSettings.tsx
@@ -48,10 +48,22 @@ export function STTSettings({
           >
             <option value="kotoba-v2.0">Kotoba Whisper v2.0 (Japanese-optimized, ~540MB)</option>
             <option value="large-v3-turbo">Large v3 Turbo (Multilingual, 6x faster, ~600MB)</option>
+            <option value="small">Small (Fast mode, ~466MB)</option>
+            <option value="base">Base (Fastest mode, ~142MB)</option>
           </select>
           {whisperVariant === 'large-v3-turbo' && (
             <div style={{ marginTop: '4px', fontSize: '11px', color: '#94a3b8' }}>
               OpenAI large-v3-turbo: 809M params, 4 decoder layers, within 1-2% WER of large-v3.
+            </div>
+          )}
+          {whisperVariant === 'small' && (
+            <div style={{ marginTop: '4px', fontSize: '11px', color: '#f59e0b' }}>
+              Fast mode: lower latency (~1-2s) but reduced accuracy. Good for real-time with acceptable quality.
+            </div>
+          )}
+          {whisperVariant === 'base' && (
+            <div style={{ marginTop: '4px', fontSize: '11px', color: '#f59e0b' }}>
+              Fastest mode: minimal latency (&lt;1s) but significantly lower accuracy. Best for speed-critical use cases.
             </div>
           )}
         </div>

--- a/src/renderer/components/settings/shared.ts
+++ b/src/renderer/components/settings/shared.ts
@@ -28,7 +28,7 @@ export const ALL_LANGUAGES = Object.keys(LANGUAGE_LABELS) as Language[]
 export type EngineMode = 'auto' | 'rotation' | 'online' | 'online-deepl' | 'online-gemini' | 'offline-opus' | 'offline-hunyuan-mt' | 'offline-hybrid'
 
 export type SttEngineType = 'whisper-local' | 'mlx-whisper'
-export type WhisperVariantType = 'kotoba-v2.0' | 'large-v3-turbo'
+export type WhisperVariantType = 'kotoba-v2.0' | 'large-v3-turbo' | 'base' | 'small'
 export type SubtitlePositionType = 'top' | 'bottom'
 
 export interface DisplayInfo {

--- a/src/renderer/hooks/useAudioCapture.ts
+++ b/src/renderer/hooks/useAudioCapture.ts
@@ -30,8 +30,48 @@ export interface NoiseSuppressionProcessor {
   destroy: () => Promise<void>
 }
 
-const STREAMING_INTERVAL_MS = 1000
+const DEFAULT_STREAMING_INTERVAL_MS = 1500
 const SAMPLE_RATE = 16000
+const MAX_ROLLING_BUFFER_SECONDS = 3
+/** RMS threshold below which a frame is considered silence for trimming */
+const SILENCE_RMS_THRESHOLD = 0.01
+
+/**
+ * Trim leading and trailing silence from audio buffer (#361).
+ * Uses frame-level RMS analysis to find speech boundaries.
+ * Keeps a small padding (160 samples = 10ms at 16kHz) around speech.
+ */
+function trimSilence(buffer: Float32Array): Float32Array | null {
+  const frameSize = 160 // 10ms at 16kHz
+  const padding = 160 // 10ms padding
+  let firstSpeechSample = -1
+  let lastSpeechSample = -1
+
+  for (let i = 0; i < buffer.length; i += frameSize) {
+    const end = Math.min(i + frameSize, buffer.length)
+    let sum = 0
+    for (let j = i; j < end; j++) {
+      sum += buffer[j] * buffer[j]
+    }
+    const rms = Math.sqrt(sum / (end - i))
+    if (rms > SILENCE_RMS_THRESHOLD) {
+      if (firstSpeechSample === -1) firstSpeechSample = i
+      lastSpeechSample = end
+    }
+  }
+
+  if (firstSpeechSample === -1) return null // All silence
+
+  const start = Math.max(0, firstSpeechSample - padding)
+  const end = Math.min(buffer.length, lastSpeechSample + padding)
+  const trimmedLength = end - start
+
+  // Only trim if we save at least 20% of the audio
+  if (trimmedLength >= buffer.length * 0.8) return buffer
+
+  if (trimmedLength < SAMPLE_RATE * 0.3) return null // Too short after trimming
+  return buffer.subarray(start, end)
+}
 
 export function useAudioCapture(noiseSuppression?: NoiseSuppressionProcessor): UseAudioCaptureReturn {
   const [devices, setDevices] = useState<AudioDevice[]>([])
@@ -113,7 +153,9 @@ export function useAudioCapture(noiseSuppression?: NoiseSuppressionProcessor): U
       buffer.set(frame, offset)
       offset += frame.length
     }
-    return buffer
+
+    // #361: Trim leading/trailing silence to reduce audio sent to Whisper
+    return trimSilence(buffer)
   }, [])
 
   const startStreamingTimer = useCallback(() => {
@@ -125,7 +167,7 @@ export function useAudioCapture(noiseSuppression?: NoiseSuppressionProcessor): U
         console.log(`[audio-capture] Streaming chunk: ${buffer.length} samples (${(buffer.length / SAMPLE_RATE).toFixed(1)}s)`)
         streamingCallbackRef.current?.(buffer)
       }
-    }, STREAMING_INTERVAL_MS)
+    }, DEFAULT_STREAMING_INTERVAL_MS)
   }, [getRollingBuffer])
 
   const stopStreamingTimer = useCallback(() => {
@@ -176,9 +218,9 @@ export function useAudioCapture(noiseSuppression?: NoiseSuppressionProcessor): U
         const rms = Math.sqrt(sum / frame.length)
         setVolume(Math.min(1, rms * 5))
 
-        // #53: accumulate frames in circular buffer during speech
+        // #53: accumulate frames in circular buffer during speech (#361: reduced from 5s to 3s)
         if (isSpeakingRef.current) {
-          const maxFrames = Math.floor((5 * SAMPLE_RATE) / frame.length)
+          const maxFrames = Math.floor((MAX_ROLLING_BUFFER_SECONDS * SAMPLE_RATE) / frame.length)
           const buf = rollingBufferRef.current
           if (buf.length < maxFrames && !rollingBufferFullRef.current) {
             buf.push(new Float32Array(frame))


### PR DESCRIPTION
## Summary
- Reduce rolling audio buffer from 5s to 3s — proportionally reduces Whisper processing time
- Add VAD-based silence trimming that strips leading/trailing silence before sending to Whisper
- Increase streaming interval from 1s to 1.5s to reduce redundant STT calls during speech
- Add whisper-small (~466MB) and whisper-base (~142MB) fast model variants for low-latency mode
- Update STT settings UI with fast model options and latency/quality trade-off descriptions

## Test plan
- [ ] Verify build passes (`npm run build`)
- [ ] Verify lint passes (`npm run lint`)
- [ ] Verify tests pass (`npx vitest run` — 66 tests)
- [ ] Manual test: start session with whisper-local, confirm streaming chunks are ~3s max
- [ ] Manual test: select "Small (Fast mode)" variant, confirm model downloads and transcribes
- [ ] Manual test: select "Base (Fastest mode)" variant, confirm model downloads and transcribes
- [ ] Manual test: verify silence trimming reduces audio length in console logs
- [ ] Manual test: confirm streaming interval feels more responsive (1.5s vs 1s with less overlap)

Closes #361