### PR TITLE
Use constants.ts for hardcoded timeouts in experimental STT engines

### DIFF
--- a/src/engines/constants.ts
+++ b/src/engines/constants.ts
@@ -60,6 +60,13 @@ export const CT2_MADLAD400_TRANSLATE_TIMEOUT_MS = 15_000
 export const CT2_MADLAD400_INIT_TIMEOUT_MS = 180_000
 
 // ---------------------------------------------------------------------------
+// Python discovery (execSync import checks)
+// ---------------------------------------------------------------------------
+
+/** Timeout for `python3 -c "import ..."` checks when locating a suitable venv (ms) */
+export const PYTHON_IMPORT_CHECK_TIMEOUT_MS = 5_000
+
+// ---------------------------------------------------------------------------
 // STT bridges (mlx-whisper, Qwen-ASR)
 // ---------------------------------------------------------------------------
 

--- a/src/engines/stt/MlxWhisperEngine.ts
+++ b/src/engines/stt/MlxWhisperEngine.ts
@@ -5,7 +5,7 @@ import { tmpdir, homedir } from 'os'
 import type { STTEngine, STTResult, Language } from '../types'
 import { ALL_LANGUAGES } from '../types'
 import { SubprocessBridge, type SpawnConfig, type InitResult } from '../SubprocessBridge'
-import { MLX_WHISPER_TRANSCRIBE_TIMEOUT_MS, MLX_WHISPER_INIT_TIMEOUT_MS } from '../constants'
+import { MLX_WHISPER_TRANSCRIBE_TIMEOUT_MS, MLX_WHISPER_INIT_TIMEOUT_MS, PYTHON_IMPORT_CHECK_TIMEOUT_MS } from '../constants'
 
 export class MlxWhisperEngine extends SubprocessBridge implements STTEngine {
   readonly id = 'mlx-whisper'
@@ -111,7 +111,7 @@ function findPython3WithMlxWhisper(): string {
   for (const p of venvPaths) {
     if (!existsSync(p)) continue
     try {
-      execSync(`${p} -c "import mlx_whisper"`, { stdio: 'ignore', timeout: 5000 })
+      execSync(`${p} -c "import mlx_whisper"`, { stdio: 'ignore', timeout: PYTHON_IMPORT_CHECK_TIMEOUT_MS })
       return p
     } catch { /* mlx_whisper not installed in this venv */ }
   }
@@ -119,7 +119,7 @@ function findPython3WithMlxWhisper(): string {
   // Try versioned python binaries (prefer 3.12/3.13 over 3.14 due to native extension compatibility)
   for (const bin of ['python3.12', 'python3.13', 'python3']) {
     try {
-      execSync(`${bin} -c "import mlx_whisper"`, { stdio: 'ignore', timeout: 5000 })
+      execSync(`${bin} -c "import mlx_whisper"`, { stdio: 'ignore', timeout: PYTHON_IMPORT_CHECK_TIMEOUT_MS })
       return bin
     } catch { /* not available or mlx_whisper not installed */ }
   }

--- a/src/engines/stt/QwenASREngine.ts
+++ b/src/engines/stt/QwenASREngine.ts
@@ -5,7 +5,7 @@ import { tmpdir, homedir } from 'os'
 import type { STTEngine, STTResult, Language } from '../types'
 import { ALL_LANGUAGES } from '../types'
 import { SubprocessBridge, type SpawnConfig, type InitResult } from '../SubprocessBridge'
-import { QWEN_ASR_TRANSCRIBE_TIMEOUT_MS, QWEN_ASR_INIT_TIMEOUT_MS } from '../constants'
+import { QWEN_ASR_TRANSCRIBE_TIMEOUT_MS, QWEN_ASR_INIT_TIMEOUT_MS, PYTHON_IMPORT_CHECK_TIMEOUT_MS } from '../constants'
 
 /** Qwen3-ASR model variant */
 export type QwenASRVariant = '0.6b' | '1.7b'
@@ -157,14 +157,14 @@ function findPython3WithQwenASR(): string {
   for (const p of venvPaths) {
     if (!existsSync(p)) continue
     try {
-      execSync(`${p} -c "import qwen_asr"`, { stdio: 'ignore', timeout: 5000 })
+      execSync(`${p} -c "import qwen_asr"`, { stdio: 'ignore', timeout: PYTHON_IMPORT_CHECK_TIMEOUT_MS })
       return p
     } catch { /* qwen_asr not installed in this venv */ }
   }
 
   // Fall back to system python3
   try {
-    execSync('python3 -c "import qwen_asr"', { stdio: 'ignore', timeout: 5000 })
+    execSync('python3 -c "import qwen_asr"', { stdio: 'ignore', timeout: PYTHON_IMPORT_CHECK_TIMEOUT_MS })
     return 'python3'
   } catch { /* not available */ }
 

--- a/src/engines/stt/SenseVoiceEngine.ts
+++ b/src/engines/stt/SenseVoiceEngine.ts
@@ -5,7 +5,7 @@ import { tmpdir, homedir } from 'os'
 import type { STTEngine, STTResult, Language } from '../types'
 import { ALL_LANGUAGES } from '../types'
 import { SubprocessBridge, type SpawnConfig, type InitResult } from '../SubprocessBridge'
-import { SENSEVOICE_TRANSCRIBE_TIMEOUT_MS, SENSEVOICE_INIT_TIMEOUT_MS } from '../constants'
+import { SENSEVOICE_TRANSCRIBE_TIMEOUT_MS, SENSEVOICE_INIT_TIMEOUT_MS, PYTHON_IMPORT_CHECK_TIMEOUT_MS } from '../constants'
 
 /**
  * SenseVoice STT engine using FunASR Python subprocess bridge.
@@ -130,14 +130,14 @@ function findPython3WithFunASR(): string {
   for (const p of venvPaths) {
     if (!existsSync(p)) continue
     try {
-      execSync(`${p} -c "import funasr"`, { stdio: 'ignore', timeout: 5000 })
+      execSync(`${p} -c "import funasr"`, { stdio: 'ignore', timeout: PYTHON_IMPORT_CHECK_TIMEOUT_MS })
       return p
     } catch { /* funasr not installed in this venv */ }
   }
 
   // Fall back to system python3
   try {
-    execSync('python3 -c "import funasr"', { stdio: 'ignore', timeout: 5000 })
+    execSync('python3 -c "import funasr"', { stdio: 'ignore', timeout: PYTHON_IMPORT_CHECK_TIMEOUT_MS })
     return 'python3'
   } catch { /* not available */ }
 


### PR DESCRIPTION
## Summary
- Added `PYTHON_IMPORT_CHECK_TIMEOUT_MS` constant (5000ms) to `src/engines/constants.ts` for the Python venv import-check `execSync` calls
- Replaced all 6 hardcoded `timeout: 5000` occurrences across `QwenASREngine`, `SenseVoiceEngine`, and `MlxWhisperEngine` with the new constant
- No other hardcoded timeouts remain in the engines directory

## Test plan
- [x] `npm run lint` passes (0 errors)
- [x] `npm run build` succeeds
- [x] `npx vitest run` — 66 tests pass

Closes #375