### PR TITLE
Centralize remaining inference params in slm-worker

### DIFF
--- a/src/main/slm-worker.ts
+++ b/src/main/slm-worker.ts
@@ -36,6 +36,12 @@ interface TranslateContextPayload {
 /** Context size for translation (short segments) */
 const TRANSLATION_CONTEXT_SIZE = 2048
 
+/** Inference parameters for summarization tasks */
+const SUMMARIZATION_PARAMS = {
+  temperature: 0.3,
+  maxTokens: 1024
+} as const
+
 let llama: Llama | null = null
 let model: LlamaModel | null = null
 let context: LlamaContext | null = null
@@ -324,10 +330,7 @@ Be concise and use bullet points.
 Transcript:
 ${transcript}`
 
-    const response = await session.prompt(prompt, {
-      temperature: 0.3,
-      maxTokens: 1024
-    })
+    const response = await session.prompt(prompt, SUMMARIZATION_PARAMS)
 
     session.dispose?.()
 


### PR DESCRIPTION
## Summary
- Extract `SUMMARIZATION_PARAMS` constant for the summarization handler's hardcoded `temperature: 0.3` and `maxTokens: 1024`
- PR #393 already centralized translation params via `getInferenceParams()` and `TRANSLATION_CONTEXT_SIZE`; this cleans up the last remaining scattered values

Closes #379