### PR TITLE
Fix pipeline event listener accumulation on reinitialization

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -35,7 +35,13 @@ const ctx: AppContext = {
   wsAudioServer: null
 }
 
-function initPipeline(): void {
+async function initPipeline(): Promise<void> {
+  // Dispose previous pipeline to prevent listener accumulation on reinitialization (#383)
+  if (ctx.pipeline) {
+    await ctx.pipeline.dispose()
+    ctx.pipeline = null
+  }
+
   ctx.pipeline = new TranslationPipeline()
 
   // Register STT engines
@@ -163,8 +169,8 @@ registerUpdateHandlers(ctx)
 
 // --- App Lifecycle ---
 
-app.whenReady().then(() => {
-  initPipeline()
+app.whenReady().then(async () => {
+  await initPipeline()
   createMainWindow(ctx)
   createSubtitleWindow(ctx)
   registerDisplayHandlers(ctx)


### PR DESCRIPTION
## Summary
- Dispose previous `TranslationPipeline` (which calls `removeAllListeners()`) before creating a new one in `initPipeline()`
- Made `initPipeline()` async to properly await disposal before re-registering

Closes #383