### PR TITLE
Migrate VAD from ScriptProcessorNode to AudioWorkletNode

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,7 +27,7 @@ Before acting, always pause and reconsider. Re-read the requirements, re-check y
 - whisper-node-addon dylib has hardcoded `@rpath` from CI — postinstall adds local rpath via `install_name_tool`
 - Electron IPC cannot transfer `Float32Array` directly — use `Array.from()` in renderer, `new Float32Array()` in main
 - macOS microphone permission: Electron dev mode runs via Terminal — grant mic access to Terminal.app in System Preferences
-- `ScriptProcessorNode` is deprecated — migrate to `AudioWorkletNode` when stability is confirmed
+- VAD uses `AudioWorkletNode` via `processorType: 'AudioWorklet'` — do not revert to deprecated `ScriptProcessorNode`
 - electron-vite 2.x requires `build.lib.entry` for main/preload configs
 - Whisper model (~540MB) downloads on first launch — handle offline gracefully
 - TranslateGemma is experimental only (8s/sentence too slow for real-time) — OPUS-MT is the fast default (279ms)

--- a/src/renderer/hooks/useAudioCapture.ts
+++ b/src/renderer/hooks/useAudioCapture.ts
@@ -206,8 +206,8 @@ export function useAudioCapture(noiseSuppression?: NoiseSuppressionProcessor): U
       negativeSpeechThreshold: 0.1,
       redemptionMs: 800,
       minSpeechMs: 250,
-      // ScriptProcessor for Electron compatibility
-      processorType: 'ScriptProcessor',
+      // AudioWorklet runs audio processing off the main thread (replaces deprecated ScriptProcessor)
+      processorType: 'AudioWorklet',
       // Serve ONNX model and WASM from public/vad/
       baseAssetPath: '/vad/',
       onnxWASMBasePath: '/vad/',


### PR DESCRIPTION
## Summary
- Replace deprecated `ScriptProcessorNode` with `AudioWorkletNode` for VAD audio processing
- Change `processorType` from `'ScriptProcessor'` to `'AudioWorklet'` in `useAudioCapture.ts`
- Update CLAUDE.md gotcha to reflect migration is complete

The `@ricky0123/vad-web` library already supports `AudioWorklet` natively. The worklet file (`vad.worklet.bundle.min.js`) is already copied to the renderer public dir by the postinstall script. This moves audio processing off the main thread, improving UI responsiveness.

Closes #368