### PR TITLE
Sync docs with PR #411-414 changes

### DIFF
--- a/.claude/rules/engines.md
+++ b/.claude/rules/engines.md
@@ -22,21 +22,22 @@ globs: src/engines/**/*.ts, src/pipeline/**/*.ts
 - Lightning Whisper MLX — JA CER 162%
 - Moonshine — JA CER 221%
 
-### Translation Engines (5 primary + 6 experimental)
+### Translation Engines (5 primary + 7 experimental)
 
 **Primary (shown in UI):**
-| Engine | File | JA→EN | EN→JA | Memory | Offline |
-|--------|------|-------|-------|--------|---------|
-| OPUS-MT (fast default) | `OpusMTTranslator.ts` | 279ms | 462ms | 0.98GB | Yes |
-| Hunyuan-MT 7B (quality) | `HunyuanMTTranslator.ts` | 3.7s | 6.3s | 4GB | Yes |
-| Google Translate | `GoogleTranslator.ts` | Fast | Fast | — | No |
-| DeepL | `DeepLTranslator.ts` | Fast | Fast | — | No |
-| Gemini | `GeminiTranslator.ts` | Fast | Fast | — | No |
+| Engine | File | JA→EN | EN→JA | Memory | Offline | Context |
+|--------|------|-------|-------|--------|---------|---------|
+| CT2 OPUS-MT (fast default) | `CT2OpusMTTranslator.ts` | ~200ms | ~400ms | ~1GB | Yes | Glossary |
+| Hunyuan-MT 7B (quality) | `HunyuanMTTranslator.ts` | 3.7s | 6.3s | 4GB | Yes | Full |
+| Google Translate | `GoogleTranslator.ts` | Fast | Fast | — | No | — |
+| DeepL | `DeepLTranslator.ts` | Fast | Fast | — | No | API context |
+| Gemini | `GeminiTranslator.ts` | Fast | Fast | — | No | Full |
 
 **Experimental (hidden from UI):**
 - HybridTranslator (`HybridTranslator.ts`) — two-stage: OPUS-MT draft + LLM refinement
 - TranslateGemma (via `SLMTranslator.ts`) — 8s/sentence, too slow for real-time
-- HY-MT1.5 (`HunyuanMT15Translator.ts`), CT2 OPUS-MT, CT2 Madlad-400, ANE — under evaluation
+- ONNX OPUS-MT (`OpusMTTranslator.ts`) — fallback, superseded by CT2 version
+- HY-MT1.5 (`HunyuanMT15Translator.ts`), CT2 Madlad-400, ANE — under evaluation
 
 **Removed (benchmark failures):**
 - ALMA-Ja, Gemma-2-JPN
@@ -72,3 +73,5 @@ globs: src/engines/**/*.ts, src/pipeline/**/*.ts
 - `HunyuanMTTranslator`, `HunyuanMT15Translator`, and `SLMTranslator` all share this worker
 - Worker hot-swaps loaded models via dispose+init sequence without process restart
 - Also handles meeting summary generation
+- Per-request profiling logs: prompt build, context creation, inference time, memory (slm-worker)
+- Worker-pool logs round-trip timing for requests > 2s

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,8 +30,8 @@ npm install          # Install deps (postinstall fixes whisper-node-addon)
 - mlx-whisper (Python subprocess bridge, Apple Silicon — JA CER 8.1%, EN WER 3.8%)
 - node-llama-cpp (Hunyuan-MT 7B quality translation, meeting summaries, UtilityProcess)
 - @ricky0123/vad-web (Silero VAD)
-- Primary translation: OPUS-MT (279ms, offline), Hunyuan-MT 7B (3.7s, quality), Google, DeepL, Gemini
-- Experimental (hidden): TranslateGemma, HY-MT1.5, CT2 OPUS-MT, CT2 Madlad-400, ANE
+- Primary translation: CT2 OPUS-MT (~200ms, CTranslate2, default offline), Hunyuan-MT 7B (3.7s, quality), Google, DeepL, Gemini
+- Experimental (hidden): TranslateGemma, HY-MT1.5, ONNX OPUS-MT (fallback), CT2 Madlad-400, ANE, Hybrid
 - Local Agreement algorithm for streaming subtitle display
 
 ### Module Structure
@@ -78,12 +78,13 @@ live-translate/
 │   │   │   ├── QwenASREngine.ts         # Qwen ASR (experimental)
 │   │   │   └── SherpaOnnxEngine.ts      # Sherpa-ONNX (experimental)
 │   │   └── translator/
-│   │       ├── OpusMTTranslator.ts       # OPUS-MT (fast default, offline)
+│   │       ├── OpusMTTranslator.ts       # OPUS-MT ONNX (fallback, offline)
+│   │       ├── CT2OpusMTTranslator.ts    # CT2 OPUS-MT (fast default, ~200ms)
 │   │       ├── HunyuanMTTranslator.ts    # Hunyuan-MT 7B (quality, offline)
 │   │       ├── HunyuanMT15Translator.ts  # HY-MT1.5 (experimental)
 │   │       ├── HybridTranslator.ts       # Two-stage: OPUS-MT draft + LLM refine
 │   │       ├── GoogleTranslator.ts
-│   │       ├── DeepLTranslator.ts
+│   │       ├── DeepLTranslator.ts        # Context-aware via API context param
 │   │       ├── GeminiTranslator.ts
 │   │       ├── MicrosoftTranslator.ts
 │   │       ├── SLMTranslator.ts          # TranslateGemma (experimental)
@@ -111,7 +112,9 @@ live-translate/
 ├── scripts/
 │   ├── fix-whisper-addon.js        # postinstall: fix macOS dylib paths
 │   └── after-pack.js              # electron-builder: fix packaged paths
-├── benchmark/                     # Translation quality benchmark (standalone)
+├── benchmark/                     # Translation + STT quality benchmark (standalone)
+│   ├── src/engines/              # Translation benchmark engines (GGUF, API, ONNX)
+│   └── src/stt-engines/          # STT benchmark engines (Whisper, SenseVoice, SherpaOnnx)
 └── models/                        # Auto-downloaded models (gitignored)
 ```
 
@@ -143,7 +146,7 @@ live-translate/
 
 **Engine Auto-Selection**
 - GPU detection via node-llama-cpp `getGpuDeviceNames()`
-- Auto mode: API rotation (if keys) → Hunyuan-MT 7B (if GPU, quality) → OPUS-MT (fast default)
+- Auto mode: API rotation (if keys) → Hunyuan-MT 7B (if GPU, quality) → CT2 OPUS-MT (fast default)
 
 **Plugin System**
 - Plugins in `userData/plugins/` with `live-translate-plugin.json` manifest

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,8 +30,11 @@ Before acting, always pause and reconsider. Re-read the requirements, re-check y
 - VAD uses `AudioWorkletNode` via `processorType: 'AudioWorklet'` — do not revert to deprecated `ScriptProcessorNode`
 - electron-vite 2.x requires `build.lib.entry` for main/preload configs
 - Whisper model (~540MB) downloads on first launch — handle offline gracefully
-- TranslateGemma is experimental only (8s/sentence too slow for real-time) — OPUS-MT is the fast default (279ms)
+- TranslateGemma is experimental only (8s/sentence too slow for real-time)
+- CT2 OPUS-MT is the fast default (~200ms, CTranslate2 accelerated) — ONNX OPUS-MT is fallback
 - Hunyuan-MT 7B is quality mode only (3.7s JA→EN) — not suitable for real-time streaming
+- DeepL API supports `context` parameter for context-aware translation (no extra billing)
+- OPUS-MT engines (CT2 and ONNX) apply glossary via pre-translation term replacement
 - GGUF models (~2.6GB+) download with resume support and SHA256 verification
 - Google Cloud Translation API v2 free tier: 500K chars/month, 6000 req/min
 - node-llama-cpp runs in shared UtilityProcess pool (worker-pool.ts → slm-worker.ts), not main process


### PR DESCRIPTION
## Description
- Update CLAUDE.md: CT2 OPUS-MT as default, DeepL context support, glossary gotchas
- Update AGENTS.md: CT2 OPUS-MT in primary translation, ONNX OPUS-MT as fallback, benchmark directory structure, CT2OpusMTTranslator in module tree
- Update engines.md: Translation engine table with Context column, profiling log info in UtilityProcess section

## Related Issues
Follow-up to #404, #405, #406, #407