### PR TITLE
#380 Consolidate engine mode constant arrays

### DIFF
--- a/src/renderer/components/settings/TranslatorSettings.tsx
+++ b/src/renderer/components/settings/TranslatorSettings.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react'
 import { Section } from './Section'
-import { inputStyle, radioLabelStyle } from './shared'
+import { API_ENGINE_MODES, LLM_ENGINE_MODES, inputStyle, radioLabelStyle } from './shared'
 import type { EngineMode } from './shared'
 
 interface TranslatorSettingsProps {
@@ -65,8 +65,8 @@ export function TranslatorSettings({
   const [newGlossarySource, setNewGlossarySource] = useState('')
   const [newGlossaryTarget, setNewGlossaryTarget] = useState('')
 
-  const showLlmOptions = ['offline-hunyuan-mt', 'offline-hybrid'].includes(engineMode)
-  const isApiEngine = ['rotation', 'online', 'online-deepl', 'online-gemini'].includes(engineMode)
+  const showLlmOptions = LLM_ENGINE_MODES.includes(engineMode)
+  const isApiEngine = API_ENGINE_MODES.includes(engineMode)
 
   return (
     <>

--- a/src/renderer/components/settings/shared.ts
+++ b/src/renderer/components/settings/shared.ts
@@ -104,6 +104,9 @@ export const colorInputStyle: React.CSSProperties = {
 /** API-based engine modes that require at least one API key */
 export const API_ENGINE_MODES: EngineMode[] = ['rotation', 'online', 'online-deepl', 'online-gemini']
 
+/** LLM-based engine modes that support KV cache / SimulMT options */
+export const LLM_ENGINE_MODES: EngineMode[] = ['offline-hunyuan-mt', 'offline-hybrid']
+
 /** Display name for each engine mode */
 export function getEngineDisplayName(mode: EngineMode): string {
   switch (mode) {


### PR DESCRIPTION
## Summary
- Added `LLM_ENGINE_MODES` constant to `shared.ts` for LLM-based engine modes (`offline-hunyuan-mt`, `offline-hybrid`)
- Replaced hardcoded arrays in `TranslatorSettings.tsx` with `API_ENGINE_MODES` and `LLM_ENGINE_MODES` from `shared.ts`

PR #391 already extracted `API_ENGINE_MODES` and centralized utilities in `shared.ts`, but `TranslatorSettings.tsx` still had two inline arrays that duplicated those constants. This PR eliminates the remaining duplication.

Closes #380