### PR TITLE
#407 Add profiling instrumentation for Hunyuan-MT P95 latency diagnosis

### DIFF
--- a/benchmark/src/runner.ts
+++ b/benchmark/src/runner.ts
@@ -64,6 +64,7 @@ async function runEngine(
         engine.translate(sentence.source, direction)
       )
 
+      const mem = snapshotMemory()
       results.push({
         id: sentence.id,
         source: sentence.source,
@@ -72,15 +73,18 @@ async function runEngine(
         direction: sentence.direction,
         domain: sentence.domain,
         length: sentence.length,
-        latencyMs: ms
+        latencyMs: ms,
+        inputCharCount: sentence.source.length,
+        rssMB: mem.rssMB
       })
 
       if ((i + 1) % 10 === 0) {
-        console.log(`  ${progress} ${ms.toFixed(0)}ms`)
+        console.log(`  ${progress} ${ms.toFixed(0)}ms inputLen=${sentence.source.length} rss=${mem.rssMB.toFixed(0)}MB`)
       }
     } catch (err) {
       const errorMsg = err instanceof Error ? err.message : String(err)
       console.error(`  ${progress} ERROR: ${errorMsg}`)
+      const mem = snapshotMemory()
       results.push({
         id: sentence.id,
         source: sentence.source,
@@ -90,6 +94,8 @@ async function runEngine(
         domain: sentence.domain,
         length: sentence.length,
         latencyMs: 0,
+        inputCharCount: sentence.source.length,
+        rssMB: mem.rssMB,
         error: errorMsg
       })
     }

--- a/benchmark/src/types.ts
+++ b/benchmark/src/types.ts
@@ -29,6 +29,8 @@ export interface SentenceResult {
   domain: string
   length: string
   latencyMs: number
+  inputCharCount: number
+  rssMB: number
   error?: string
 }
 

--- a/src/engines/translator/HunyuanMTTranslator.ts
+++ b/src/engines/translator/HunyuanMTTranslator.ts
@@ -2,6 +2,9 @@ import { join } from 'path'
 import type { TranslatorEngine, Language, TranslateContext } from '../types'
 import { getGGUFDir, downloadGGUF, getHunyuanMTVariants } from '../model-downloader'
 import { workerPool } from '../../main/worker-pool'
+import { createLogger } from '../../main/logger'
+
+const log = createLogger('hunyuan-mt')
 
 /**
  * Hunyuan-MT-7B translator via node-llama-cpp UtilityProcess.
@@ -61,10 +64,14 @@ export class HunyuanMTTranslator implements TranslatorEngine {
       throw new Error('[hunyuan-mt-worker] Not initialized')
     }
 
-    return workerPool.sendRequest(
+    const t0 = performance.now()
+    const result = await workerPool.sendRequest(
       { type: 'translate', text, from, to, context },
       'translate'
     )
+    const ms = performance.now() - t0
+    log.info(`translate ${from}→${to} inputLen=${text.length} outputLen=${result.length} time=${ms.toFixed(0)}ms`)
+    return result
   }
 
   async translateIncremental(

--- a/src/main/slm-worker.ts
+++ b/src/main/slm-worker.ts
@@ -212,17 +212,22 @@ async function createContextSequence(): Promise<LlamaContextSequence> {
 async function runInference(
   prompt: string,
   previousOutput?: string
-): Promise<string> {
+): Promise<{ response: string; inferenceMs: number; contextMs: number }> {
   const { LlamaChatSession } = await import('node-llama-cpp')
 
+  const t0 = performance.now()
   const contextSequence = await createContextSequence()
+  const contextMs = performance.now() - t0
+
   const session = new LlamaChatSession({ contextSequence })
 
   const inferenceParams = getInferenceParams()
+  const t1 = performance.now()
   const response = await session.prompt(prompt, {
     ...inferenceParams,
     ...(previousOutput?.trim() && { responsePrefix: previousOutput })
   })
+  const inferenceMs = performance.now() - t1
 
   // Log speculative decoding stats for debugging
   if (speculativeEnabled && contextSequence.tokenPredictions) {
@@ -235,7 +240,7 @@ async function runInference(
   contextSequence.dispose?.()
   session.dispose?.()
 
-  return response.trim()
+  return { response: response.trim(), inferenceMs, contextMs }
 }
 
 async function handleTranslate(
@@ -255,13 +260,27 @@ async function handleTranslate(
   }
 
   try {
+    const memBefore = process.memoryUsage()
+    const t0 = performance.now()
     const prompt = buildTranslationPrompt(text, from, to, translateContext)
-    const result = await runInference(prompt)
+    const promptMs = performance.now() - t0
+
+    const { response, inferenceMs, contextMs } = await runInference(prompt)
+    const memAfter = process.memoryUsage()
+    const totalMs = performance.now() - t0
+
+    log.info(
+      `Profile: total=${totalMs.toFixed(0)}ms prompt=${promptMs.toFixed(0)}ms ` +
+      `ctx=${contextMs.toFixed(0)}ms inference=${inferenceMs.toFixed(0)}ms ` +
+      `inputLen=${text.length} outputLen=${response.length} ` +
+      `rss=${(memAfter.rss / 1048576).toFixed(0)}MB ` +
+      `heapDelta=${((memAfter.heapUsed - memBefore.heapUsed) / 1048576).toFixed(1)}MB`
+    )
 
     process.parentPort!.postMessage({
       type: 'result',
       id,
-      text: result
+      text: response
     })
   } catch (err) {
     process.parentPort!.postMessage({
@@ -290,13 +309,26 @@ async function handleTranslateIncremental(
   }
 
   try {
+    const memBefore = process.memoryUsage()
+    const t0 = performance.now()
     const prompt = buildTranslationPrompt(text, from, to, translateContext)
-    const result = await runInference(prompt, previousOutput)
+    const promptMs = performance.now() - t0
+    const { response, inferenceMs, contextMs } = await runInference(prompt, previousOutput)
+    const memAfter = process.memoryUsage()
+    const totalMs = performance.now() - t0
+
+    log.info(
+      `Profile(incr): total=${totalMs.toFixed(0)}ms prompt=${promptMs.toFixed(0)}ms ` +
+      `ctx=${contextMs.toFixed(0)}ms inference=${inferenceMs.toFixed(0)}ms ` +
+      `inputLen=${text.length} outputLen=${response.length} ` +
+      `rss=${(memAfter.rss / 1048576).toFixed(0)}MB ` +
+      `heapDelta=${((memAfter.heapUsed - memBefore.heapUsed) / 1048576).toFixed(1)}MB`
+    )
 
     process.parentPort!.postMessage({
       type: 'result',
       id,
-      text: result
+      text: response
     })
   } catch (err) {
     process.parentPort!.postMessage({

--- a/src/main/worker-pool.ts
+++ b/src/main/worker-pool.ts
@@ -111,6 +111,7 @@ class WorkerPool {
 
     const id = String(this.nextId++)
     const timeout = TIMEOUT_BY_TYPE[type]
+    const sendTime = performance.now()
 
     return new Promise<string>((resolve, reject) => {
       this.evictOldestPending()
@@ -120,7 +121,17 @@ class WorkerPool {
         reject(new Error(`Worker request timed out (${type})`))
       }, timeout)
 
-      this.pending.set(id, { resolve, reject, timer })
+      this.pending.set(id, {
+        resolve: (value: string) => {
+          const roundTripMs = performance.now() - sendTime
+          if (roundTripMs > 2000) {
+            log.info(`Request ${id} round-trip: ${roundTripMs.toFixed(0)}ms (${type})`)
+          }
+          resolve(value)
+        },
+        reject,
+        timer
+      })
       this.worker!.postMessage({ ...message, id })
     })
   }


### PR DESCRIPTION
## Description
- Add per-request profiling to `slm-worker.ts`: prompt build time, context creation time, inference time, memory before/after
- Add round-trip timing to `worker-pool.ts` (logs requests > 2s)
- Add input/output length and timing logs to `HunyuanMTTranslator.ts`
- Add per-sentence `inputCharCount` and `rssMB` to benchmark results for correlation analysis

### Profiling output format
```
[slm-worker] Profile: total=3717ms prompt=1ms ctx=12ms inference=3704ms inputLen=53 outputLen=42 rss=4150MB heapDelta=0.3MB
[hunyuan-mt] translate ja→en inputLen=53 outputLen=42 time=3720ms
[worker-pool] Request 42 round-trip: 3722ms (translate)
```

### Analysis from existing benchmark data
P95 spike correlates with input length:
- SHORT (9.6 chars): 1,315ms avg
- MEDIUM (26.4 chars): 3,125ms avg
- LONG (59.5 chars): 6,990ms avg (5.3x slower)

This profiling will confirm whether inference time (token generation) is the dominant factor or if memory/queue contention contributes.

## Related Issues
Closes #407