### PR TITLE
Consolidate duplicate WebSocket port constant

### DIFF
--- a/src/main/constants.ts
+++ b/src/main/constants.ts
@@ -1,0 +1,2 @@
+/** Default WebSocket port for Chrome extension audio server */
+export const DEFAULT_WS_PORT = 9876

--- a/src/main/ipc-handlers.ts
+++ b/src/main/ipc-handlers.ts
@@ -21,6 +21,7 @@ import { getSubtitleHeight } from './window-manager'
 import { WsAudioServer } from './ws-audio-server'
 import type { AppContext } from './app-context'
 import type { EngineConfig } from '../engines/types'
+import { DEFAULT_WS_PORT } from './constants'
 
 const log = createLogger('ipc')
 
@@ -40,8 +41,6 @@ interface PipelineStartConfig extends EngineConfig {
   microsoftApiKey?: string
   microsoftRegion?: string
 }
-
-const DEFAULT_WS_PORT = 9876
 
 /** Register all IPC handlers (pipeline, settings, session, display, ws-audio) */
 export function registerIpcHandlers(ctx: AppContext): void {

--- a/src/main/store.ts
+++ b/src/main/store.ts
@@ -1,5 +1,6 @@
 import Store from 'electron-store'
 import type { GlossaryEntry, Language, SourceLanguage } from '../engines/types'
+import { DEFAULT_WS_PORT } from './constants'
 
 export interface QuotaRecord {
   monthKey: string
@@ -103,7 +104,7 @@ export const store = new Store<AppSettings>({
     sherpaOnnxModel: 'whisper-base',
     sourceLanguage: 'auto',
     targetLanguage: 'en',
-    wsAudioPort: 9876,
+    wsAudioPort: DEFAULT_WS_PORT,
     noiseSuppressionEnabled: false
   }
 })

--- a/src/main/ws-audio-server.ts
+++ b/src/main/ws-audio-server.ts
@@ -17,6 +17,7 @@ import { createServer, type Server, type IncomingMessage } from 'http'
 import { WebSocketServer, WebSocket } from 'ws'
 import { EventEmitter } from 'events'
 import { createLogger } from './logger'
+import { DEFAULT_WS_PORT } from './constants'
 
 const log = createLogger('ws-audio')
 
@@ -41,7 +42,7 @@ export class WsAudioServer extends EventEmitter {
   private _port: number
   private _running = false
 
-  constructor(port = 9876) {
+  constructor(port = DEFAULT_WS_PORT) {
     super()
     this._port = port
   }


### PR DESCRIPTION
## Description

Extract `DEFAULT_WS_PORT = 9876` into a single shared `src/main/constants.ts` file and import it in the 3 files that previously defined it independently:

- `src/main/ws-audio-server.ts` — constructor default parameter
- `src/main/ipc-handlers.ts` — fallback port for WS audio handlers
- `src/main/store.ts` — electron-store default value

Closes #373