### PR TITLE
#376 Fix display event listener cleanup in window-manager

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -173,10 +173,11 @@ app.whenReady().then(async () => {
   await initPipeline()
   createMainWindow(ctx)
   createSubtitleWindow(ctx)
-  registerDisplayHandlers(ctx)
+  cleanupDisplayHandlers = registerDisplayHandlers(ctx)
   initAutoUpdater(ctx)
 })
 
+let cleanupDisplayHandlers: (() => void) | null = null
 let isQuitting = false
 app.on('before-quit', (event) => {
   if (isQuitting) return
@@ -186,6 +187,8 @@ app.on('before-quit', (event) => {
   // Async cleanup before quit — timeout after 5s to prevent hanging (#222)
   ;(async () => {
     try {
+      cleanupDisplayHandlers?.()
+      cleanupDisplayHandlers = null
       disposeAutoUpdater()
       ctx.logger?.endSession()
       ctx.logger = null

--- a/src/main/window-manager.ts
+++ b/src/main/window-manager.ts
@@ -78,10 +78,10 @@ export function createSubtitleWindow(ctx: AppContext): void {
   })
 }
 
-/** Register display-change event handlers */
-export function registerDisplayHandlers(ctx: AppContext): void {
+/** Register display-change event handlers. Returns a cleanup function that removes the listeners. */
+export function registerDisplayHandlers(ctx: AppContext): () => void {
   // #46: reposition subtitle window when external display is disconnected
-  screen.on('display-removed', () => {
+  const onDisplayRemoved = (): void => {
     if (!ctx.subtitleWindow) return
     const primaryDisplay = screen.getPrimaryDisplay()
     const h = getSubtitleHeight(primaryDisplay)
@@ -93,9 +93,17 @@ export function registerDisplayHandlers(ctx: AppContext): void {
     })
     // #64: notify renderer to refresh display list
     ctx.mainWindow?.webContents.send('displays-changed')
-  })
+  }
 
-  screen.on('display-added', () => {
+  const onDisplayAdded = (): void => {
     ctx.mainWindow?.webContents.send('displays-changed')
-  })
+  }
+
+  screen.on('display-removed', onDisplayRemoved)
+  screen.on('display-added', onDisplayAdded)
+
+  return () => {
+    screen.removeListener('display-removed', onDisplayRemoved)
+    screen.removeListener('display-added', onDisplayAdded)
+  }
 }


### PR DESCRIPTION
## Summary
- `registerDisplayHandlers()` now returns a cleanup function that removes `display-removed` and `display-added` listeners from `screen`
- The call site in `index.ts` stores the cleanup function and invokes it during `before-quit` shutdown

Closes #376