### PR TITLE
#378 Add IPC input validation for session operations

### DIFF
--- a/src/main/ipc-handlers.ts
+++ b/src/main/ipc-handlers.ts
@@ -22,6 +22,8 @@ import { WsAudioServer } from './ws-audio-server'
 import type { AppContext } from './app-context'
 import type { EngineConfig } from '../engines/types'
 import { DEFAULT_WS_PORT, SAMPLE_RATE } from './constants'
+import { validateSessionId, validateSearchQuery, VALID_EXPORT_FORMATS } from './ipc-validators'
+import type { ExportFormat } from './ipc-validators'
 
 const log = createLogger('ipc')
 
@@ -330,16 +332,29 @@ export function registerIpcHandlers(ctx: AppContext): void {
 
   // #121: Session management
   ipcMain.handle('list-sessions', () => SessionManager.listSessions())
-  ipcMain.handle('load-session', (_event, id: string) => SessionManager.loadSession(id))
-  ipcMain.handle('search-sessions', (_event, query: string) => SessionManager.searchSessions(query))
+  ipcMain.handle('load-session', (_event, id: string) => {
+    const err = validateSessionId(id)
+    if (err) return { error: err }
+    return SessionManager.loadSession(id)
+  })
+  ipcMain.handle('search-sessions', (_event, query: string) => {
+    const err = validateSearchQuery(query)
+    if (err) return { error: err }
+    return SessionManager.searchSessions(query)
+  })
   ipcMain.handle('delete-session', (_event, id: string) => {
+    const err = validateSessionId(id)
+    if (err) return { error: err }
     SessionManager.deleteSession(id)
     return { success: true }
   })
-  ipcMain.handle('export-session', (_event, id: string, format: 'text' | 'srt' | 'markdown') => {
+  ipcMain.handle('export-session', (_event, id: string, format: ExportFormat) => {
+    const err = validateSessionId(id)
+    if (err) return { error: err }
+    const safeFormat = (VALID_EXPORT_FORMATS as readonly string[]).includes(format) ? format : 'text'
     const data = SessionManager.loadSession(id)
     if (!data) return { error: 'Session not found' }
-    switch (format) {
+    switch (safeFormat) {
       case 'srt': return { content: SessionManager.exportAsSRT(data), ext: '.srt' }
       case 'markdown': return { content: SessionManager.exportAsMarkdown(data), ext: '.md' }
       default: return { content: SessionManager.exportAsText(data), ext: '.txt' }

--- a/src/main/ipc-validators.test.ts
+++ b/src/main/ipc-validators.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from 'vitest'
+import { validateSessionId, validateSearchQuery } from './ipc-validators'
+
+describe('validateSessionId', () => {
+  it('accepts valid session IDs', () => {
+    expect(validateSessionId('2024-01-15T10-30-00-000')).toBeNull()
+    expect(validateSessionId('abc-123_T')).toBeNull()
+    expect(validateSessionId('simple')).toBeNull()
+  })
+
+  it('rejects non-string input', () => {
+    expect(validateSessionId(123)).toBe('Session ID must be a string')
+    expect(validateSessionId(null)).toBe('Session ID must be a string')
+    expect(validateSessionId(undefined)).toBe('Session ID must be a string')
+    expect(validateSessionId({})).toBe('Session ID must be a string')
+  })
+
+  it('rejects empty string', () => {
+    expect(validateSessionId('')).toBe('Session ID must not be empty')
+  })
+
+  it('rejects strings exceeding max length', () => {
+    const longId = 'a'.repeat(129)
+    expect(validateSessionId(longId)).toBe('Session ID exceeds max length (128)')
+  })
+
+  it('rejects path traversal characters', () => {
+    expect(validateSessionId('../etc/passwd')).toBe('Session ID contains invalid characters')
+    expect(validateSessionId('../../secret')).toBe('Session ID contains invalid characters')
+    expect(validateSessionId('foo/bar')).toBe('Session ID contains invalid characters')
+    expect(validateSessionId('foo\\bar')).toBe('Session ID contains invalid characters')
+  })
+
+  it('rejects special characters', () => {
+    expect(validateSessionId('id with spaces')).toBe('Session ID contains invalid characters')
+    expect(validateSessionId('id:colon')).toBe('Session ID contains invalid characters')
+    expect(validateSessionId('id.dot')).toBe('Session ID contains invalid characters')
+  })
+})
+
+describe('validateSearchQuery', () => {
+  it('accepts valid queries', () => {
+    expect(validateSearchQuery('hello world')).toBeNull()
+    expect(validateSearchQuery('meeting notes 2024')).toBeNull()
+  })
+
+  it('rejects non-string input', () => {
+    expect(validateSearchQuery(123)).toBe('Search query must be a string')
+    expect(validateSearchQuery(null)).toBe('Search query must be a string')
+  })
+
+  it('rejects empty string', () => {
+    expect(validateSearchQuery('')).toBe('Search query must not be empty')
+  })
+
+  it('rejects queries exceeding max length', () => {
+    const longQuery = 'a'.repeat(257)
+    expect(validateSearchQuery(longQuery)).toBe('Search query exceeds max length (256)')
+  })
+})

--- a/src/main/ipc-validators.ts
+++ b/src/main/ipc-validators.ts
@@ -1,0 +1,26 @@
+/** Max length for session IDs */
+const SESSION_ID_MAX_LENGTH = 128
+
+/** Allowed characters for session IDs: alphanumeric, hyphens, underscores, T (ISO timestamp separator) */
+const SESSION_ID_PATTERN = /^[a-zA-Z0-9\-_T]+$/
+
+/** Validate a session ID from IPC input. Returns error string or null if valid. */
+export function validateSessionId(id: unknown): string | null {
+  if (typeof id !== 'string') return 'Session ID must be a string'
+  if (id.length === 0) return 'Session ID must not be empty'
+  if (id.length > SESSION_ID_MAX_LENGTH) return `Session ID exceeds max length (${SESSION_ID_MAX_LENGTH})`
+  if (!SESSION_ID_PATTERN.test(id)) return 'Session ID contains invalid characters'
+  return null
+}
+
+/** Validate a search query from IPC input. Returns error string or null if valid. */
+export function validateSearchQuery(query: unknown): string | null {
+  if (typeof query !== 'string') return 'Search query must be a string'
+  if (query.length === 0) return 'Search query must not be empty'
+  if (query.length > 256) return 'Search query exceeds max length (256)'
+  return null
+}
+
+/** Valid export formats */
+export const VALID_EXPORT_FORMATS = ['text', 'srt', 'markdown'] as const
+export type ExportFormat = (typeof VALID_EXPORT_FORMATS)[number]


### PR DESCRIPTION
## Description

Add input validation at the IPC boundary for session-related handlers (`load-session`, `search-sessions`, `delete-session`, `export-session`).

Previously, the `id` parameter was passed directly to `SessionManager` without validation at the IPC layer. While `SessionManager.sanitizeId()` strips invalid characters internally, it silently transforms malformed input rather than rejecting it. This adds explicit validation that:

- Type checks (must be string)
- Length limits (128 chars for session IDs, 256 for search queries)
- Character whitelist for session IDs (alphanumeric, hyphens, underscores, T)
- Returns meaningful error messages for invalid input
- Validates export format parameter

Extracted validators into `src/main/ipc-validators.ts` for testability, with 10 unit tests covering valid inputs, type errors, empty strings, length limits, path traversal, and special characters.

Closes #378