### PR TITLE
#405 Add SherpaOnnx SenseVoice STT benchmark support

### DIFF
--- a/benchmark/package.json
+++ b/benchmark/package.json
@@ -29,7 +29,8 @@
     "stt:sensevoice": "tsx --expose-gc run.ts --stt --engines sensevoice",
     "stt:qwen": "tsx --expose-gc run.ts --stt --engines qwen-asr",
     "stt:sherpa": "tsx --expose-gc run.ts --stt --engines sherpa-onnx",
-    "stt:all": "tsx --expose-gc run.ts --stt --engines whisper-local,mlx-whisper,lightning-whisper,moonshine,sensevoice,qwen-asr,sherpa-onnx",
+    "stt:sherpa-sensevoice": "tsx --expose-gc run.ts --stt --engines sherpa-sensevoice",
+    "stt:all": "tsx --expose-gc run.ts --stt --engines whisper-local,mlx-whisper,lightning-whisper,moonshine,sensevoice,qwen-asr,sherpa-onnx,sherpa-sensevoice",
     "stt:generate-testset": "bash scripts/generate-stt-testset.sh"
   },
   "dependencies": {

--- a/benchmark/resources/sherpa-onnx-bridge.py
+++ b/benchmark/resources/sherpa-onnx-bridge.py
@@ -54,10 +54,35 @@ def init_model(model_name="sherpa-onnx-whisper-medium"):
             return
 
         # Detect model type and create recognizer
-        encoder = os.path.join(model_dir, f"{model_name}-encoder.onnx")
-        decoder = os.path.join(model_dir, f"{model_name}-decoder.onnx")
+        sensevoice_model = os.path.join(model_dir, "model.onnx")
+        paraformer_model = os.path.join(model_dir, "model.int8.onnx")
+        tokens = os.path.join(model_dir, "tokens.txt")
 
-        if os.path.exists(encoder) and os.path.exists(decoder):
+        # Encoder/decoder paths: try both plain and model-name-prefixed variants
+        encoder = os.path.join(model_dir, "encoder.onnx")
+        decoder = os.path.join(model_dir, "decoder.onnx")
+        if not os.path.exists(encoder):
+            encoder = os.path.join(model_dir, f"{model_name}-encoder.onnx")
+            decoder = os.path.join(model_dir, f"{model_name}-decoder.onnx")
+
+        name_lower = model_name.lower()
+
+        if ("sense-voice" in name_lower or "sensevoice" in name_lower) and os.path.exists(sensevoice_model):
+            # SenseVoice model (non-autoregressive, single model file)
+            recognizer = sherpa_onnx.OfflineRecognizer.from_sense_voice(
+                model=sensevoice_model,
+                tokens=tokens,
+                num_threads=4,
+                use_itn=True,
+            )
+        elif "paraformer" in name_lower and os.path.exists(paraformer_model):
+            # Paraformer model
+            recognizer = sherpa_onnx.OfflineRecognizer.from_paraformer(
+                paraformer=paraformer_model,
+                tokens=tokens,
+                num_threads=4,
+            )
+        elif os.path.exists(encoder) and os.path.exists(decoder):
             # Whisper-style model
             recognizer = sherpa_onnx.OfflineRecognizer.from_whisper(
                 encoder=encoder,
@@ -65,19 +90,22 @@ def init_model(model_name="sherpa-onnx-whisper-medium"):
                 num_threads=4,
             )
         else:
-            # Try int8 variants
-            encoder = os.path.join(model_dir, f"{model_name}-encoder.int8.onnx")
-            decoder = os.path.join(model_dir, f"{model_name}-decoder.int8.onnx")
-            if os.path.exists(encoder) and os.path.exists(decoder):
+            # Try int8 Whisper variants
+            encoder_int8 = os.path.join(model_dir, f"{model_name}-encoder.int8.onnx")
+            decoder_int8 = os.path.join(model_dir, f"{model_name}-decoder.int8.onnx")
+            if os.path.exists(encoder_int8) and os.path.exists(decoder_int8):
                 recognizer = sherpa_onnx.OfflineRecognizer.from_whisper(
-                    encoder=encoder,
-                    decoder=decoder,
+                    encoder=encoder_int8,
+                    decoder=decoder_int8,
                     num_threads=4,
                 )
             else:
                 output(
                     {
-                        "error": f"Could not find encoder/decoder files in {model_dir}"
+                        "error": f"Could not find model files in {model_dir}. "
+                        f"Expected one of: model.onnx (SenseVoice), "
+                        f"encoder.onnx+decoder.onnx (Whisper), "
+                        f"model.int8.onnx (Paraformer)"
                     }
                 )
                 return
@@ -117,9 +145,13 @@ def transcribe(audio_path, sample_rate=16000):
         stream.accept_waveform(sample_rate, samples)
         recognizer.decode_stream(stream)
 
-        text = stream.result.text
+        result = stream.result
+        text = result.text
 
-        output({"text": text.strip(), "language": "en"})
+        # SenseVoice may return language info via result.lang
+        lang = getattr(result, "lang", None) or "en"
+
+        output({"text": text.strip(), "language": lang})
     except Exception as e:
         output({"error": f"Transcription failed: {e}"})
 

--- a/benchmark/run.ts
+++ b/benchmark/run.ts
@@ -37,7 +37,8 @@ const AVAILABLE_STT_ENGINES = [
   'moonshine',
   'sensevoice',
   'qwen-asr',
-  'sherpa-onnx'
+  'sherpa-onnx',
+  'sherpa-sensevoice'
 ] as const
 type STTEngineId = (typeof AVAILABLE_STT_ENGINES)[number]
 
@@ -224,6 +225,14 @@ async function createSTTEngine(id: STTEngineId): Promise<STTBenchmarkEngine> {
     case 'sherpa-onnx': {
       const { SherpaOnnxBench } = await import('./src/stt-engines/sherpa-onnx.js')
       return new SherpaOnnxBench()
+    }
+    case 'sherpa-sensevoice': {
+      const { SherpaOnnxBench } = await import('./src/stt-engines/sherpa-onnx.js')
+      return new SherpaOnnxBench({
+        model: 'sherpa-onnx-sense-voice-zh-en-ja-ko-yue-2024-07-17',
+        id: 'sherpa-sensevoice',
+        label: 'Sherpa-ONNX SenseVoice Small'
+      })
     }
   }
 }

--- a/benchmark/src/stt-engines/sherpa-onnx.ts
+++ b/benchmark/src/stt-engines/sherpa-onnx.ts
@@ -12,14 +12,16 @@ const BRIDGE_SCRIPT = join(__dirname, '..', '..', 'resources', 'sherpa-onnx-brid
  * Optimized for low-latency on-device inference.
  */
 export class SherpaOnnxBench implements STTBenchmarkEngine {
-  readonly id = 'sherpa-onnx'
-  readonly label = 'Sherpa-ONNX'
+  readonly id: string
+  readonly label: string
 
   private bridge: PythonBridge
   private model: string
 
-  constructor(options?: { model?: string }) {
+  constructor(options?: { model?: string; id?: string; label?: string }) {
     this.model = options?.model ?? 'sherpa-onnx-whisper-medium'
+    this.id = options?.id ?? 'sherpa-onnx'
+    this.label = options?.label ?? `Sherpa-ONNX (${this.model})`
     this.bridge = new PythonBridge(BRIDGE_SCRIPT)
   }
 


### PR DESCRIPTION
## Description
- Add SenseVoice and Paraformer model type support to `sherpa-onnx-bridge.py` (previously Whisper-only)
- Make `SherpaOnnxBench` constructor accept custom model/id/label for reuse across model types
- Register `sherpa-sensevoice` engine ID in benchmark runner with SenseVoice Small preset
- Add `stt:sherpa-sensevoice` npm script for standalone benchmarking

### How to run
```bash
# Download model first
# https://github.com/k2-fsa/sherpa-onnx/releases → sherpa-onnx-sense-voice-zh-en-ja-ko-yue-2024-07-17
cd benchmark && npm run stt:sherpa-sensevoice
```

Decision criteria from issue:
- CER ≤ 0.20 AND latency < 500ms → adopt as default STT
- CER > 0.25 → reject
- CER 0.20-0.25 → offer as "fast mode" option

## Related Issues
Closes #405