### PR TITLE
Fix UtilityProcess pooling: reuse single slm-worker

### DIFF
--- a/src/engines/translator/HunyuanMT15Translator.ts
+++ b/src/engines/translator/HunyuanMT15Translator.ts
@@ -1,29 +1,11 @@
-import { utilityProcess } from 'electron'
 import { join } from 'path'
 import type { TranslatorEngine, Language, TranslateContext } from '../types'
 import { getGGUFDir, downloadGGUF, getHunyuanMT15Variants } from '../model-downloader'
-import {
-  WORKER_TRANSLATE_TIMEOUT_MS,
-  WORKER_INIT_TIMEOUT_MS,
-  WORKER_DISPOSE_GRACE_MS,
-  WORKER_MAX_PENDING_REQUESTS
-} from '../constants'
-
-/** Messages received from the slm-worker UtilityProcess */
-type WorkerMessage =
-  | { type: 'ready' }
-  | { type: 'result'; id: string; text: string }
-  | { type: 'error'; id?: string; message: string }
-
-interface PendingRequest {
-  resolve: (text: string) => void
-  reject: (err: Error) => void
-  timer: ReturnType<typeof setTimeout>
-}
+import { workerPool } from '../../main/worker-pool'
 
 /**
  * HY-MT1.5-1.8B translator via node-llama-cpp UtilityProcess.
- * Uses the same slm-worker.ts as Hunyuan-MT 7B but with HY-MT1.5 prompt format.
+ * Uses the shared worker pool instead of spawning its own process.
  * 1.8B parameter model (~1.1GB Q4_K_M) supporting 36 languages.
  * License: Tencent Hunyuan Community License (Apache 2.0 based, commercial OK < 100M MAU).
  */
@@ -32,13 +14,12 @@ export class HunyuanMT15Translator implements TranslatorEngine {
   readonly name = 'HY-MT1.5-1.8B (Offline)'
   readonly isOffline = true
 
-  private worker: Electron.UtilityProcess | null = null
-  private pending = new Map<string, PendingRequest>()
-  private nextId = 0
+  private initialized = false
   private initPromise: Promise<void> | null = null
   private onProgress?: (message: string) => void
   private variant: string
   private kvCacheQuant: boolean
+  private modelPath: string = ''
 
   constructor(options?: { onProgress?: (message: string) => void; variant?: string; kvCacheQuant?: boolean }) {
     this.onProgress = options?.onProgress
@@ -53,124 +34,37 @@ export class HunyuanMT15Translator implements TranslatorEngine {
   }
 
   private async doInitialize(): Promise<void> {
-    if (this.worker) return
+    if (this.initialized) return
 
     // Download model if needed
     const variants = getHunyuanMT15Variants()
     const variantConfig = variants[this.variant] ?? variants['Q4_K_M']!
-    const modelPath = join(getGGUFDir(), variantConfig.filename)
+    this.modelPath = join(getGGUFDir(), variantConfig.filename)
     await downloadGGUF(variantConfig.filename, variantConfig.url, this.onProgress, variantConfig.sha256)
 
-    // Spawn UtilityProcess (reuses the same slm-worker)
     this.onProgress?.('Starting HY-MT1.5-1.8B worker...')
-    const workerPath = join(__dirname, 'slm-worker.js')
 
-    this.worker = utilityProcess.fork(workerPath)
+    await workerPool.acquire({
+      modelPath: this.modelPath,
+      kvCacheQuant: this.kvCacheQuant,
+      modelType: 'hunyuan-mt-15'
+    }, this.onProgress)
 
-    this.worker.on('exit', (code) => {
-      console.log(`[hunyuan-mt-15-worker] Worker exited with code ${code}`)
-      this.worker = null
-      for (const [id, req] of this.pending) {
-        clearTimeout(req.timer)
-        req.reject(new Error('Worker process exited'))
-        this.pending.delete(id)
-      }
-    })
-
-    // Wait for init before registering the general message handler
-    await new Promise<void>((resolve, reject) => {
-      const timeout = setTimeout(() => {
-        this.worker?.removeListener('message', initHandler)
-        try { this.worker?.kill() } catch (e) { console.warn('[hunyuan-mt-15-worker] Failed to kill worker on timeout:', e) }
-        this.worker = null
-        reject(new Error('HY-MT1.5 initialization timed out'))
-      }, WORKER_INIT_TIMEOUT_MS)
-
-      const initHandler = (msg: WorkerMessage): void => {
-        if (!this.worker) return
-
-        if (msg.type === 'ready') {
-          clearTimeout(timeout)
-          this.worker?.removeListener('message', initHandler)
-          this.onProgress?.('HY-MT1.5-1.8B model loaded')
-          resolve()
-        } else if (msg.type === 'error') {
-          clearTimeout(timeout)
-          this.worker?.removeListener('message', initHandler)
-          reject(new Error(msg.message))
-        }
-      }
-
-      this.worker!.on('message', initHandler)
-      this.worker!.postMessage({
-        type: 'init',
-        modelPath,
-        kvCacheQuant: this.kvCacheQuant,
-        modelType: 'hunyuan-mt-15'
-      })
-    })
-
-    if (!this.worker) {
-      throw new Error('Worker was killed during initialization')
-    }
-
-    // Clear any leftover listeners before registering to prevent duplicates
-    this.worker.removeAllListeners('message')
-    this.worker.on('message', (msg: WorkerMessage) => {
-      if (msg.type === 'result' && msg.id) {
-        const req = this.pending.get(msg.id)
-        if (req) {
-          clearTimeout(req.timer)
-          this.pending.delete(msg.id)
-          req.resolve(msg.text)
-        }
-        return
-      }
-      if (msg.type === 'error' && msg.id) {
-        const req = this.pending.get(msg.id)
-        if (req) {
-          clearTimeout(req.timer)
-          this.pending.delete(msg.id)
-          req.reject(new Error(msg.message))
-        }
-        return
-      }
-      if (msg.type === 'error') {
-        console.error('[hunyuan-mt-15-worker] Worker error:', msg.message)
-      }
-    })
-  }
-
-  /** Evict the oldest pending request if the map is at capacity */
-  private evictOldestPending(): void {
-    if (this.pending.size >= WORKER_MAX_PENDING_REQUESTS) {
-      const oldestKey = this.pending.keys().next().value!
-      const oldest = this.pending.get(oldestKey)!
-      this.pending.delete(oldestKey)
-      clearTimeout(oldest.timer)
-      oldest.reject(new Error('Evicted: worker pending request limit exceeded'))
-    }
+    this.onProgress?.('HY-MT1.5-1.8B model loaded')
+    this.initialized = true
   }
 
   async translate(text: string, from: Language, to: Language, context?: TranslateContext): Promise<string> {
     if (!text.trim()) return ''
     if (from === to) return text
-    if (!this.worker) {
+    if (!this.initialized) {
       throw new Error('[hunyuan-mt-15-worker] Not initialized')
     }
 
-    const id = String(this.nextId++)
-
-    return new Promise<string>((resolve, reject) => {
-      this.evictOldestPending()
-      const timer = setTimeout(() => {
-        this.pending.delete(id)
-        reject(new Error('HY-MT1.5 translation timed out'))
-      }, WORKER_TRANSLATE_TIMEOUT_MS)
-
-      this.pending.set(id, { resolve, reject, timer })
-      this.worker!.postMessage({ type: 'translate', id, text, from, to, context })
-    })
+    return workerPool.sendRequest(
+      { type: 'translate', text, from, to, context },
+      'translate'
+    )
   }
 
   async translateIncremental(
@@ -182,64 +76,21 @@ export class HunyuanMT15Translator implements TranslatorEngine {
   ): Promise<string> {
     if (!text.trim()) return previousOutput || ''
     if (from === to) return text
-    if (!this.worker) {
+    if (!this.initialized) {
       throw new Error('[hunyuan-mt-15-worker] Not initialized')
     }
 
-    const id = String(this.nextId++)
-
-    return new Promise<string>((resolve, reject) => {
-      this.evictOldestPending()
-      const timer = setTimeout(() => {
-        this.pending.delete(id)
-        reject(new Error('HY-MT1.5 incremental translation timed out'))
-      }, WORKER_TRANSLATE_TIMEOUT_MS)
-
-      this.pending.set(id, { resolve, reject, timer })
-      this.worker!.postMessage({
-        type: 'translate-incremental',
-        id,
-        text,
-        previousOutput,
-        from,
-        to,
-        context
-      })
-    })
+    return workerPool.sendRequest(
+      { type: 'translate-incremental', text, previousOutput, from, to, context },
+      'translate-incremental'
+    )
   }
 
   async dispose(): Promise<void> {
-    if (this.worker) {
-      // Remove all listeners before sending dispose to prevent exit handler from firing
-      this.worker.removeAllListeners()
-      try {
-        // Wait for the worker to confirm disposal or fall back to timeout
-        await new Promise<void>((resolve) => {
-          const timeout = setTimeout(resolve, WORKER_DISPOSE_GRACE_MS)
-          this.worker!.on('message', (msg: any) => {
-            if (msg.type === 'disposed') {
-              clearTimeout(timeout)
-              resolve()
-            }
-          })
-          this.worker!.postMessage({ type: 'dispose' })
-        })
-      } catch {
-        // Ignore errors during disposal
-      }
-      try {
-        this.worker.kill()
-      } catch {
-        // Already exited
-      }
-      this.worker = null
+    if (this.initialized) {
+      await workerPool.release()
+      this.initialized = false
     }
-
-    for (const [, req] of this.pending) {
-      clearTimeout(req.timer)
-      req.reject(new Error('Translator disposed'))
-    }
-    this.pending.clear()
     this.initPromise = null
   }
 }

--- a/src/engines/translator/HunyuanMTTranslator.ts
+++ b/src/engines/translator/HunyuanMTTranslator.ts
@@ -1,29 +1,11 @@
-import { utilityProcess } from 'electron'
 import { join } from 'path'
 import type { TranslatorEngine, Language, TranslateContext } from '../types'
 import { getGGUFDir, downloadGGUF, getHunyuanMTVariants } from '../model-downloader'
-import {
-  WORKER_TRANSLATE_TIMEOUT_MS,
-  WORKER_INIT_TIMEOUT_MS,
-  WORKER_DISPOSE_GRACE_MS,
-  WORKER_MAX_PENDING_REQUESTS
-} from '../constants'
-
-/** Messages received from the slm-worker UtilityProcess */
-type WorkerMessage =
-  | { type: 'ready' }
-  | { type: 'result'; id: string; text: string }
-  | { type: 'error'; id?: string; message: string }
-
-interface PendingRequest {
-  resolve: (text: string) => void
-  reject: (err: Error) => void
-  timer: ReturnType<typeof setTimeout>
-}
+import { workerPool } from '../../main/worker-pool'
 
 /**
  * Hunyuan-MT-7B translator via node-llama-cpp UtilityProcess.
- * Uses the same slm-worker.ts as TranslateGemma but with Hunyuan-MT prompt format.
+ * Uses the shared worker pool instead of spawning its own process.
  * WMT25 winner: 30/31 categories, 33 languages, 15-65% improvement over Google Translate.
  * License: Tencent Hunyuan Community License (Apache 2.0 based, commercial OK < 100M MAU).
  */
@@ -32,13 +14,12 @@ export class HunyuanMTTranslator implements TranslatorEngine {
   readonly name = 'Hunyuan-MT 7B (Offline)'
   readonly isOffline = true
 
-  private worker: Electron.UtilityProcess | null = null
-  private pending = new Map<string, PendingRequest>()
-  private nextId = 0
+  private initialized = false
   private initPromise: Promise<void> | null = null
   private onProgress?: (message: string) => void
   private variant: string
   private kvCacheQuant: boolean
+  private modelPath: string = ''
 
   constructor(options?: { onProgress?: (message: string) => void; variant?: string; kvCacheQuant?: boolean }) {
     this.onProgress = options?.onProgress
@@ -53,124 +34,37 @@ export class HunyuanMTTranslator implements TranslatorEngine {
   }
 
   private async doInitialize(): Promise<void> {
-    if (this.worker) return
+    if (this.initialized) return
 
     // Download model if needed
     const variants = getHunyuanMTVariants()
     const variantConfig = variants[this.variant] ?? variants['Q4_K_M']!
-    const modelPath = join(getGGUFDir(), variantConfig.filename)
+    this.modelPath = join(getGGUFDir(), variantConfig.filename)
     await downloadGGUF(variantConfig.filename, variantConfig.url, this.onProgress, variantConfig.sha256)
 
-    // Spawn UtilityProcess (reuses the same slm-worker)
     this.onProgress?.('Starting Hunyuan-MT 7B worker...')
-    const workerPath = join(__dirname, 'slm-worker.js')
 
-    this.worker = utilityProcess.fork(workerPath)
+    await workerPool.acquire({
+      modelPath: this.modelPath,
+      kvCacheQuant: this.kvCacheQuant,
+      modelType: 'hunyuan-mt'
+    }, this.onProgress)
 
-    this.worker.on('exit', (code) => {
-      console.log(`[hunyuan-mt-worker] Worker exited with code ${code}`)
-      this.worker = null
-      for (const [id, req] of this.pending) {
-        clearTimeout(req.timer)
-        req.reject(new Error('Worker process exited'))
-        this.pending.delete(id)
-      }
-    })
-
-    // Wait for init before registering the general message handler
-    await new Promise<void>((resolve, reject) => {
-      const timeout = setTimeout(() => {
-        this.worker?.removeListener('message', initHandler)
-        try { this.worker?.kill() } catch (e) { console.warn('[hunyuan-mt-worker] Failed to kill worker on timeout:', e) }
-        this.worker = null
-        reject(new Error('Hunyuan-MT initialization timed out'))
-      }, WORKER_INIT_TIMEOUT_MS)
-
-      const initHandler = (msg: WorkerMessage): void => {
-        if (!this.worker) return
-
-        if (msg.type === 'ready') {
-          clearTimeout(timeout)
-          this.worker?.removeListener('message', initHandler)
-          this.onProgress?.('Hunyuan-MT 7B model loaded')
-          resolve()
-        } else if (msg.type === 'error') {
-          clearTimeout(timeout)
-          this.worker?.removeListener('message', initHandler)
-          reject(new Error(msg.message))
-        }
-      }
-
-      this.worker!.on('message', initHandler)
-      this.worker!.postMessage({
-        type: 'init',
-        modelPath,
-        kvCacheQuant: this.kvCacheQuant,
-        modelType: 'hunyuan-mt'
-      })
-    })
-
-    if (!this.worker) {
-      throw new Error('Worker was killed during initialization')
-    }
-
-    // Clear any leftover listeners before registering to prevent duplicates
-    this.worker.removeAllListeners('message')
-    this.worker.on('message', (msg: WorkerMessage) => {
-      if (msg.type === 'result' && msg.id) {
-        const req = this.pending.get(msg.id)
-        if (req) {
-          clearTimeout(req.timer)
-          this.pending.delete(msg.id)
-          req.resolve(msg.text)
-        }
-        return
-      }
-      if (msg.type === 'error' && msg.id) {
-        const req = this.pending.get(msg.id)
-        if (req) {
-          clearTimeout(req.timer)
-          this.pending.delete(msg.id)
-          req.reject(new Error(msg.message))
-        }
-        return
-      }
-      if (msg.type === 'error') {
-        console.error('[hunyuan-mt-worker] Worker error:', msg.message)
-      }
-    })
-  }
-
-  /** Evict the oldest pending request if the map is at capacity */
-  private evictOldestPending(): void {
-    if (this.pending.size >= WORKER_MAX_PENDING_REQUESTS) {
-      const oldestKey = this.pending.keys().next().value!
-      const oldest = this.pending.get(oldestKey)!
-      this.pending.delete(oldestKey)
-      clearTimeout(oldest.timer)
-      oldest.reject(new Error('Evicted: worker pending request limit exceeded'))
-    }
+    this.onProgress?.('Hunyuan-MT 7B model loaded')
+    this.initialized = true
   }
 
   async translate(text: string, from: Language, to: Language, context?: TranslateContext): Promise<string> {
     if (!text.trim()) return ''
     if (from === to) return text
-    if (!this.worker) {
+    if (!this.initialized) {
       throw new Error('[hunyuan-mt-worker] Not initialized')
     }
 
-    const id = String(this.nextId++)
-
-    return new Promise<string>((resolve, reject) => {
-      this.evictOldestPending()
-      const timer = setTimeout(() => {
-        this.pending.delete(id)
-        reject(new Error('Hunyuan-MT translation timed out'))
-      }, WORKER_TRANSLATE_TIMEOUT_MS)
-
-      this.pending.set(id, { resolve, reject, timer })
-      this.worker!.postMessage({ type: 'translate', id, text, from, to, context })
-    })
+    return workerPool.sendRequest(
+      { type: 'translate', text, from, to, context },
+      'translate'
+    )
   }
 
   async translateIncremental(
@@ -182,64 +76,21 @@ export class HunyuanMTTranslator implements TranslatorEngine {
   ): Promise<string> {
     if (!text.trim()) return previousOutput || ''
     if (from === to) return text
-    if (!this.worker) {
+    if (!this.initialized) {
       throw new Error('[hunyuan-mt-worker] Not initialized')
     }
 
-    const id = String(this.nextId++)
-
-    return new Promise<string>((resolve, reject) => {
-      this.evictOldestPending()
-      const timer = setTimeout(() => {
-        this.pending.delete(id)
-        reject(new Error('Hunyuan-MT incremental translation timed out'))
-      }, WORKER_TRANSLATE_TIMEOUT_MS)
-
-      this.pending.set(id, { resolve, reject, timer })
-      this.worker!.postMessage({
-        type: 'translate-incremental',
-        id,
-        text,
-        previousOutput,
-        from,
-        to,
-        context
-      })
-    })
+    return workerPool.sendRequest(
+      { type: 'translate-incremental', text, previousOutput, from, to, context },
+      'translate-incremental'
+    )
   }
 
   async dispose(): Promise<void> {
-    if (this.worker) {
-      // Remove all listeners before sending dispose to prevent exit handler from firing
-      this.worker.removeAllListeners()
-      try {
-        // Wait for the worker to confirm disposal or fall back to timeout
-        await new Promise<void>((resolve) => {
-          const timeout = setTimeout(resolve, WORKER_DISPOSE_GRACE_MS)
-          this.worker!.on('message', (msg: any) => {
-            if (msg.type === 'disposed') {
-              clearTimeout(timeout)
-              resolve()
-            }
-          })
-          this.worker!.postMessage({ type: 'dispose' })
-        })
-      } catch {
-        // Ignore errors during disposal
-      }
-      try {
-        this.worker.kill()
-      } catch {
-        // Already exited
-      }
-      this.worker = null
+    if (this.initialized) {
+      await workerPool.release()
+      this.initialized = false
     }
-
-    for (const [, req] of this.pending) {
-      clearTimeout(req.timer)
-      req.reject(new Error('Translator disposed'))
-    }
-    this.pending.clear()
     this.initPromise = null
   }
 }

--- a/src/engines/translator/SLMTranslator.ts
+++ b/src/engines/translator/SLMTranslator.ts
@@ -1,42 +1,22 @@
-import { utilityProcess } from 'electron'
 import { join } from 'path'
 import type { TranslatorEngine, Language, TranslateContext } from '../types'
 import { getGGUFDir, downloadGGUF, getGGUFVariants, isGGUFDownloaded } from '../model-downloader'
 import type { SLMModelSize } from '../model-downloader'
-import {
-  WORKER_TRANSLATE_TIMEOUT_MS,
-  WORKER_SUMMARIZE_TIMEOUT_MS,
-  WORKER_INIT_TIMEOUT_MS,
-  WORKER_DISPOSE_GRACE_MS,
-  WORKER_MAX_PENDING_REQUESTS
-} from '../constants'
-
-/** Messages received from the slm-worker UtilityProcess */
-type WorkerMessage =
-  | { type: 'ready' }
-  | { type: 'result'; id: string; text: string }
-  | { type: 'error'; id?: string; message: string }
-
-interface PendingRequest {
-  resolve: (text: string) => void
-  reject: (err: Error) => void
-  timer: ReturnType<typeof setTimeout>
-}
+import { workerPool } from '../../main/worker-pool'
 
 export class SLMTranslator implements TranslatorEngine {
   readonly id = 'slm-translate'
   readonly name: string
   readonly isOffline = true
 
-  private worker: Electron.UtilityProcess | null = null
-  private pending = new Map<string, PendingRequest>()
-  private nextId = 0
+  private initialized = false
   private initPromise: Promise<void> | null = null
   private onProgress?: (message: string) => void
   private variant: string
   private modelSize: SLMModelSize
   private kvCacheQuant: boolean
   private speculativeDecoding: boolean
+  private modelPath: string = ''
 
   constructor(options?: { onProgress?: (message: string) => void; variant?: string; modelSize?: SLMModelSize; kvCacheQuant?: boolean; speculativeDecoding?: boolean }) {
     this.onProgress = options?.onProgress
@@ -54,12 +34,12 @@ export class SLMTranslator implements TranslatorEngine {
   }
 
   private async doInitialize(): Promise<void> {
-    if (this.worker) return
+    if (this.initialized) return
 
     // Download model if needed
     const variants = getGGUFVariants(this.modelSize)
     const variantConfig = variants[this.variant] ?? variants['Q4_K_M']!
-    const modelPath = join(getGGUFDir(), variantConfig.filename)
+    this.modelPath = join(getGGUFDir(), variantConfig.filename)
     await downloadGGUF(variantConfig.filename, variantConfig.url, this.onProgress, variantConfig.sha256)
 
     // Resolve draft model path for speculative decoding (4B draft + 12B verifier)
@@ -75,120 +55,30 @@ export class SLMTranslator implements TranslatorEngine {
       }
     }
 
-    // Spawn UtilityProcess
     this.onProgress?.(`Starting TranslateGemma ${this.modelSize.toUpperCase()} worker...`)
-    const workerPath = join(__dirname, 'slm-worker.js')
 
-    this.worker = utilityProcess.fork(workerPath)
+    await workerPool.acquire({
+      modelPath: this.modelPath,
+      kvCacheQuant: this.kvCacheQuant,
+      draftModelPath
+    }, this.onProgress)
 
-    this.worker.on('exit', (code) => {
-      console.log(`[slm-worker] Worker exited with code ${code}`)
-      this.worker = null
-      for (const [id, req] of this.pending) {
-        clearTimeout(req.timer)
-        req.reject(new Error('Worker process exited'))
-        this.pending.delete(id)
-      }
-    })
-
-    // Wait for init before registering the general message handler
-    await new Promise<void>((resolve, reject) => {
-      const timeout = setTimeout(() => {
-        this.worker?.removeListener('message', initHandler)
-        // Kill orphaned worker on timeout
-        try { this.worker?.kill() } catch (e) { console.warn('[slm-worker] Failed to kill worker on timeout:', e) }
-        this.worker = null
-        reject(new Error('TranslateGemma initialization timed out'))
-      }, WORKER_INIT_TIMEOUT_MS)
-
-      const initHandler = (msg: WorkerMessage): void => {
-        // Guard: ignore messages if worker was killed during timeout (#205)
-        if (!this.worker) return
-
-        if (msg.type === 'ready') {
-          clearTimeout(timeout)
-          this.worker?.removeListener('message', initHandler)
-          const specLabel = draftModelPath ? ' (speculative decoding)' : ''
-          this.onProgress?.(`TranslateGemma ${this.modelSize.toUpperCase()} model loaded${specLabel}`)
-          resolve()
-        } else if (msg.type === 'error') {
-          clearTimeout(timeout)
-          this.worker?.removeListener('message', initHandler)
-          reject(new Error(msg.message))
-        }
-      }
-
-      this.worker!.on('message', initHandler)
-      this.worker!.postMessage({
-        type: 'init',
-        modelPath,
-        kvCacheQuant: this.kvCacheQuant,
-        ...(draftModelPath && { draftModelPath })
-      })
-    })
-
-    // Guard: worker may have been killed during init timeout (#205)
-    if (!this.worker) {
-      throw new Error('Worker was killed during initialization')
-    }
-
-    // Clear any leftover listeners before registering to prevent duplicates (#206)
-    this.worker.removeAllListeners('message')
-    this.worker.on('message', (msg: WorkerMessage) => {
-      if (msg.type === 'result' && msg.id) {
-        const req = this.pending.get(msg.id)
-        if (req) {
-          clearTimeout(req.timer)
-          this.pending.delete(msg.id)
-          req.resolve(msg.text)
-        }
-        return
-      }
-      if (msg.type === 'error' && msg.id) {
-        const req = this.pending.get(msg.id)
-        if (req) {
-          clearTimeout(req.timer)
-          this.pending.delete(msg.id)
-          req.reject(new Error(msg.message))
-        }
-        return
-      }
-      if (msg.type === 'error') {
-        console.error('[slm-worker] Worker error:', msg.message)
-      }
-    })
-  }
-
-  /** Evict the oldest pending request if the map is at capacity */
-  private evictOldestPending(): void {
-    if (this.pending.size >= WORKER_MAX_PENDING_REQUESTS) {
-      const oldestKey = this.pending.keys().next().value!
-      const oldest = this.pending.get(oldestKey)!
-      this.pending.delete(oldestKey)
-      clearTimeout(oldest.timer)
-      oldest.reject(new Error('Evicted: worker pending request limit exceeded'))
-    }
+    const specLabel = draftModelPath ? ' (speculative decoding)' : ''
+    this.onProgress?.(`TranslateGemma ${this.modelSize.toUpperCase()} model loaded${specLabel}`)
+    this.initialized = true
   }
 
   async translate(text: string, from: Language, to: Language, context?: TranslateContext): Promise<string> {
     if (!text.trim()) return ''
     if (from === to) return text
-    if (!this.worker) {
+    if (!this.initialized) {
       throw new Error('[slm-worker] Not initialized')
     }
 
-    const id = String(this.nextId++)
-
-    return new Promise<string>((resolve, reject) => {
-      this.evictOldestPending()
-      const timer = setTimeout(() => {
-        this.pending.delete(id)
-        reject(new Error('TranslateGemma translation timed out'))
-      }, WORKER_TRANSLATE_TIMEOUT_MS)
-
-      this.pending.set(id, { resolve, reject, timer })
-      this.worker!.postMessage({ type: 'translate', id, text, from, to, context })
-    })
+    return workerPool.sendRequest(
+      { type: 'translate', text, from, to, context },
+      'translate'
+    )
   }
 
   async translateIncremental(
@@ -200,82 +90,32 @@ export class SLMTranslator implements TranslatorEngine {
   ): Promise<string> {
     if (!text.trim()) return previousOutput || ''
     if (from === to) return text
-    if (!this.worker) {
+    if (!this.initialized) {
       throw new Error('[slm-worker] Not initialized')
     }
 
-    const id = String(this.nextId++)
-
-    return new Promise<string>((resolve, reject) => {
-      this.evictOldestPending()
-      const timer = setTimeout(() => {
-        this.pending.delete(id)
-        reject(new Error('TranslateGemma incremental translation timed out'))
-      }, WORKER_TRANSLATE_TIMEOUT_MS)
-
-      this.pending.set(id, { resolve, reject, timer })
-      this.worker!.postMessage({
-        type: 'translate-incremental',
-        id,
-        text,
-        previousOutput,
-        from,
-        to,
-        context
-      })
-    })
+    return workerPool.sendRequest(
+      { type: 'translate-incremental', text, previousOutput, from, to, context },
+      'translate-incremental'
+    )
   }
 
   async summarize(transcript: string): Promise<string> {
-    if (!this.worker) {
+    if (!this.initialized) {
       throw new Error('[slm-worker] Not initialized')
     }
 
-    const id = String(this.nextId++)
-    return new Promise<string>((resolve, reject) => {
-      this.evictOldestPending()
-      const timer = setTimeout(() => {
-        this.pending.delete(id)
-        reject(new Error('Summarization timed out'))
-      }, WORKER_SUMMARIZE_TIMEOUT_MS)
-
-      this.pending.set(id, { resolve, reject, timer })
-      this.worker!.postMessage({ type: 'summarize', id, transcript })
-    })
+    return workerPool.sendRequest(
+      { type: 'summarize', transcript },
+      'summarize'
+    )
   }
 
   async dispose(): Promise<void> {
-    if (this.worker) {
-      // Remove all listeners before sending dispose to prevent exit handler from firing
-      this.worker.removeAllListeners()
-      try {
-        // Wait for the worker to confirm disposal or fall back to timeout
-        await new Promise<void>((resolve) => {
-          const timeout = setTimeout(resolve, WORKER_DISPOSE_GRACE_MS)
-          this.worker!.on('message', (msg: any) => {
-            if (msg.type === 'disposed') {
-              clearTimeout(timeout)
-              resolve()
-            }
-          })
-          this.worker!.postMessage({ type: 'dispose' })
-        })
-      } catch {
-        // Ignore errors during disposal
-      }
-      try {
-        this.worker.kill()
-      } catch {
-        // Already exited
-      }
-      this.worker = null
+    if (this.initialized) {
+      await workerPool.release()
+      this.initialized = false
     }
-
-    for (const [, req] of this.pending) {
-      clearTimeout(req.timer)
-      req.reject(new Error('Translator disposed'))
-    }
-    this.pending.clear()
     this.initPromise = null
   }
 }

--- a/src/main/ipc-handlers.ts
+++ b/src/main/ipc-handlers.ts
@@ -6,10 +6,10 @@ import { GeminiTranslator } from '../engines/translator/GeminiTranslator'
 import { MicrosoftTranslator } from '../engines/translator/MicrosoftTranslator'
 import { ApiRotationController } from '../engines/translator/ApiRotationController'
 import type { ProviderConfig, QuotaStore } from '../engines/translator/ApiRotationController'
-import { SLMTranslator } from '../engines/translator/SLMTranslator'
 import { detectGpu } from '../engines/gpu-detector'
-import { isGGUFDownloaded, getGGUFVariants, getHunyuanMTVariants, getHunyuanMT15Variants, getWhisperVariants, isModelDownloaded as isWhisperModelDownloaded } from '../engines/model-downloader'
+import { isGGUFDownloaded, getGGUFDir, downloadGGUF, getGGUFVariants, getHunyuanMTVariants, getHunyuanMT15Variants, getWhisperVariants, isModelDownloaded as isWhisperModelDownloaded } from '../engines/model-downloader'
 import type { SLMModelSize, WhisperVariant } from '../engines/model-downloader'
+import { workerPool } from './worker-pool'
 import { listPlugins } from '../engines/plugin-loader'
 import { TranscriptLogger } from '../logger/TranscriptLogger'
 import * as SessionManager from '../logger/SessionManager'
@@ -300,19 +300,28 @@ export function registerIpcHandlers(ctx: AppContext): void {
         return { error: 'Transcript is empty' }
       }
 
-      // Use SLM translator for summarization
-      const slm = new SLMTranslator({
-        onProgress: (msg) => ctx.mainWindow?.webContents.send('status-update', msg),
-        kvCacheQuant: store.get('slmKvCacheQuant'),
-        modelSize: store.get('slmModelSize')
-      })
+      // Use shared worker pool for summarization
+      const modelSize = (store.get('slmModelSize') as SLMModelSize) || '4b'
+      const variants = getGGUFVariants(modelSize)
+      const variantConfig = variants['Q4_K_M']!
+      const modelPath = join(getGGUFDir(), variantConfig.filename)
+      await downloadGGUF(variantConfig.filename, variantConfig.url,
+        (msg) => ctx.mainWindow?.webContents.send('status-update', msg),
+        variantConfig.sha256)
+
+      await workerPool.acquire({
+        modelPath,
+        kvCacheQuant: store.get('slmKvCacheQuant') as boolean
+      }, (msg) => ctx.mainWindow?.webContents.send('status-update', msg))
 
       try {
-        await slm.initialize()
-        const summary = await slm.summarize(transcript)
+        const summary = await workerPool.sendRequest(
+          { type: 'summarize', transcript },
+          'summarize'
+        )
         return { summary }
       } finally {
-        await slm.dispose()
+        await workerPool.release()
       }
     } catch (err) {
       return { error: sanitizeErrorMessage(err instanceof Error ? err.message : String(err)) }

--- a/src/main/worker-pool.ts
+++ b/src/main/worker-pool.ts
@@ -1,0 +1,308 @@
+/**
+ * Shared UtilityProcess pool for slm-worker.
+ *
+ * Ensures only ONE slm-worker UtilityProcess runs at a time.
+ * Multiple engines (SLMTranslator, HunyuanMTTranslator, HunyuanMT15Translator)
+ * and the generate-summary handler all share this single worker.
+ *
+ * When a different model is needed, the pool sends a dispose+init sequence
+ * to hot-swap the loaded model without killing the process.
+ */
+
+import { utilityProcess } from 'electron'
+import { join } from 'path'
+import {
+  WORKER_INIT_TIMEOUT_MS,
+  WORKER_DISPOSE_GRACE_MS,
+  WORKER_MAX_PENDING_REQUESTS,
+  WORKER_TRANSLATE_TIMEOUT_MS,
+  WORKER_SUMMARIZE_TIMEOUT_MS
+} from '../engines/constants'
+
+/** Messages received from the slm-worker UtilityProcess */
+export type WorkerMessage =
+  | { type: 'ready' }
+  | { type: 'result'; id: string; text: string }
+  | { type: 'error'; id?: string; message: string }
+  | { type: 'disposed' }
+
+export interface PendingRequest {
+  resolve: (text: string) => void
+  reject: (err: Error) => void
+  timer: ReturnType<typeof setTimeout>
+}
+
+export interface WorkerInitOptions {
+  modelPath: string
+  kvCacheQuant?: boolean
+  modelType?: string
+  draftModelPath?: string
+}
+
+/** Timeout value by request type */
+export type RequestType = 'translate' | 'translate-incremental' | 'summarize'
+
+const TIMEOUT_BY_TYPE: Record<RequestType, number> = {
+  'translate': WORKER_TRANSLATE_TIMEOUT_MS,
+  'translate-incremental': WORKER_TRANSLATE_TIMEOUT_MS,
+  'summarize': WORKER_SUMMARIZE_TIMEOUT_MS
+}
+
+/**
+ * Singleton pool managing a single slm-worker UtilityProcess.
+ * Reference-counted: the process stays alive while any engine holds a reference.
+ */
+class WorkerPool {
+  private worker: Electron.UtilityProcess | null = null
+  private pending = new Map<string, PendingRequest>()
+  private nextId = 0
+  private refCount = 0
+  private currentModelPath: string | null = null
+  private initPromise: Promise<void> | null = null
+  private onProgress?: (message: string) => void
+
+  /**
+   * Acquire a reference to the shared worker, initializing it with the given model.
+   * If the worker is already running with a different model, it will hot-swap.
+   */
+  async acquire(options: WorkerInitOptions, onProgress?: (message: string) => void): Promise<void> {
+    this.refCount++
+    this.onProgress = onProgress
+
+    // If worker exists and same model is loaded, skip init
+    if (this.worker && this.currentModelPath === options.modelPath) {
+      return
+    }
+
+    // If worker exists but different model, hot-swap via dispose+init
+    if (this.worker && this.currentModelPath !== options.modelPath) {
+      await this.hotSwapModel(options)
+      return
+    }
+
+    // No worker yet — spawn and init
+    if (!this.initPromise || !this.worker) {
+      this.initPromise = this.spawnAndInit(options)
+    }
+    return this.initPromise
+  }
+
+  /**
+   * Release a reference. When refCount reaches 0, the worker is killed.
+   */
+  async release(): Promise<void> {
+    this.refCount = Math.max(0, this.refCount - 1)
+
+    if (this.refCount === 0) {
+      await this.killWorker()
+    }
+  }
+
+  /**
+   * Send a message to the worker and return a promise for the result.
+   */
+  sendRequest(message: Record<string, unknown>, type: RequestType): Promise<string> {
+    if (!this.worker) {
+      return Promise.reject(new Error('[worker-pool] Worker not initialized'))
+    }
+
+    const id = String(this.nextId++)
+    const timeout = TIMEOUT_BY_TYPE[type]
+
+    return new Promise<string>((resolve, reject) => {
+      this.evictOldestPending()
+
+      const timer = setTimeout(() => {
+        this.pending.delete(id)
+        reject(new Error(`Worker request timed out (${type})`))
+      }, timeout)
+
+      this.pending.set(id, { resolve, reject, timer })
+      this.worker!.postMessage({ ...message, id })
+    })
+  }
+
+  /** Check if the worker is alive and initialized */
+  get isAlive(): boolean {
+    return this.worker !== null
+  }
+
+  /** The model currently loaded in the worker */
+  get loadedModelPath(): string | null {
+    return this.currentModelPath
+  }
+
+  /** Current number of active references */
+  get references(): number {
+    return this.refCount
+  }
+
+  // ---------------------------------------------------------------------------
+  // Internal
+  // ---------------------------------------------------------------------------
+
+  private async spawnAndInit(options: WorkerInitOptions): Promise<void> {
+    const workerPath = join(__dirname, 'slm-worker.js')
+    this.worker = utilityProcess.fork(workerPath)
+
+    this.worker.on('exit', (code) => {
+      console.log(`[worker-pool] Worker exited with code ${code}`)
+      this.worker = null
+      this.currentModelPath = null
+      this.initPromise = null
+      // Reject all pending requests
+      for (const [id, req] of this.pending) {
+        clearTimeout(req.timer)
+        req.reject(new Error('Worker process exited'))
+        this.pending.delete(id)
+      }
+    })
+
+    await this.initModel(options)
+    this.registerMessageHandler()
+  }
+
+  private async hotSwapModel(options: WorkerInitOptions): Promise<void> {
+    // Send dispose to unload current model (but keep process alive)
+    await this.disposeModel()
+    // Re-init with new model
+    await this.initModel(options)
+  }
+
+  private initModel(options: WorkerInitOptions): Promise<void> {
+    return new Promise<void>((resolve, reject) => {
+      const timeout = setTimeout(() => {
+        this.worker?.removeListener('message', initHandler)
+        reject(new Error('Worker initialization timed out'))
+      }, WORKER_INIT_TIMEOUT_MS)
+
+      const initHandler = (msg: WorkerMessage): void => {
+        if (!this.worker) return
+
+        if (msg.type === 'ready') {
+          clearTimeout(timeout)
+          this.worker?.removeListener('message', initHandler)
+          this.currentModelPath = options.modelPath
+          resolve()
+        } else if (msg.type === 'error') {
+          clearTimeout(timeout)
+          this.worker?.removeListener('message', initHandler)
+          reject(new Error(msg.message))
+        }
+      }
+
+      this.worker!.on('message', initHandler)
+      this.worker!.postMessage({
+        type: 'init',
+        modelPath: options.modelPath,
+        kvCacheQuant: options.kvCacheQuant,
+        modelType: options.modelType,
+        ...(options.draftModelPath && { draftModelPath: options.draftModelPath })
+      })
+    })
+  }
+
+  private disposeModel(): Promise<void> {
+    return new Promise<void>((resolve) => {
+      if (!this.worker) {
+        resolve()
+        return
+      }
+
+      const timeout = setTimeout(resolve, WORKER_DISPOSE_GRACE_MS)
+
+      const disposeHandler = (msg: WorkerMessage): void => {
+        if (msg.type === 'disposed') {
+          clearTimeout(timeout)
+          this.worker?.removeListener('message', disposeHandler)
+          this.currentModelPath = null
+          resolve()
+        }
+      }
+
+      this.worker.on('message', disposeHandler)
+      this.worker.postMessage({ type: 'dispose' })
+    })
+  }
+
+  private registerMessageHandler(): void {
+    if (!this.worker) return
+
+    // Clear leftover listeners to prevent duplicates
+    this.worker.removeAllListeners('message')
+    this.worker.on('message', (msg: WorkerMessage) => {
+      if (msg.type === 'result' && msg.id) {
+        const req = this.pending.get(msg.id)
+        if (req) {
+          clearTimeout(req.timer)
+          this.pending.delete(msg.id)
+          req.resolve(msg.text)
+        }
+        return
+      }
+      if (msg.type === 'error' && msg.id) {
+        const req = this.pending.get(msg.id)
+        if (req) {
+          clearTimeout(req.timer)
+          this.pending.delete(msg.id)
+          req.reject(new Error(msg.message))
+        }
+        return
+      }
+      if (msg.type === 'error') {
+        console.error('[worker-pool] Worker error:', msg.message)
+      }
+    })
+  }
+
+  private async killWorker(): Promise<void> {
+    if (!this.worker) return
+
+    this.worker.removeAllListeners()
+
+    try {
+      await new Promise<void>((resolve) => {
+        const timeout = setTimeout(resolve, WORKER_DISPOSE_GRACE_MS)
+        this.worker!.on('message', (msg: WorkerMessage) => {
+          if (msg.type === 'disposed') {
+            clearTimeout(timeout)
+            resolve()
+          }
+        })
+        this.worker!.postMessage({ type: 'dispose' })
+      })
+    } catch {
+      // Ignore errors during disposal
+    }
+
+    try {
+      this.worker.kill()
+    } catch {
+      // Already exited
+    }
+
+    this.worker = null
+    this.currentModelPath = null
+    this.initPromise = null
+
+    // Reject all pending requests
+    for (const [, req] of this.pending) {
+      clearTimeout(req.timer)
+      req.reject(new Error('Worker pool disposed'))
+    }
+    this.pending.clear()
+  }
+
+  private evictOldestPending(): void {
+    if (this.pending.size >= WORKER_MAX_PENDING_REQUESTS) {
+      const oldestKey = this.pending.keys().next().value!
+      const oldest = this.pending.get(oldestKey)!
+      this.pending.delete(oldestKey)
+      clearTimeout(oldest.timer)
+      oldest.reject(new Error('Evicted: worker pending request limit exceeded'))
+    }
+  }
+}
+
+/** Singleton shared worker pool */
+export const workerPool = new WorkerPool()


### PR DESCRIPTION
## Description

Replace per-engine UtilityProcess spawning with a singleton `WorkerPool` that manages a single slm-worker process. Previously, each LLM translator (SLMTranslator, HunyuanMTTranslator, HunyuanMT15Translator) and the `generate-summary` handler each spawned their own `utilityProcess.fork()`, resulting in 3+ concurrent worker processes consuming 8-12GB+ memory in hybrid mode.

### Changes

- **New `src/main/worker-pool.ts`**: Singleton `WorkerPool` class with reference counting, model hot-swapping, and proper lifecycle management
- **Refactored translators**: `SLMTranslator`, `HunyuanMTTranslator`, `HunyuanMT15Translator` now acquire/release from the shared pool instead of managing their own worker
- **Refactored `generate-summary`**: Uses the shared pool instead of creating a temporary `SLMTranslator` instance

### Key design decisions

- **Single process, model hot-swap**: Only one slm-worker runs at a time. When a different model is needed, the pool sends dispose+init to swap models without killing the process
- **Reference counting**: Worker stays alive while any engine holds a reference; killed when refCount reaches 0
- **Same public API**: All translator classes maintain the same `TranslatorEngine` interface

Closes #367