### PR TITLE
Consolidate logging: replace console.* with createLogger()

### DIFF
--- a/src/engines/SubprocessBridge.ts
+++ b/src/engines/SubprocessBridge.ts
@@ -6,6 +6,7 @@ import {
   BRIDGE_MAX_PENDING_REQUESTS,
   BRIDGE_PENDING_TIMEOUT_MS
 } from './constants'
+import { createLogger, type Logger } from '../main/logger'
 
 /**
  * Spawn configuration returned by subclasses to define how the Python bridge
@@ -42,11 +43,23 @@ export type InitResult = Record<string, unknown>
  */
 export abstract class SubprocessBridge {
   protected process: ChildProcess | null = null
+  private _log: Logger | null = null
   private initPromise: Promise<void> | null = null
   private pendingRequests = new Map<number, { resolve: (data: Record<string, unknown>) => void; timer: ReturnType<typeof setTimeout> }>()
   private nextRequestId = 0
   private buffer = ''
   private stderrRateLimit = { count: 0, lastReset: Date.now() }
+
+  /** Lazily initialized logger using the subclass log prefix */
+  protected get log(): Logger {
+    if (!this._log) {
+      // Strip brackets from prefix like '[ct2-opus-mt]' -> 'ct2-opus-mt'
+      const prefix = this.getLogPrefix()
+      const module = prefix.replace(/^\[|\]$/g, '')
+      this._log = createLogger(module)
+    }
+    return this._log
+  }
 
   /** Called on each parsed status message from the bridge (msg.status). Override to forward progress. */
   protected onStatusMessage(_status: string): void {
@@ -91,7 +104,6 @@ export abstract class SubprocessBridge {
   private async doInitialize(): Promise<void> {
     if (this.process) return
 
-    const prefix = this.getLogPrefix()
     const initTimeout = this.getInitTimeout()
 
     let spawnConfig: SpawnConfig
@@ -102,11 +114,11 @@ export abstract class SubprocessBridge {
     }
 
     const timer = setTimeout(() => {
-      console.error(`${prefix} bridge initialization timed out`)
+      this.log.error('bridge initialization timed out')
       try {
         this.process?.kill()
       } catch (e) {
-        console.warn(`${prefix} bridge: failed to kill process on timeout:`, e)
+        this.log.warn('bridge: failed to kill process on timeout:', e)
       }
       this.process = null
     }, initTimeout)
@@ -122,7 +134,7 @@ export abstract class SubprocessBridge {
 
     this.process.on('error', (err) => {
       clearTimeout(timer)
-      console.error(`${prefix} bridge failed to start:`, err.message)
+      this.log.error('bridge failed to start:', err.message)
       this.process = null
     })
 
@@ -149,7 +161,7 @@ export abstract class SubprocessBridge {
             pending.resolve(msg)
           }
         } catch {
-          console.warn(`${prefix} bridge invalid JSON:`, line)
+          this.log.warn('bridge invalid JSON:', line)
         }
       }
     })
@@ -161,12 +173,12 @@ export abstract class SubprocessBridge {
       }
       if (this.stderrRateLimit.count < BRIDGE_STDERR_MAX_LINES) {
         this.stderrRateLimit.count++
-        console.warn(`${prefix} bridge stderr:`, data.toString().trim())
+        this.log.warn('bridge stderr:', data.toString().trim())
       }
     })
 
     this.process.on('exit', (code) => {
-      console.log(`${prefix} bridge exited with code ${code}`)
+      this.log.info(`bridge exited with code ${code}`)
       this.process = null
     })
 
@@ -177,7 +189,7 @@ export abstract class SubprocessBridge {
         initTimeout
       )
       if (result.error) {
-        throw new Error(`${prefix} init failed: ${result.error}`)
+        throw new Error(`${this.getLogPrefix()} init failed: ${result.error}`)
       }
       this.onInitComplete(result)
     } catch (err) {
@@ -185,7 +197,7 @@ export abstract class SubprocessBridge {
         try {
           this.process.kill()
         } catch (e) {
-          console.warn(`${prefix} bridge: failed to kill process during init cleanup:`, e)
+          this.log.warn('bridge: failed to kill process during init cleanup:', e)
         }
         this.process = null
       }
@@ -251,21 +263,20 @@ export abstract class SubprocessBridge {
   }
 
   async dispose(): Promise<void> {
-    const prefix = this.getLogPrefix()
-    console.log(`${prefix} bridge disposing resources`)
+    this.log.info('bridge disposing resources')
     if (this.process) {
       try {
         this.sendCommand({ action: 'dispose' }).catch((e) => {
-          console.warn(`${prefix} bridge: failed to send dispose command:`, e)
+          this.log.warn('bridge: failed to send dispose command:', e)
         })
         await new Promise((resolve) => setTimeout(resolve, 500))
       } catch (e) {
-        console.warn(`${prefix} bridge: error during dispose command:`, e)
+        this.log.warn('bridge: error during dispose command:', e)
       }
       try {
         this.process.kill()
       } catch (e) {
-        console.warn(`${prefix} bridge: failed to kill process during dispose:`, e)
+        this.log.warn('bridge: failed to kill process during dispose:', e)
       }
       this.process = null
     }

--- a/src/engines/gpu-detector.ts
+++ b/src/engines/gpu-detector.ts
@@ -1,3 +1,7 @@
+import { createLogger } from '../main/logger'
+
+const log = createLogger('gpu-detector')
+
 /**
  * GPU detection via node-llama-cpp.
  * Returns detected GPU names and whether a GPU is available.
@@ -22,7 +26,7 @@ export async function detectGpu(): Promise<GpuInfo> {
       gpuNames: gpuNames.map(String)
     }
   } catch (err) {
-    console.warn('[gpu-detector] Failed to detect GPU:', err)
+    log.warn('Failed to detect GPU:', err)
     // Don't cache errors — allow retry on next call
     return { hasGpu: false, gpuNames: [] }
   }

--- a/src/engines/model-downloader.ts
+++ b/src/engines/model-downloader.ts
@@ -3,6 +3,9 @@ import { join } from 'path'
 import { existsSync, mkdirSync, unlinkSync, statSync, createWriteStream } from 'fs'
 import { writeFile } from 'fs/promises'
 import { createHash } from 'crypto'
+import { createLogger } from '../main/logger'
+
+const log = createLogger('model-downloader')
 
 export const MODEL_FILENAME = 'ggml-kotoba-whisper-v2.0-q5_0.bin'
 export const MODEL_URL =
@@ -275,7 +278,7 @@ async function doDownloadWithResume(
       // If server doesn't support Range, start over
       if (response.status === 200 && existingSize > 0) {
         existingSize = 0
-        try { unlinkSync(partialPath) } catch (e) { console.warn('[model-downloader] Failed to remove partial file for restart:', e) }
+        try { unlinkSync(partialPath) } catch (e) { log.warn('Failed to remove partial file for restart:', e) }
       }
 
       if (!response.ok && response.status !== 206) {
@@ -315,7 +318,7 @@ async function doDownloadWithResume(
 
       // SHA256 verification (streaming to avoid loading multi-GB files into memory)
       if (!expectedSha256) {
-        console.warn(`[model-downloader] No SHA256 hash provided for ${label} — skipping integrity verification`)
+        log.warn(`No SHA256 hash provided for ${label} — skipping integrity verification`)
       }
       if (expectedSha256) {
         onProgress?.('Verifying file integrity...')
@@ -341,7 +344,7 @@ async function doDownloadWithResume(
 
     } catch (err) {
       if (attempt >= MAX_RETRIES) {
-        try { if (existsSync(partialPath)) unlinkSync(partialPath) } catch (e) { console.warn('[model-downloader] Failed to clean up partial file after max retries:', e) }
+        try { if (existsSync(partialPath)) unlinkSync(partialPath) } catch (e) { log.warn('Failed to clean up partial file after max retries:', e) }
         throw err
       }
       const delay = RETRY_DELAYS[attempt]

--- a/src/engines/plugin-loader.ts
+++ b/src/engines/plugin-loader.ts
@@ -2,6 +2,9 @@ import { app } from 'electron'
 import { join } from 'path'
 import { existsSync, readdirSync, readFileSync } from 'fs'
 import type { STTEngine, TranslatorEngine, E2ETranslationEngine } from './types'
+import { createLogger } from '../main/logger'
+
+const log = createLogger('plugin-loader')
 
 /** Plugin manifest schema (live-translate-plugin.json) */
 export interface PluginManifest {
@@ -42,7 +45,7 @@ export function discoverPlugins(): LoadedPlugin[] {
     try {
       const manifest: PluginManifest = JSON.parse(readFileSync(manifestPath, 'utf-8'))
       if (!validateManifest(manifest)) {
-        console.warn(`[plugin-loader] Invalid manifest in ${dir.name}, skipping`)
+        log.warn(`Invalid manifest in ${dir.name}, skipping`)
         continue
       }
 
@@ -51,7 +54,7 @@ export function discoverPlugins(): LoadedPlugin[] {
         path: join(pluginsDir, dir.name)
       })
     } catch (err) {
-      console.warn(`[plugin-loader] Failed to read manifest in ${dir.name}:`, err)
+      log.warn(`Failed to read manifest in ${dir.name}:`, err)
     }
   }
 
@@ -95,7 +98,7 @@ export async function loadPluginEngine(
     throw new Error(`Plugin entry point escapes plugin directory via symlink: ${plugin.manifest.entryPoint}`)
   }
 
-  console.warn(`[plugin-loader] Loading plugin "${plugin.manifest.name}" — plugins run with full system access`)
+  log.warn(`Loading plugin "${plugin.manifest.name}" — plugins run with full system access`)
 
   const module = await import(entryPath)
   const createEngine = module.default || module.createEngine

--- a/src/engines/stt/MlxWhisperEngine.ts
+++ b/src/engines/stt/MlxWhisperEngine.ts
@@ -76,12 +76,12 @@ export class MlxWhisperEngine extends SubprocessBridge implements STTEngine {
         })
       } catch (err) {
         // Timeout or bridge error — return null per interface contract
-        console.error('[mlx-whisper] Bridge error:', err instanceof Error ? err.message : err)
+        this.log.error('Bridge error:', err instanceof Error ? err.message : err)
         return null
       }
 
       if (result.error) {
-        console.error('[mlx-whisper] Transcription error:', result.error)
+        this.log.error('Transcription error:', result.error)
         return null
       }
 
@@ -94,7 +94,7 @@ export class MlxWhisperEngine extends SubprocessBridge implements STTEngine {
         timestamp: Date.now()
       }
     } finally {
-      try { unlinkSync(tempPath) } catch (e) { console.warn('[mlx-whisper] Failed to delete temp file:', e) }
+      try { unlinkSync(tempPath) } catch (e) { this.log.warn('Failed to delete temp file:', e) }
     }
   }
 }

--- a/src/engines/stt/QwenASREngine.ts
+++ b/src/engines/stt/QwenASREngine.ts
@@ -116,12 +116,12 @@ export class QwenASREngine extends SubprocessBridge implements STTEngine {
           sample_rate: sampleRate
         })
       } catch (err) {
-        console.error('[qwen-asr] Bridge error:', err instanceof Error ? err.message : err)
+        this.log.error('Bridge error:', err instanceof Error ? err.message : err)
         return null
       }
 
       if (result.error) {
-        console.error('[qwen-asr] Transcription error:', result.error)
+        this.log.error('Transcription error:', result.error)
         return null
       }
 
@@ -140,7 +140,7 @@ export class QwenASREngine extends SubprocessBridge implements STTEngine {
         timestamp: Date.now()
       }
     } finally {
-      try { unlinkSync(tempPath) } catch (e) { console.warn('[qwen-asr] Failed to delete temp file:', e) }
+      try { unlinkSync(tempPath) } catch (e) { this.log.warn('Failed to delete temp file:', e) }
     }
   }
 }

--- a/src/engines/stt/SenseVoiceEngine.ts
+++ b/src/engines/stt/SenseVoiceEngine.ts
@@ -89,12 +89,12 @@ export class SenseVoiceEngine extends SubprocessBridge implements STTEngine {
           sample_rate: sampleRate
         })
       } catch (err) {
-        console.error('[sensevoice] Bridge error:', err instanceof Error ? err.message : err)
+        this.log.error('Bridge error:', err instanceof Error ? err.message : err)
         return null
       }
 
       if (result.error) {
-        console.error('[sensevoice] Transcription error:', result.error)
+        this.log.error('Transcription error:', result.error)
         return null
       }
 
@@ -112,7 +112,7 @@ export class SenseVoiceEngine extends SubprocessBridge implements STTEngine {
         timestamp: Date.now()
       }
     } finally {
-      try { unlinkSync(tempPath) } catch (e) { console.warn('[sensevoice] Failed to delete temp file:', e) }
+      try { unlinkSync(tempPath) } catch (e) { this.log.warn('Failed to delete temp file:', e) }
     }
   }
 }

--- a/src/engines/stt/SherpaOnnxEngine.ts
+++ b/src/engines/stt/SherpaOnnxEngine.ts
@@ -85,7 +85,9 @@ export const SHERPA_ONNX_MODELS: Record<string, SherpaOnnxModelConfig> = {
   }
 }
 
-const LOG_PREFIX = '[sherpa-onnx]'
+import { createLogger } from '../../main/logger'
+
+const log = createLogger('sherpa-onnx')
 const MODELS_SUBDIR = 'sherpa-onnx'
 
 /**
@@ -133,7 +135,7 @@ export class SherpaOnnxEngine implements STTEngine {
 
     const modelConfig = SHERPA_ONNX_MODELS[this.modelKey]
     if (!modelConfig) {
-      throw new Error(`${LOG_PREFIX} Unknown model key: ${this.modelKey}`)
+      throw new Error(`${'[sherpa-onnx]'} Unknown model key: ${this.modelKey}`)
     }
 
     this.onProgress?.(`Loading Sherpa-ONNX ${modelConfig.label}...`)
@@ -147,7 +149,7 @@ export class SherpaOnnxEngine implements STTEngine {
     const modelDir = join(modelsRoot, modelConfig.dirName)
     if (!existsSync(modelDir)) {
       throw new Error(
-        `${LOG_PREFIX} Model directory not found: ${modelDir}. ` +
+        `${'[sherpa-onnx]'} Model directory not found: ${modelDir}. ` +
         `Download the model from https://github.com/k2-fsa/sherpa-onnx/releases ` +
         `and extract it to ${modelsRoot}/`
       )
@@ -160,7 +162,7 @@ export class SherpaOnnxEngine implements STTEngine {
       sherpaOnnx = require('sherpa-onnx-node') as SherpaOnnxModule
     } catch (err) {
       throw new Error(
-        `${LOG_PREFIX} Failed to load sherpa-onnx-node. ` +
+        `${'[sherpa-onnx]'} Failed to load sherpa-onnx-node. ` +
         `Install it with: npm install sherpa-onnx-node. ` +
         `Error: ${err instanceof Error ? err.message : err}`
       )
@@ -172,7 +174,7 @@ export class SherpaOnnxEngine implements STTEngine {
       this.recognizer = new sherpaOnnx.OfflineRecognizer(config)
     } catch (err) {
       throw new Error(
-        `${LOG_PREFIX} Failed to create recognizer: ${err instanceof Error ? err.message : err}`
+        `${'[sherpa-onnx]'} Failed to create recognizer: ${err instanceof Error ? err.message : err}`
       )
     }
 
@@ -241,13 +243,13 @@ export class SherpaOnnxEngine implements STTEngine {
         timestamp: Date.now()
       }
     } catch (err) {
-      console.error(`${LOG_PREFIX} Transcription error:`, err)
+      log.error('Transcription error:', err)
       return null
     }
   }
 
   async dispose(): Promise<void> {
-    console.log(`${LOG_PREFIX} Disposing resources`)
+    log.info('Disposing resources')
     // OfflineRecognizer is freed by GC; clear our reference
     this.recognizer = null
     this.initPromise = null

--- a/src/engines/stt/WhisperLocalEngine.ts
+++ b/src/engines/stt/WhisperLocalEngine.ts
@@ -3,6 +3,9 @@ import { getModelPath, isModelDownloaded, downloadModel } from '../model-downloa
 import type { WhisperVariant } from '../model-downloader'
 import { filterWhisperHallucination } from '../../pipeline/whisper-filter'
 import type { STTEngine, STTResult, Language } from '../types'
+import { createLogger } from '../../main/logger'
+
+const log = createLogger('whisper-local')
 
 export class WhisperLocalEngine implements STTEngine {
   readonly id = 'whisper-local'
@@ -79,7 +82,7 @@ export class WhisperLocalEngine implements STTEngine {
         timestamp: Date.now()
       }
     } catch (err) {
-      console.error('Whisper transcription error:', err)
+      log.error('Transcription error:', err)
       return null
     } finally {
       release!()
@@ -87,7 +90,7 @@ export class WhisperLocalEngine implements STTEngine {
   }
 
   async dispose(): Promise<void> {
-    console.log('[whisper-local] Disposing resources')
+    log.info('Disposing resources')
   }
 
   private detectLanguage(text: string): Language {

--- a/src/engines/translator/ANETranslator.ts
+++ b/src/engines/translator/ANETranslator.ts
@@ -82,7 +82,7 @@ export class ANETranslator extends SubprocessBridge implements TranslatorEngine 
     if (!text.trim()) return ''
     if (from === to) return text
     if (!this.process) {
-      console.error(`[ane-translate] Bridge not running for ${from}->${to}`)
+      this.log.error(`Bridge not running for ${from}->${to}`)
       return ''
     }
 
@@ -101,16 +101,13 @@ export class ANETranslator extends SubprocessBridge implements TranslatorEngine 
       })
 
       if (result.error) {
-        console.error('[ane-translate] Translation error:', result.error)
+        this.log.error('Translation error:', result.error)
         return ''
       }
 
       return (result.translated as string) || ''
     } catch (err) {
-      console.error(
-        '[ane-translate] Bridge error:',
-        err instanceof Error ? err.message : err
-      )
+      this.log.error('Bridge error:', err instanceof Error ? err.message : err)
       return ''
     }
   }

--- a/src/engines/translator/ApiRotationController.ts
+++ b/src/engines/translator/ApiRotationController.ts
@@ -1,4 +1,7 @@
 import type { TranslatorEngine, Language, TranslateContext } from '../types'
+import { createLogger } from '../../main/logger'
+
+const log = createLogger('rotation')
 
 export interface ProviderConfig {
   engine: TranslatorEngine
@@ -63,7 +66,7 @@ export class ApiRotationController implements TranslatorEngine {
           id: provider.engine.id,
           error: err instanceof Error ? err : new Error(String(err))
         })
-        console.warn(`[rotation] ${provider.engine.id} init failed:`, err)
+        log.warn(`${provider.engine.id} init failed:`, err)
       }
     }
 
@@ -107,15 +110,13 @@ export class ApiRotationController implements TranslatorEngine {
         // Cooldown elapsed — reset and retry
         this.failureCount.set(providerId, 0)
         this.failureDisabledAt.delete(providerId)
-        console.log(`[rotation] ${providerId}: cooldown elapsed, re-enabling`)
+        log.info(`${providerId}: cooldown elapsed, re-enabling`)
       }
 
       // Warn if approaching limit (90%)
       const usageRatio = record.charCount / provider.monthlyCharLimit
       if (usageRatio >= 0.9 && usageRatio < 1) {
-        console.warn(
-          `[rotation] ${providerId}: ${Math.round(usageRatio * 100)}% quota used (${record.charCount}/${provider.monthlyCharLimit})`
-        )
+        log.warn(`${providerId}: ${Math.round(usageRatio * 100)}% quota used (${record.charCount}/${provider.monthlyCharLimit})`)
       }
 
       try {
@@ -133,7 +134,7 @@ export class ApiRotationController implements TranslatorEngine {
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err)
         errors.push(`${providerId}: ${message}`)
-        console.error(`[rotation] ${providerId} failed:`, message)
+        log.error(`${providerId} failed:`, message)
 
         // Mark as exhausted on quota errors
         if (message.includes('Quota exceeded') || message.includes('456')) {
@@ -147,7 +148,7 @@ export class ApiRotationController implements TranslatorEngine {
         this.failureCount.set(providerId, currentFailures)
         if (currentFailures >= ApiRotationController.MAX_CONSECUTIVE_FAILURES) {
           this.failureDisabledAt.set(providerId, Date.now())
-          console.warn(`[rotation] ${providerId}: disabled after ${currentFailures} consecutive failures (cooldown 5min)`)
+          log.warn(`${providerId}: disabled after ${currentFailures} consecutive failures (cooldown 5min)`)
           this.onStatusUpdate?.(`${provider.engine.name} temporarily disabled after repeated failures`)
         }
 
@@ -163,7 +164,7 @@ export class ApiRotationController implements TranslatorEngine {
   async dispose(): Promise<void> {
     for (const provider of this.providers) {
       await provider.engine.dispose().catch((err) => {
-        console.warn(`[rotation] Error disposing ${provider.engine.id}:`, err)
+        log.warn(`Error disposing ${provider.engine.id}:`, err)
       })
     }
   }

--- a/src/engines/translator/CT2Madlad400Translator.ts
+++ b/src/engines/translator/CT2Madlad400Translator.ts
@@ -74,7 +74,7 @@ export class CT2Madlad400Translator extends SubprocessBridge implements Translat
   ): Promise<string> {
     if (!text.trim()) return ''
     if (!this.process) {
-      console.error(`[ct2-madlad-400] Bridge not running for translation to ${to}`)
+      this.log.error(`Bridge not running for translation to ${to}`)
       return ''
     }
 
@@ -86,16 +86,13 @@ export class CT2Madlad400Translator extends SubprocessBridge implements Translat
       })
 
       if (result.error) {
-        console.error('[ct2-madlad-400] Translation error:', result.error)
+        this.log.error('Translation error:', result.error)
         return ''
       }
 
       return (result.translated as string) || ''
     } catch (err) {
-      console.error(
-        '[ct2-madlad-400] Bridge error:',
-        err instanceof Error ? err.message : err
-      )
+      this.log.error('Bridge error:', err instanceof Error ? err.message : err)
       return ''
     }
   }

--- a/src/engines/translator/CT2OpusMTTranslator.ts
+++ b/src/engines/translator/CT2OpusMTTranslator.ts
@@ -77,7 +77,7 @@ export class CT2OpusMTTranslator extends SubprocessBridge implements TranslatorE
     if (!text.trim()) return ''
     if (from === to) return text
     if (!this.process) {
-      console.error(`[ct2-opus-mt] Bridge not running for ${from}->${to}`)
+      this.log.error(`Bridge not running for ${from}->${to}`)
       return ''
     }
 
@@ -91,16 +91,13 @@ export class CT2OpusMTTranslator extends SubprocessBridge implements TranslatorE
       })
 
       if (result.error) {
-        console.error('[ct2-opus-mt] Translation error:', result.error)
+        this.log.error('Translation error:', result.error)
         return ''
       }
 
       return (result.translated as string) || ''
     } catch (err) {
-      console.error(
-        '[ct2-opus-mt] Bridge error:',
-        err instanceof Error ? err.message : err
-      )
+      this.log.error('Bridge error:', err instanceof Error ? err.message : err)
       return ''
     }
   }

--- a/src/engines/translator/DeepLTranslator.ts
+++ b/src/engines/translator/DeepLTranslator.ts
@@ -1,5 +1,8 @@
 import type { TranslatorEngine, Language } from '../types'
 import { apiFetch, apiInitialize, DEFAULT_TIMEOUT_MS } from './api-utils'
+import { createLogger } from '../../main/logger'
+
+const log = createLogger('deepl')
 
 const DEEPL_FREE_URL = 'https://api-free.deepl.com/v2/translate'
 const DEEPL_PRO_URL = 'https://api.deepl.com/v2/translate'
@@ -86,6 +89,6 @@ export class DeepLTranslator implements TranslatorEngine {
   }
 
   async dispose(): Promise<void> {
-    console.log('[deepl] Disposing resources')
+    log.info('Disposing resources')
   }
 }

--- a/src/engines/translator/GeminiTranslator.ts
+++ b/src/engines/translator/GeminiTranslator.ts
@@ -1,6 +1,9 @@
 import type { TranslatorEngine, Language, TranslateContext } from '../types'
 import { LANG_NAMES_EN } from '../language-names'
 import { apiFetch, DEFAULT_TIMEOUT_MS } from './api-utils'
+import { createLogger } from '../../main/logger'
+
+const log = createLogger('gemini')
 
 const GEMINI_API_URL =
   'https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent'
@@ -85,6 +88,6 @@ export class GeminiTranslator implements TranslatorEngine {
   }
 
   async dispose(): Promise<void> {
-    console.log('[gemini] Disposing resources')
+    log.info('Disposing resources')
   }
 }

--- a/src/engines/translator/GoogleTranslator.ts
+++ b/src/engines/translator/GoogleTranslator.ts
@@ -1,5 +1,8 @@
 import type { TranslatorEngine, Language } from '../types'
 import { apiFetch, apiInitialize, DEFAULT_TIMEOUT_MS } from './api-utils'
+import { createLogger } from '../../main/logger'
+
+const log = createLogger('google-translate')
 
 const GOOGLE_TRANSLATE_URL = 'https://translation.googleapis.com/language/translate/v2'
 
@@ -57,6 +60,6 @@ export class GoogleTranslator implements TranslatorEngine {
   }
 
   async dispose(): Promise<void> {
-    console.log('[google-translate] Disposing resources')
+    log.info('Disposing resources')
   }
 }

--- a/src/engines/translator/HybridTranslator.ts
+++ b/src/engines/translator/HybridTranslator.ts
@@ -1,4 +1,7 @@
 import type { TranslatorEngine, Language, TranslateContext, TranslationResult } from '../types'
+import { createLogger } from '../../main/logger'
+
+const log = createLogger('hybrid')
 
 /**
  * Callback type for emitting draft translation results.
@@ -71,7 +74,7 @@ export class HybridTranslator implements TranslatorEngine {
       }
     } catch (err) {
       // If refinement fails, fall back to draft silently
-      console.warn('[hybrid] Refinement failed, using draft:', err)
+      log.warn('Refinement failed, using draft:', err)
     }
 
     return draftText
@@ -82,12 +85,12 @@ export class HybridTranslator implements TranslatorEngine {
     try {
       await this.draftEngine.dispose()
     } catch (err) {
-      console.warn('[hybrid] Error disposing draft engine:', err)
+      log.warn('Error disposing draft engine:', err)
     }
     try {
       await this.refineEngine.dispose()
     } catch (err) {
-      console.warn('[hybrid] Error disposing refine engine:', err)
+      log.warn('Error disposing refine engine:', err)
     }
   }
 }

--- a/src/engines/translator/MicrosoftTranslator.ts
+++ b/src/engines/translator/MicrosoftTranslator.ts
@@ -1,5 +1,8 @@
 import type { TranslatorEngine, Language } from '../types'
 import { apiFetch, apiInitialize, DEFAULT_TIMEOUT_MS } from './api-utils'
+import { createLogger } from '../../main/logger'
+
+const log = createLogger('microsoft-translate')
 
 const MS_TRANSLATE_URL = 'https://api.cognitive.microsofttranslator.com/translate'
 const API_VERSION = '3.0'
@@ -69,6 +72,6 @@ export class MicrosoftTranslator implements TranslatorEngine {
   }
 
   async dispose(): Promise<void> {
-    console.log('[microsoft-translate] Disposing resources')
+    log.info('Disposing resources')
   }
 }

--- a/src/engines/translator/OpusMTTranslator.ts
+++ b/src/engines/translator/OpusMTTranslator.ts
@@ -2,6 +2,9 @@ import { app } from 'electron'
 import { join } from 'path'
 import type { TranslatorEngine, Language } from '../types'
 import { isHallucination } from './hallucination-filter'
+import { createLogger } from '../../main/logger'
+
+const log = createLogger('opus-mt')
 
 // Dynamic import for ESM-only @huggingface/transformers
 type TranslationPipeline = ((text: string) => Promise<Array<{ translation_text: string }>>) & {
@@ -68,7 +71,7 @@ export class OpusMTTranslator implements TranslatorEngine {
 
     const pipe = from === 'ja' ? this.jaToEn : this.enToJa
     if (!pipe) {
-      console.error(`[opus-mt] Pipeline not initialized for ${from}→${to}`)
+      log.error(`Pipeline not initialized for ${from}→${to}`)
       return ''
     }
 
@@ -76,7 +79,7 @@ export class OpusMTTranslator implements TranslatorEngine {
     const translated = result[0]?.translation_text || ''
 
     if (isHallucination(trimmed, translated, from, to)) {
-      console.warn(`[opus-mt] Hallucination detected: "${trimmed}" → "${translated.substring(0, 80)}..." (filtered)`)
+      log.warn(`Hallucination detected: "${trimmed}" → "${translated.substring(0, 80)}..." (filtered)`)
       return ''
     }
 
@@ -84,14 +87,14 @@ export class OpusMTTranslator implements TranslatorEngine {
   }
 
   async dispose(): Promise<void> {
-    console.log('[opus-mt] Disposing resources')
+    log.info('Disposing resources')
     try {
       await Promise.all([
         this.jaToEn?.dispose(),
         this.enToJa?.dispose()
       ])
     } catch (err) {
-      console.error('[opus-mt] Error during pipeline disposal:', err)
+      log.error('Error during pipeline disposal:', err)
     }
     this.jaToEn = null
     this.enToJa = null

--- a/src/logger/SessionManager.ts
+++ b/src/logger/SessionManager.ts
@@ -10,6 +10,9 @@ import {
 } from 'fs'
 import { appendFile } from 'fs/promises'
 import type { TranslationResult } from '../engines/types'
+import { createLogger } from '../main/logger'
+
+const log = createLogger('session-manager')
 
 export interface SessionMetadata {
   id: string
@@ -83,7 +86,7 @@ export async function appendEntry(sessionId: string, result: TranslationResult):
   try {
     await appendFile(entriesPath, JSON.stringify(entry) + '\n', 'utf-8')
   } catch (err) {
-    console.error('[session-manager] Failed to append entry:', err)
+    log.error('Failed to append entry:', err)
   }
 }
 
@@ -108,7 +111,7 @@ export function endSession(sessionId: string): void {
 
     writeFileSync(path, JSON.stringify(data, null, 2))
   } catch (err) {
-    console.error('[session-manager] Failed to end session:', err)
+    log.error('Failed to end session:', err)
   }
 }
 

--- a/src/logger/TranscriptLogger.ts
+++ b/src/logger/TranscriptLogger.ts
@@ -3,6 +3,9 @@ import { join } from 'path'
 import { existsSync, mkdirSync, writeFileSync } from 'fs'
 import { appendFile } from 'fs/promises'
 import type { TranslationResult } from '../engines/types'
+import { createLogger } from '../main/logger'
+
+const log = createLogger('logger')
 
 export class TranscriptLogger {
   private logPath: string
@@ -59,11 +62,11 @@ export class TranscriptLogger {
       })
       .catch((err) => {
         this.consecutiveFailures++
-        console.error('[logger] Failed to write log entry:', err)
+        log.error('Failed to write log entry:', err)
         if (this.consecutiveFailures >= TranscriptLogger.MAX_FAILURES) {
           this.loggingDisabled = true
           const msg = `Transcript logging disabled after ${this.consecutiveFailures} failures: ${(err as Error).message}`
-          console.error(`[logger] ${msg}`)
+          log.error(msg)
           this.onStatusUpdate?.(msg)
         }
       })
@@ -84,7 +87,7 @@ export class TranscriptLogger {
     try {
       writeFileSync(this.logPath, footer, { encoding: 'utf-8', flag: 'a' })
     } catch (err) {
-      console.error('[logger] Failed to write session footer:', err)
+      log.error('Failed to write session footer:', err)
       this.onStatusUpdate?.(`Failed to write session footer: ${(err as Error).message}`)
     }
   }

--- a/src/main/slm-worker.ts
+++ b/src/main/slm-worker.ts
@@ -16,6 +16,9 @@
 
 import type { Llama, LlamaModel, LlamaContext, LlamaContextSequence } from 'node-llama-cpp'
 import { LANG_NAMES_EN, LANG_NAMES_ZH } from '../engines/language-names'
+import { createLogger } from './logger'
+
+const log = createLogger('slm-worker')
 
 type ModelType = 'translategemma' | 'hunyuan-mt' | 'hunyuan-mt-15' | 'gemma2-jpn' | 'alma-ja'
 
@@ -59,11 +62,11 @@ async function handleInit(
 ): Promise<void> {
   activeModelType = modelType ?? 'translategemma'
   const { getLlama } = await import('node-llama-cpp')
-  console.log('[slm-worker] Getting llama instance...')
+  log.info('Getting llama instance...')
   llama = await getLlama({ gpu: 'auto' })
-  console.log('[slm-worker] Loading model:', modelPath)
+  log.info('Loading model:', modelPath)
   model = await llama.loadModel({ modelPath })
-  console.log('[slm-worker] Model loaded, creating context...')
+  log.info('Model loaded, creating context...')
 
   const contextOptions: Record<string, unknown> = {
     contextSize: TRANSLATION_CONTEXT_SIZE
@@ -74,14 +77,14 @@ async function handleInit(
   }
   try {
     context = await model.createContext(contextOptions)
-    console.log('[slm-worker] Context created successfully')
+    log.info('Context created successfully')
   } catch (err) {
-    console.error('[slm-worker] createContext failed:', err)
+    log.error('createContext failed:', err)
     // Retry without KV cache quantization
     if (kvCacheQuant) {
-      console.log('[slm-worker] Retrying without KV cache quantization...')
+      log.info('Retrying without KV cache quantization...')
       context = await model.createContext({ contextSize: TRANSLATION_CONTEXT_SIZE })
-      console.log('[slm-worker] Context created without KV cache quant')
+      log.info('Context created without KV cache quant')
     } else {
       throw err
     }
@@ -98,9 +101,9 @@ async function handleInit(
       }
       draftContext = await draftModel.createContext(draftContextOptions)
       speculativeEnabled = true
-      console.log('[slm-worker] Speculative decoding enabled with draft model')
+      log.info('Speculative decoding enabled with draft model')
     } catch (err) {
-      console.error('[slm-worker] Failed to load draft model, falling back to standard decoding:', err)
+      log.error('Failed to load draft model, falling back to standard decoding:', err)
       draftModel = null
       draftContext = null
       speculativeEnabled = false
@@ -225,7 +228,7 @@ async function runInference(
   if (speculativeEnabled && contextSequence.tokenPredictions) {
     const stats = contextSequence.tokenPredictions
     const label = previousOutput !== undefined ? 'Incremental speculative' : 'Speculative'
-    console.log(`[slm-worker] ${label} stats — validated: ${stats.validated}, refuted: ${stats.refuted}`)
+    log.info(`${label} stats — validated: ${stats.validated}, refuted: ${stats.refuted}`)
   }
 
   // Clean up the session context to free memory

--- a/src/main/worker-pool.ts
+++ b/src/main/worker-pool.ts
@@ -18,6 +18,9 @@ import {
   WORKER_TRANSLATE_TIMEOUT_MS,
   WORKER_SUMMARIZE_TIMEOUT_MS
 } from '../engines/constants'
+import { createLogger } from './logger'
+
+const log = createLogger('worker-pool')
 
 /** Messages received from the slm-worker UtilityProcess */
 export type WorkerMessage =
@@ -146,7 +149,7 @@ class WorkerPool {
     this.worker = utilityProcess.fork(workerPath)
 
     this.worker.on('exit', (code) => {
-      console.log(`[worker-pool] Worker exited with code ${code}`)
+      log.info(`Worker exited with code ${code}`)
       this.worker = null
       this.currentModelPath = null
       this.initPromise = null
@@ -250,7 +253,7 @@ class WorkerPool {
         return
       }
       if (msg.type === 'error') {
-        console.error('[worker-pool] Worker error:', msg.message)
+        log.error('Worker error:', msg.message)
       }
     })
   }

--- a/src/pipeline/EngineManager.ts
+++ b/src/pipeline/EngineManager.ts
@@ -6,6 +6,9 @@ import type {
 } from '../engines/types'
 import { HybridTranslator } from '../engines/translator/HybridTranslator'
 import type { EventEmitter } from 'events'
+import { createLogger } from '../main/logger'
+
+const log = createLogger('pipeline')
 
 const ENGINE_INIT_TIMEOUT_MS = 5 * 60_000 // 5 minutes for model download
 
@@ -93,7 +96,7 @@ export class EngineManager {
         try {
           await engine.dispose()
         } catch (err) {
-          console.warn('[pipeline] Error during engine disposal:', err)
+          log.warn('Error during engine disposal:', err)
         }
       }
     }

--- a/src/pipeline/MemoryMonitor.ts
+++ b/src/pipeline/MemoryMonitor.ts
@@ -1,3 +1,7 @@
+import { createLogger } from '../main/logger'
+
+const log = createLogger('memory')
+
 /**
  * Periodically logs process memory usage.
  * Extracted from TranslationPipeline to isolate monitoring concerns.
@@ -34,8 +38,6 @@ export class MemoryMonitor {
     const elapsed = this.startedAt
       ? `${((Date.now() - this.startedAt) / 60_000).toFixed(1)}min`
       : '0min'
-    console.log(
-      `[memory] elapsed=${elapsed} heap=${mb(mem.heapUsed)}/${mb(mem.heapTotal)}MB rss=${mb(mem.rss)}MB external=${mb(mem.external)}MB`
-    )
+    log.info(`elapsed=${elapsed} heap=${mb(mem.heapUsed)}/${mb(mem.heapTotal)}MB rss=${mb(mem.rss)}MB external=${mb(mem.external)}MB`)
   }
 }

--- a/src/pipeline/StreamingProcessor.ts
+++ b/src/pipeline/StreamingProcessor.ts
@@ -9,6 +9,9 @@ import type { STTEngine } from '../engines/types'
 import type { LocalAgreement } from './LocalAgreement'
 import type { ContextBuffer } from './ContextBuffer'
 import type { SpeakerTracker } from './SpeakerTracker'
+import { createLogger } from '../main/logger'
+
+const log = createLogger('pipeline:stream')
 
 const MAX_STREAMING_LOCK_RESOLVERS = 50
 const STREAMING_LOCK_TIMEOUT_MS = 10_000
@@ -77,14 +80,14 @@ export class StreamingProcessor {
       const sttResult = await sttEngine.processAudio(audioBuffer, sampleRate)
       const sttMs = (performance.now() - t0).toFixed(0)
       if (!sttResult || !sttResult.text.trim()) {
-        console.log(`[pipeline:stream] STT: ${sttMs}ms → (no result, ${(audioBuffer.length / sampleRate).toFixed(1)}s audio)`)
+        log.info(`STT: ${sttMs}ms → (no result, ${(audioBuffer.length / sampleRate).toFixed(1)}s audio)`)
         // Reset agreement on silence to prevent stale state accumulation (#75)
         this.deps.agreement.reset()
         this.lastTranslatedConfirmed = ''
         this.simulMtPreviousOutput = ''
         return null
       }
-      console.log(`[pipeline:stream] STT: ${sttMs}ms → "${sttResult.text}" [${sttResult.language}]`)
+      log.info(`STT: ${sttMs}ms → "${sttResult.text}" [${sttResult.language}]`)
 
       const agreement = this.deps.agreement.update(sttResult.text)
       const targetLang = this.deps.resolveTargetLanguage(sttResult.language)
@@ -239,7 +242,7 @@ export class StreamingProcessor {
         const idx = this.streamingLockResolvers.indexOf(resolve)
         if (idx !== -1) {
           this.streamingLockResolvers.splice(idx, 1)
-          console.warn('[pipeline] streamingLock wait timed out')
+          log.warn('streamingLock wait timed out')
           resolve()
         }
       }, STREAMING_LOCK_TIMEOUT_MS)

--- a/src/pipeline/TranslationPipeline.ts
+++ b/src/pipeline/TranslationPipeline.ts
@@ -15,6 +15,9 @@ import { SpeakerTracker } from './SpeakerTracker'
 import { EngineManager } from './EngineManager'
 import { StreamingProcessor } from './StreamingProcessor'
 import { MemoryMonitor } from './MemoryMonitor'
+import { createLogger } from '../main/logger'
+
+const log = createLogger('pipeline')
 
 export interface PipelineEvents {
   result: (result: TranslationResult) => void
@@ -127,7 +130,7 @@ export class TranslationPipeline extends EventEmitter {
     const prev = this._state
     this._state = newState
     this.emit('state-change', newState)
-    console.log(`[pipeline] ${prev} → ${newState}`)
+    log.info(`${prev} → ${newState}`)
   }
 
   /** Whether the pipeline is actively processing audio */
@@ -241,7 +244,7 @@ export class TranslationPipeline extends EventEmitter {
 
   start(): void {
     if (this._state !== PipelineState.IDLE) {
-      console.warn(`[pipeline] Cannot start in state: ${this._state}`)
+      log.warn(`Cannot start in state: ${this._state}`)
       return
     }
     this.setState(PipelineState.RUNNING)
@@ -312,10 +315,10 @@ export class TranslationPipeline extends EventEmitter {
     const sttResult = await this.engineManager.sttEngine.processAudio(audioChunk, sampleRate)
     const sttMs = (performance.now() - t0).toFixed(0)
     if (!sttResult || !sttResult.isFinal || !sttResult.text.trim()) {
-      console.log(`[pipeline] STT: ${sttMs}ms → (no result)`)
+      log.info(`STT: ${sttMs}ms → (no result)`)
       return null
     }
-    console.log(`[pipeline] STT: ${sttMs}ms → "${sttResult.text}" [${sttResult.language}]`)
+    log.info(`STT: ${sttMs}ms → "${sttResult.text}" [${sttResult.language}]`)
 
     const targetLang = this.resolveTargetLanguage(sttResult.language)
 
@@ -335,7 +338,7 @@ export class TranslationPipeline extends EventEmitter {
         this.contextBuffer.getContext(glossary, speakerId)
       )
       const translateMs = (performance.now() - t1).toFixed(0)
-      console.log(`[pipeline] Translate: ${translateMs}ms → "${translated}"`)
+      log.info(`Translate: ${translateMs}ms → "${translated}"`)
 
       this.contextBuffer.add(sttResult.text, translated, speakerId)
 
@@ -348,7 +351,7 @@ export class TranslationPipeline extends EventEmitter {
         speakerId
       }
     } catch (translatorErr) {
-      console.error('[pipeline] Translator error:', translatorErr)
+      log.error('Translator error:', translatorErr)
       this.emit('error', new Error(`Translation failed: ${translatorErr instanceof Error ? translatorErr.message : translatorErr}`))
       return null
     }
@@ -357,7 +360,7 @@ export class TranslationPipeline extends EventEmitter {
   /** Fire-and-forget recovery — does not block the IPC handler (#218) */
   private scheduleRecovery(): void {
     this.attemptRecovery().catch((err) => {
-      console.error('[pipeline] Background recovery error:', err)
+      log.error('Background recovery error:', err)
     })
   }
 
@@ -365,7 +368,7 @@ export class TranslationPipeline extends EventEmitter {
     if (!this.canTransitionTo(PipelineState.RECOVERING) || !this.engineManager.config) return
     this.setState(PipelineState.RECOVERING)
 
-    console.log('[pipeline] Attempting auto-recovery after consecutive errors...')
+    log.info('Attempting auto-recovery after consecutive errors...')
     this.emit('engine-loading', 'Recovering from errors...')
 
     try {
@@ -385,9 +388,9 @@ export class TranslationPipeline extends EventEmitter {
       // switchEngine leaves us in IDLE, so start again
       this.setState(PipelineState.RUNNING)
       this.memoryMonitor.start()
-      console.log('[pipeline] Auto-recovery successful')
+      log.info('Auto-recovery successful')
     } catch (err) {
-      console.error('[pipeline] Auto-recovery failed:', err)
+      log.error('Auto-recovery failed:', err)
       this.consecutiveErrors = 0 // reset to prevent re-triggering
       this.setState(PipelineState.IDLE)
       this.emit('error', new Error('Auto-recovery failed. Please restart manually.'))


### PR DESCRIPTION
## Summary
- Replace direct `console.log/warn/error` calls with `createLogger()` across 27 main process files
- Add lazy `this.log` getter to `SubprocessBridge` base class so all bridge subclasses share structured logging
- Add `createLogger()` to `slm-worker.ts` (UtilityProcess) — the utility has no Electron dependencies
- Renderer files left unchanged (console.* is appropriate for DevTools output)

## Changes
- **Pipeline**: `TranslationPipeline`, `StreamingProcessor`, `EngineManager`, `MemoryMonitor`
- **STT engines**: `WhisperLocalEngine`, `SherpaOnnxEngine`, `MlxWhisperEngine`, `QwenASREngine`, `SenseVoiceEngine`
- **Translator engines**: `OpusMTTranslator`, `GoogleTranslator`, `DeepLTranslator`, `GeminiTranslator`, `MicrosoftTranslator`, `HybridTranslator`, `ApiRotationController`, `ANETranslator`, `CT2OpusMTTranslator`, `CT2Madlad400Translator`
- **Infrastructure**: `SubprocessBridge`, `worker-pool`, `slm-worker`, `model-downloader`, `plugin-loader`, `gpu-detector`
- **Logger utilities**: `TranscriptLogger`, `SessionManager`

## Test plan
- [x] `npm run lint` — 0 errors (8 pre-existing warnings)
- [x] `npm run build` — clean build
- [x] `npx vitest run` — 79/79 tests pass

Closes #382