### PR TITLE
#385 Fix ESLint config for preload and vendored files

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -5,7 +5,20 @@ export default tseslint.config(
   eslint.configs.recommended,
   tseslint.configs.recommended,
   {
-    ignores: ['dist/', 'out/', 'node_modules/', 'chrome-extension/', 'benchmark/']
+    ignores: ['dist/', 'out/', 'node_modules/', 'chrome-extension/', 'benchmark/', 'src/renderer/public/vad/**']
+  },
+  // Preload scripts are compiled to CommonJS — allow exports/require globals
+  {
+    files: ['src/preload/**/*.js'],
+    languageOptions: {
+      globals: {
+        exports: 'writable',
+        require: 'readonly',
+        module: 'writable',
+        __dirname: 'readonly',
+        __filename: 'readonly'
+      }
+    }
   },
   {
     rules: {


### PR DESCRIPTION
## Summary
- Add CommonJS globals (`exports`, `require`, `module`, `__dirname`, `__filename`) override for `src/preload/**/*.js` to resolve "not defined" errors
- Add `src/renderer/public/vad/**` to ESLint ignore patterns to skip vendored minified files

## Verification
- `npm run lint`: 0 errors (was 16)
- `npm run build`: passes
- `npx vitest run`: 66 tests pass

Closes #385