### PR TITLE
Fix WebSocket client listeners not removed on disconnect

### DIFF
--- a/src/main/ws-audio-server.ts
+++ b/src/main/ws-audio-server.ts
@@ -101,6 +101,7 @@ export class WsAudioServer extends EventEmitter {
           if (this.client === ws) {
             this.client = null
           }
+          ws.removeAllListeners()
           this.emit('disconnected')
         })
 
@@ -139,8 +140,9 @@ export class WsAudioServer extends EventEmitter {
 
     this._running = false
 
-    // Close client connection
+    // Close client connection and remove its listeners
     if (this.client) {
+      this.client.removeAllListeners()
       this.client.close(1000, 'Server shutting down')
       this.client = null
     }


### PR DESCRIPTION
## Summary
- Call `ws.removeAllListeners()` in the close handler to clean up message/close/error listeners when a client disconnects
- Call `removeAllListeners()` on the client in `stop()` before closing the connection to prevent leaked listeners during server shutdown

Closes #377