### PR TITLE
Centralize hardcoded sample rate constant

### DIFF
--- a/src/main/audio-handlers.ts
+++ b/src/main/audio-handlers.ts
@@ -1,6 +1,7 @@
 import { ipcMain } from 'electron'
 import { sanitizeErrorMessage } from './error-utils'
 import { createLogger } from './logger'
+import { SAMPLE_RATE } from './constants'
 import type { AppContext } from './app-context'
 
 const log = createLogger('audio')
@@ -70,9 +71,9 @@ export function registerAudioHandlers(ctx: AppContext): void {
     processingAudio = true
     const t0 = performance.now()
     try {
-      const result = await ctx.pipeline.process(chunk, 16000)
+      const result = await ctx.pipeline.process(chunk, SAMPLE_RATE)
       const elapsed = (performance.now() - t0).toFixed(0)
-      if (result) log.info(`process-audio: ${elapsed}ms, ${(chunk.length / 16000).toFixed(1)}s audio`)
+      if (result) log.info(`process-audio: ${elapsed}ms, ${(chunk.length / SAMPLE_RATE).toFixed(1)}s audio`)
       return result
     } catch (err) {
       log.error('Pipeline error:', err)
@@ -97,9 +98,9 @@ export function registerAudioHandlers(ctx: AppContext): void {
     processingStreaming = true
     const t0 = performance.now()
     try {
-      const result = await ctx.pipeline.processStreaming(chunk, 16000)
+      const result = await ctx.pipeline.processStreaming(chunk, SAMPLE_RATE)
       const elapsed = (performance.now() - t0).toFixed(0)
-      if (result) log.info(`streaming: ${elapsed}ms, ${(chunk.length / 16000).toFixed(1)}s audio`)
+      if (result) log.info(`streaming: ${elapsed}ms, ${(chunk.length / SAMPLE_RATE).toFixed(1)}s audio`)
       return result
     } catch (err) {
       log.error('Streaming pipeline error:', err)
@@ -120,9 +121,9 @@ export function registerAudioHandlers(ctx: AppContext): void {
     processingFinalize = true
     const t0 = performance.now()
     try {
-      const result = await ctx.pipeline.finalizeStreaming(chunk, 16000)
+      const result = await ctx.pipeline.finalizeStreaming(chunk, SAMPLE_RATE)
       const elapsed = (performance.now() - t0).toFixed(0)
-      if (result) log.info(`finalize: ${elapsed}ms, ${(chunk.length / 16000).toFixed(1)}s audio`)
+      if (result) log.info(`finalize: ${elapsed}ms, ${(chunk.length / SAMPLE_RATE).toFixed(1)}s audio`)
       return result
     } catch (err) {
       log.error('Finalize streaming error:', err)

--- a/src/main/constants.ts
+++ b/src/main/constants.ts
@@ -1,2 +1,5 @@
 /** Default WebSocket port for Chrome extension audio server */
 export const DEFAULT_WS_PORT = 9876
+
+/** Audio sample rate in Hz used across the pipeline (16kHz mono) */
+export const SAMPLE_RATE = 16000

--- a/src/main/ipc-handlers.ts
+++ b/src/main/ipc-handlers.ts
@@ -21,7 +21,7 @@ import { getSubtitleHeight } from './window-manager'
 import { WsAudioServer } from './ws-audio-server'
 import type { AppContext } from './app-context'
 import type { EngineConfig } from '../engines/types'
-import { DEFAULT_WS_PORT } from './constants'
+import { DEFAULT_WS_PORT, SAMPLE_RATE } from './constants'
 
 const log = createLogger('ipc')
 
@@ -413,7 +413,7 @@ export function registerIpcHandlers(ctx: AppContext): void {
         if (!ctx.pipeline?.running) return
 
         try {
-          await ctx.pipeline.process(chunk, 16000)
+          await ctx.pipeline.process(chunk, SAMPLE_RATE)
         } catch (err) {
           log.error('Pipeline processing error (ws-audio):', err)
         }

--- a/src/main/ws-audio-server.ts
+++ b/src/main/ws-audio-server.ts
@@ -17,7 +17,7 @@ import { createServer, type Server, type IncomingMessage } from 'http'
 import { WebSocketServer, WebSocket } from 'ws'
 import { EventEmitter } from 'events'
 import { createLogger } from './logger'
-import { DEFAULT_WS_PORT } from './constants'
+import { DEFAULT_WS_PORT, SAMPLE_RATE } from './constants'
 
 const log = createLogger('ws-audio')
 
@@ -31,8 +31,6 @@ export interface WsAudioServerEvents {
   /** Emitted on server errors */
   error: (error: Error) => void
 }
-
-const SAMPLE_RATE = 16000
 const MIN_SAMPLES = 8000 // 0.5s minimum
 
 export class WsAudioServer extends EventEmitter {


### PR DESCRIPTION
## Summary
- Add `SAMPLE_RATE = 16000` to `src/main/constants.ts`
- Replace all 6 hardcoded `16000` literals in `audio-handlers.ts` with the shared constant
- Replace hardcoded `16000` in `ipc-handlers.ts` (ws-audio forwarding)
- Replace local `SAMPLE_RATE` in `ws-audio-server.ts` with the shared import

Closes #374