### PR TITLE
#408 Add Qwen3-ASR speech-swift (Swift native) STT engine

### DIFF
--- a/benchmark/src/stt-engines/qwen3-asr-swift.ts
+++ b/benchmark/src/stt-engines/qwen3-asr-swift.ts
@@ -1,0 +1,96 @@
+import { execFile } from 'child_process'
+import { existsSync } from 'fs'
+import type { STTBenchmarkEngine } from '../stt-types.js'
+
+/** Well-known paths where the speech-swift `audio` binary may be installed */
+const SPEECH_SWIFT_PATHS = [
+  '/opt/homebrew/bin/audio',
+  '/usr/local/bin/audio'
+]
+
+/**
+ * Qwen3-ASR STT benchmark engine via speech-swift (Swift native, Apple Silicon).
+ *
+ * Uses the `audio transcribe` CLI from speech-swift (qwen3-asr-swift).
+ * No Python dependency — pure Swift + MLX.
+ *
+ * Install: brew tap soniqo/speech https://github.com/soniqo/speech-swift && brew install speech
+ */
+export class Qwen3ASRSwiftBench implements STTBenchmarkEngine {
+  readonly id: string
+  readonly label: string
+
+  private binaryPath: string | null = null
+  private engine: string
+  private timeoutMs: number
+
+  constructor(options?: { variant?: '0.6b' | '1.7b'; timeoutMs?: number }) {
+    const variant = options?.variant ?? '0.6b'
+    this.engine = variant === '1.7b' ? 'qwen3-1.7b' : 'qwen3-mlx'
+    this.id = `qwen3-asr-swift-${variant}`
+    this.label = `Qwen3-ASR Swift ${variant.toUpperCase()}`
+    this.timeoutMs = options?.timeoutMs ?? 60_000
+  }
+
+  async initialize(): Promise<void> {
+    this.binaryPath = findSpeechSwiftBinary()
+    if (!this.binaryPath) {
+      throw new Error(
+        'speech-swift `audio` binary not found. Install via: ' +
+        'brew tap soniqo/speech https://github.com/soniqo/speech-swift && brew install speech'
+      )
+    }
+    console.log(`[qwen3-asr-swift] Using binary: ${this.binaryPath}, engine: ${this.engine}`)
+
+    // Warmup: trigger model download if needed
+    console.log(`[qwen3-asr-swift] Warming up (model download on first run)...`)
+    // We skip actual warmup transcription here — the first benchmark entry
+    // will be warmup (handled by stt-runner's WARMUP_COUNT).
+  }
+
+  async transcribe(audioPath: string): Promise<{ text: string; language?: string }> {
+    if (!this.binaryPath) {
+      throw new Error('Engine not initialized')
+    }
+
+    const text = await runTranscribe(this.binaryPath, this.engine, audioPath, this.timeoutMs)
+
+    return {
+      text: text.trim(),
+      language: undefined // speech-swift CLI does not output language info
+    }
+  }
+
+  async dispose(): Promise<void> {
+    this.binaryPath = null
+  }
+}
+
+/** Find the speech-swift `audio` binary */
+function findSpeechSwiftBinary(): string | null {
+  for (const p of SPEECH_SWIFT_PATHS) {
+    if (existsSync(p)) return p
+  }
+  return null
+}
+
+/** Run `audio transcribe --engine <engine> <file>` and return stdout text */
+function runTranscribe(
+  binaryPath: string,
+  engine: string,
+  audioPath: string,
+  timeoutMs: number
+): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const args = ['transcribe', '--engine', engine, audioPath]
+
+    execFile(binaryPath, args, { timeout: timeoutMs }, (err, stdout, stderr) => {
+      if (err) {
+        const msg = stderr?.trim() || err.message
+        reject(new Error(`speech-swift error: ${msg}`))
+        return
+      }
+      resolve(stdout)
+    })
+  })
+}

--- a/src/engines/constants.ts
+++ b/src/engines/constants.ts
@@ -82,6 +82,12 @@ export const QWEN_ASR_TRANSCRIBE_TIMEOUT_MS = 30_000
 /** Init timeout for Qwen-ASR bridge (ms) */
 export const QWEN_ASR_INIT_TIMEOUT_MS = 120_000
 
+/** Command timeout for speech-swift (Qwen3-ASR Swift) transcription (ms) */
+export const SPEECH_SWIFT_TRANSCRIBE_TIMEOUT_MS = 30_000
+
+/** Init timeout for speech-swift — first run triggers model download (ms) */
+export const SPEECH_SWIFT_INIT_TIMEOUT_MS = 300_000
+
 /** Command timeout for SenseVoice transcription (ms) */
 export const SENSEVOICE_TRANSCRIBE_TIMEOUT_MS = 30_000
 

--- a/src/engines/stt/SpeechSwiftEngine.ts
+++ b/src/engines/stt/SpeechSwiftEngine.ts
@@ -1,0 +1,261 @@
+import { execFile } from 'child_process'
+import { join } from 'path'
+import { writeFileSync, unlinkSync, existsSync } from 'fs'
+import { tmpdir } from 'os'
+import type { STTEngine, STTResult, Language } from '../types'
+import { createLogger } from '../../main/logger'
+import {
+  SPEECH_SWIFT_TRANSCRIBE_TIMEOUT_MS,
+  SPEECH_SWIFT_INIT_TIMEOUT_MS
+} from '../constants'
+
+const log = createLogger('speech-swift')
+
+/** speech-swift model variant */
+export type SpeechSwiftVariant = '0.6b' | '1.7b'
+
+/** speech-swift model variant configuration */
+export interface SpeechSwiftVariantConfig {
+  /** CLI engine flag value */
+  engine: string
+  /** Approximate memory usage in MB */
+  memoryMB: number
+  /** Human-readable label */
+  label: string
+  /** Description shown in UI */
+  description: string
+}
+
+/** Available speech-swift model variants */
+export const SPEECH_SWIFT_VARIANTS: Record<SpeechSwiftVariant, SpeechSwiftVariantConfig> = {
+  '0.6b': {
+    engine: 'qwen3-mlx',
+    memoryMB: 2200,
+    label: '0.6B (Fast)',
+    description: '0.6B params, ~2.2GB — RTF ~0.08, Swift native MLX'
+  },
+  '1.7b': {
+    engine: 'qwen3-1.7b',
+    memoryMB: 4000,
+    label: '1.7B (Best Quality)',
+    description: '1.7B params, ~4GB — SOTA accuracy, Swift native MLX'
+  }
+}
+
+/** Well-known paths where the speech-swift `audio` binary may be installed */
+const SPEECH_SWIFT_PATHS = [
+  '/opt/homebrew/bin/audio',
+  '/usr/local/bin/audio'
+]
+
+/**
+ * Qwen3-ASR STT engine via speech-swift (Swift native, Apple Silicon only).
+ *
+ * speech-swift (qwen3-asr-swift) provides a native Swift + MLX implementation
+ * of Qwen3-ASR. This engine spawns the `audio transcribe` CLI per audio chunk,
+ * avoiding any Python dependency.
+ *
+ * Install via Homebrew:
+ *   brew tap soniqo/speech https://github.com/soniqo/speech-swift
+ *   brew install speech
+ *
+ * Or build from source:
+ *   git clone https://github.com/soniqo/speech-swift && cd speech-swift && make build
+ */
+export class SpeechSwiftEngine implements STTEngine {
+  readonly id = 'speech-swift'
+  readonly name: string
+  readonly isOffline = true
+
+  private variant: SpeechSwiftVariant
+  private binaryPath: string | null = null
+  private initPromise: Promise<void> | null = null
+  private onProgress?: (message: string) => void
+
+  constructor(options?: {
+    variant?: SpeechSwiftVariant
+    onProgress?: (message: string) => void
+  }) {
+    this.variant = options?.variant ?? '0.6b'
+    this.onProgress = options?.onProgress
+    const config = SPEECH_SWIFT_VARIANTS[this.variant]
+    this.name = `Qwen3-ASR Swift (${config.label})`
+  }
+
+  async initialize(): Promise<void> {
+    if (this.initPromise) return this.initPromise
+    this.initPromise = this.doInitialize()
+    return this.initPromise
+  }
+
+  private async doInitialize(): Promise<void> {
+    if (this.binaryPath) return
+
+    this.onProgress?.('Locating speech-swift binary...')
+
+    // Find the `audio` binary
+    const found = findSpeechSwiftBinary()
+    if (!found) {
+      throw new Error(
+        'speech-swift `audio` binary not found. Install via Homebrew: ' +
+        'brew tap soniqo/speech https://github.com/soniqo/speech-swift && brew install speech'
+      )
+    }
+    this.binaryPath = found
+    log.info(`Using speech-swift binary: ${this.binaryPath}`)
+
+    // Warmup: run a version check / short transcription to trigger model download
+    this.onProgress?.('Warming up Qwen3-ASR (model download on first run)...')
+
+    const config = SPEECH_SWIFT_VARIANTS[this.variant]
+    const warmupPath = join(tmpdir(), `speech-swift-warmup-${Date.now()}.wav`)
+
+    try {
+      // Generate a short silent WAV for warmup (0.5s silence)
+      writeSilentWav(warmupPath, 8000, 16000)
+
+      await this.runTranscribe(warmupPath, SPEECH_SWIFT_INIT_TIMEOUT_MS)
+      this.onProgress?.(`Qwen3-ASR Swift ${config.label} ready`)
+    } catch (err) {
+      // If warmup fails, the binary may still work for real audio
+      log.warn('Warmup failed (model may still be downloading):', err)
+      this.onProgress?.(`Qwen3-ASR Swift ${config.label} ready (warmup skipped)`)
+    } finally {
+      try { unlinkSync(warmupPath) } catch { /* ignore */ }
+    }
+  }
+
+  async processAudio(audioChunk: Float32Array, sampleRate: number): Promise<STTResult | null> {
+    if (!this.binaryPath) return null
+
+    const tempPath = join(tmpdir(), `speech-swift-${Date.now()}.wav`)
+    try {
+      writeWav(tempPath, audioChunk, sampleRate)
+
+      const text = await this.runTranscribe(tempPath, SPEECH_SWIFT_TRANSCRIBE_TIMEOUT_MS)
+      if (!text.trim()) return null
+
+      // speech-swift does not output language info via CLI —
+      // use script-based fallback detection
+      const language = detectLanguageFallback(text.trim())
+
+      return {
+        text: text.trim(),
+        language,
+        isFinal: true,
+        timestamp: Date.now()
+      }
+    } catch (err) {
+      log.error('Transcription error:', err instanceof Error ? err.message : err)
+      return null
+    } finally {
+      try { unlinkSync(tempPath) } catch { /* ignore */ }
+    }
+  }
+
+  async dispose(): Promise<void> {
+    log.info('Disposing resources')
+    this.binaryPath = null
+    this.initPromise = null
+  }
+
+  /**
+   * Run `audio transcribe <file>` and return the stdout text.
+   */
+  private runTranscribe(audioPath: string, timeoutMs: number): Promise<string> {
+    return new Promise((resolve, reject) => {
+      if (!this.binaryPath) {
+        reject(new Error('Binary path not set'))
+        return
+      }
+
+      const config = SPEECH_SWIFT_VARIANTS[this.variant]
+      const args = ['transcribe', '--engine', config.engine, audioPath]
+
+      execFile(this.binaryPath, args, { timeout: timeoutMs }, (err, stdout, stderr) => {
+        if (err) {
+          const msg = stderr?.trim() || err.message
+          reject(new Error(`speech-swift error: ${msg}`))
+          return
+        }
+        resolve(stdout)
+      })
+    })
+  }
+}
+
+/** Find the speech-swift `audio` binary */
+function findSpeechSwiftBinary(): string | null {
+  for (const p of SPEECH_SWIFT_PATHS) {
+    if (existsSync(p)) return p
+  }
+  return null
+}
+
+/**
+ * Fallback script-based language detection when the model does not
+ * provide a language field.
+ */
+function detectLanguageFallback(text: string): Language {
+  if (!text) return 'en'
+
+  const jpKana = text.match(/[\u3040-\u309F\u30A0-\u30FF]/g)
+  const jpCount = jpKana?.length ?? 0
+  if (jpCount / text.length > 0.3 && jpCount >= 2) return 'ja'
+
+  const cjk = text.match(/[\u4E00-\u9FFF\u3400-\u4DBF]/g)
+  const cjkCount = cjk?.length ?? 0
+  if (cjkCount / text.length > 0.3 && cjkCount >= 2 && jpCount === 0) return 'zh'
+
+  const ko = text.match(/[\uAC00-\uD7AF\u1100-\u11FF\u3130-\u318F]/g)
+  const koCount = ko?.length ?? 0
+  if (koCount / text.length > 0.3 && koCount >= 2) return 'ko'
+
+  const th = text.match(/[\u0E00-\u0E7F]/g)
+  const thCount = th?.length ?? 0
+  if (thCount / text.length > 0.3 && thCount >= 2) return 'th'
+
+  const ar = text.match(/[\u0600-\u06FF\u0750-\u077F]/g)
+  const arCount = ar?.length ?? 0
+  if (arCount / text.length > 0.3 && arCount >= 2) return 'ar'
+
+  return 'en'
+}
+
+/** Write Float32Array as a minimal WAV file */
+function writeWav(path: string, samples: Float32Array, sampleRate: number): void {
+  const numChannels = 1
+  const bitsPerSample = 16
+  const bytesPerSample = bitsPerSample / 8
+  const dataSize = samples.length * bytesPerSample
+  const buffer = Buffer.alloc(44 + dataSize)
+
+  // WAV header
+  buffer.write('RIFF', 0)
+  buffer.writeUInt32LE(36 + dataSize, 4)
+  buffer.write('WAVE', 8)
+  buffer.write('fmt ', 12)
+  buffer.writeUInt32LE(16, 16) // chunk size
+  buffer.writeUInt16LE(1, 20) // PCM
+  buffer.writeUInt16LE(numChannels, 22)
+  buffer.writeUInt32LE(sampleRate, 24)
+  buffer.writeUInt32LE(sampleRate * numChannels * bytesPerSample, 28)
+  buffer.writeUInt16LE(numChannels * bytesPerSample, 32)
+  buffer.writeUInt16LE(bitsPerSample, 34)
+  buffer.write('data', 36)
+  buffer.writeUInt32LE(dataSize, 40)
+
+  // Convert Float32 [-1, 1] to Int16
+  for (let i = 0; i < samples.length; i++) {
+    const s = Math.max(-1, Math.min(1, samples[i]))
+    buffer.writeInt16LE(Math.round(s * 32767), 44 + i * 2)
+  }
+
+  writeFileSync(path, buffer)
+}
+
+/** Write a short silent WAV file for warmup */
+function writeSilentWav(path: string, numSamples: number, sampleRate: number): void {
+  const samples = new Float32Array(numSamples)
+  writeWav(path, samples, sampleRate)
+}

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -4,6 +4,7 @@ import { WhisperLocalEngine } from '../engines/stt/WhisperLocalEngine'
 import { MlxWhisperEngine } from '../engines/stt/MlxWhisperEngine'
 import { SenseVoiceEngine } from '../engines/stt/SenseVoiceEngine'
 import { SherpaOnnxEngine } from '../engines/stt/SherpaOnnxEngine'
+import { SpeechSwiftEngine } from '../engines/stt/SpeechSwiftEngine'
 import { OpusMTTranslator } from '../engines/translator/OpusMTTranslator'
 import { CT2OpusMTTranslator } from '../engines/translator/CT2OpusMTTranslator'
 import { CT2Madlad400Translator } from '../engines/translator/CT2Madlad400Translator'
@@ -64,6 +65,12 @@ async function initPipeline(): Promise<void> {
     onProgress: (msg) => ctx.mainWindow?.webContents.send('status-update', msg),
     modelKey: (store.get('sherpaOnnxModel') as string) || undefined
   }))
+  // Experimental: requires speech-swift binary (Homebrew) — Apple Silicon only, not shown in UI
+  if (process.platform === 'darwin') {
+    ctx.pipeline.registerSTT('speech-swift', () => new SpeechSwiftEngine({
+      onProgress: (msg) => ctx.mainWindow?.webContents.send('status-update', msg)
+    }))
+  }
 
   // Register translator engines
   // ONNX-based OPUS-MT — fallback, superseded by CT2 version as default (#404)


### PR DESCRIPTION
## Description

Add experimental Qwen3-ASR STT engine via [speech-swift](https://github.com/ivan-digital/qwen3-asr-swift) — a Swift native + MLX implementation requiring no Python dependency. Apple Silicon only.

### Changes

- **`SpeechSwiftEngine.ts`** — New STT engine that spawns the `audio transcribe` CLI per audio chunk. Supports 0.6B (fast) and 1.7B (quality) variants. Uses script-based language fallback detection since the CLI outputs plain text only.
- **`constants.ts`** — Added `SPEECH_SWIFT_TRANSCRIBE_TIMEOUT_MS` (30s) and `SPEECH_SWIFT_INIT_TIMEOUT_MS` (300s for first-run model download).
- **`index.ts`** — Registered as experimental STT engine (macOS/darwin only, hidden from UI).
- **`benchmark/src/stt-engines/qwen3-asr-swift.ts`** — Benchmark engine for STT evaluation.

### Design decisions

- **CLI-per-request** instead of SubprocessBridge: speech-swift is a CLI tool (`audio transcribe <file>`) that outputs plain text, not a long-running JSON-over-stdio server. Using `execFile` per request is the natural fit.
- **Language detection fallback**: The CLI does not output language metadata, so we reuse the script-based Unicode range detection pattern from `SherpaOnnxEngine`.
- **Homebrew binary discovery**: Checks `/opt/homebrew/bin/audio` and `/usr/local/bin/audio`.

### Prerequisites

```bash
brew tap soniqo/speech https://github.com/soniqo/speech-swift
brew install speech
```

Closes #408