### PR TITLE
#409 Add GER async STT post-processing

### DIFF
--- a/src/engines/constants.ts
+++ b/src/engines/constants.ts
@@ -103,3 +103,16 @@ export const ANE_TRANSLATE_TIMEOUT_MS = 30_000
 
 /** Init timeout for ANE bridge — first-run CoreML conversion can be slow (ms) */
 export const ANE_INIT_TIMEOUT_MS = 600_000
+
+// ---------------------------------------------------------------------------
+// GER (Generative Error Correction) — async STT post-processing (#409)
+// ---------------------------------------------------------------------------
+
+/** STT confidence threshold below which GER correction is triggered (0.0–1.0) */
+export const GER_CONFIDENCE_THRESHOLD = 0.7
+
+/** Maximum latency allowed for GER correction before it is skipped (ms) */
+export const GER_TIMEOUT_MS = 2_000
+
+/** Minimum text length to consider for GER correction (chars) */
+export const GER_MIN_TEXT_LENGTH = 4

--- a/src/engines/types.ts
+++ b/src/engines/types.ts
@@ -39,6 +39,8 @@ export interface STTResult {
   timestamp: number
   /** Speaker identifier (if diarization is enabled) */
   speakerId?: string
+  /** STT confidence score (0.0–1.0). Used by GER to decide if correction is needed. */
+  confidence?: number
 }
 
 /** Translation pipeline result */
@@ -57,8 +59,8 @@ export interface TranslationResult {
   isInterim?: boolean
   /** Speaker identifier (if diarization is enabled) */
   speakerId?: string
-  /** Translation stage for hybrid mode: 'draft' (OPUS-MT) or 'refined' (LLM) */
-  translationStage?: 'draft' | 'refined'
+  /** Translation stage: 'draft' (OPUS-MT), 'refined' (LLM), or 'ger-corrected' (GER post-correction) */
+  translationStage?: 'draft' | 'refined' | 'ger-corrected'
 }
 
 /**

--- a/src/main/slm-worker.ts
+++ b/src/main/slm-worker.ts
@@ -28,6 +28,7 @@ type WorkerInboundMessage =
   | { type: 'translate'; id: string; text: string; from: string; to: string; context?: TranslateContextPayload }
   | { type: 'translate-incremental'; id: string; text: string; previousOutput: string; from: string; to: string; context?: TranslateContextPayload }
   | { type: 'summarize'; id: string; transcript: string }
+  | { type: 'ger-correct'; id: string; text: string; language: string; glossary?: Array<{ source: string; target: string }> }
   | { type: 'dispose' }
 
 interface TranslateContextPayload {
@@ -383,6 +384,69 @@ ${transcript}`
   }
 }
 
+/**
+ * Handle GER (Generative Error Correction) request.
+ * Performs selective correction of STT output focused on glossary terms,
+ * proper nouns, numbers, and units. Does NOT rewrite the entire text.
+ */
+async function handleGERCorrect(
+  id: string,
+  text: string,
+  language: string,
+  glossary?: Array<{ source: string; target: string }>
+): Promise<void> {
+  if (!context) {
+    process.parentPort!.postMessage({
+      type: 'error',
+      id,
+      message: 'Model not initialized'
+    })
+    return
+  }
+
+  try {
+    const t0 = performance.now()
+    const langName = LANG_NAMES_EN[language] ?? language
+
+    // Build a targeted correction prompt
+    const parts: string[] = []
+    parts.push(
+      `You are a speech recognition error corrector for ${langName}.`,
+      'Fix ONLY clear errors in proper nouns, numbers, units, and technical terms.',
+      'Do NOT rephrase or rewrite. Output the corrected text only.'
+    )
+
+    if (glossary && glossary.length > 0) {
+      const entries = glossary.map((g) => `  "${g.source}"`).join('\n')
+      parts.push(`\nKnown terms (correct spellings):\n${entries}`)
+    }
+
+    parts.push(`\nSTT output:\n${text}`)
+
+    const prompt = parts.join('\n')
+
+    const { response, inferenceMs } = await runInference(prompt)
+    const totalMs = performance.now() - t0
+
+    log.info(
+      `GER: total=${totalMs.toFixed(0)}ms inference=${inferenceMs.toFixed(0)}ms ` +
+      `inputLen=${text.length} outputLen=${response.length}`
+    )
+
+    process.parentPort!.postMessage({
+      type: 'result',
+      id,
+      text: response
+    })
+  } catch (err) {
+    process.parentPort!.postMessage({
+      type: 'error',
+      id,
+      message: err instanceof Error ? err.message : String(err)
+    })
+  }
+}
+
 async function handleDispose(): Promise<void> {
   try {
     if (draftContext) {
@@ -431,6 +495,9 @@ process.parentPort!.on('message', (e: { data: WorkerInboundMessage }) => {
         case 'summarize':
           await handleSummarize(msg.id, msg.transcript)
           break
+        case 'ger-correct':
+          await handleGERCorrect(msg.id, msg.text, msg.language, msg.glossary)
+          break
         case 'dispose':
           await handleDispose()
           break
@@ -444,7 +511,7 @@ process.parentPort!.on('message', (e: { data: WorkerInboundMessage }) => {
     }
   }
 
-  if (msg.type === 'translate' || msg.type === 'translate-incremental' || msg.type === 'summarize') {
+  if (msg.type === 'translate' || msg.type === 'translate-incremental' || msg.type === 'summarize' || msg.type === 'ger-correct') {
     // Queue to serialize context access
     requestQueue = requestQueue.then(handleMessage, handleMessage)
   } else {

--- a/src/main/worker-pool.ts
+++ b/src/main/worker-pool.ts
@@ -43,12 +43,13 @@ export interface WorkerInitOptions {
 }
 
 /** Timeout value by request type */
-export type RequestType = 'translate' | 'translate-incremental' | 'summarize'
+export type RequestType = 'translate' | 'translate-incremental' | 'summarize' | 'ger-correct'
 
 const TIMEOUT_BY_TYPE: Record<RequestType, number> = {
   'translate': WORKER_TRANSLATE_TIMEOUT_MS,
   'translate-incremental': WORKER_TRANSLATE_TIMEOUT_MS,
-  'summarize': WORKER_SUMMARIZE_TIMEOUT_MS
+  'summarize': WORKER_SUMMARIZE_TIMEOUT_MS,
+  'ger-correct': WORKER_TRANSLATE_TIMEOUT_MS
 }
 
 /**

--- a/src/pipeline/GERProcessor.ts
+++ b/src/pipeline/GERProcessor.ts
@@ -1,0 +1,189 @@
+/**
+ * GER (Generative Error Correction) processor for async STT post-processing (#409).
+ *
+ * Design:
+ *   STT result → Translation (immediate, uncorrected) → Display
+ *            ↘ GER (async, background) → Re-translate if changed → Update display
+ *
+ * GER runs in the shared SLM UtilityProcess (worker-pool.ts → slm-worker.ts).
+ * It is selective: only triggers when STT confidence is below a threshold,
+ * and only corrects proper nouns, numbers, units, and glossary terms.
+ *
+ * This feature is experimental and disabled by default.
+ */
+
+import type { EventEmitter } from 'events'
+import type {
+  Language,
+  GlossaryEntry,
+  TranslatorEngine,
+  TranslationResult
+} from '../engines/types'
+import {
+  GER_CONFIDENCE_THRESHOLD,
+  GER_TIMEOUT_MS,
+  GER_MIN_TEXT_LENGTH
+} from '../engines/constants'
+import { workerPool } from '../main/worker-pool'
+import { createLogger } from '../main/logger'
+
+const log = createLogger('pipeline:ger')
+
+export interface GERDeps {
+  readonly emitter: EventEmitter
+  getTranslator(): TranslatorEngine | null
+  getGlossary(): GlossaryEntry[]
+}
+
+/**
+ * Async GER post-correction processor.
+ * Call `maybeCorrect()` after STT produces a result — it runs in the background
+ * and emits a 'ger-corrected' event if the corrected text differs.
+ */
+export class GERProcessor {
+  private enabled = false
+  private deps: GERDeps
+  /** Track in-flight corrections to avoid duplicate work */
+  private pendingTimestamp: number | null = null
+
+  constructor(deps: GERDeps) {
+    this.deps = deps
+  }
+
+  /** Enable or disable GER post-correction */
+  setEnabled(enabled: boolean): void {
+    this.enabled = enabled
+    log.info(`GER ${enabled ? 'enabled' : 'disabled'}`)
+  }
+
+  get isEnabled(): boolean {
+    return this.enabled
+  }
+
+  /**
+   * Attempt async GER correction on the given STT result.
+   * Returns immediately (fire-and-forget). If correction succeeds and
+   * the text differs, re-translates and emits 'ger-corrected' event.
+   *
+   * @param sttText - Raw STT text
+   * @param confidence - STT confidence (0.0–1.0), undefined means unknown
+   * @param language - Detected source language
+   * @param targetLanguage - Translation target language
+   * @param timestamp - Original result timestamp for deduplication
+   * @param speakerId - Speaker identifier
+   */
+  maybeCorrect(
+    sttText: string,
+    confidence: number | undefined,
+    language: Language,
+    targetLanguage: Language,
+    timestamp: number,
+    speakerId?: string
+  ): void {
+    if (!this.enabled) return
+
+    // Skip if text is too short to meaningfully correct
+    if (sttText.length < GER_MIN_TEXT_LENGTH) return
+
+    // Skip if confidence is above threshold (STT is confident enough)
+    if (confidence !== undefined && confidence >= GER_CONFIDENCE_THRESHOLD) {
+      log.info(`GER skipped: confidence ${confidence.toFixed(2)} >= ${GER_CONFIDENCE_THRESHOLD}`)
+      return
+    }
+
+    // Skip if worker is not alive (no SLM model loaded)
+    if (!workerPool.isAlive) {
+      log.info('GER skipped: SLM worker not running')
+      return
+    }
+
+    // Skip if another correction is already in flight
+    if (this.pendingTimestamp !== null) {
+      log.info('GER skipped: correction already in flight')
+      return
+    }
+
+    this.pendingTimestamp = timestamp
+    this.runCorrection(sttText, language, targetLanguage, timestamp, speakerId).catch((err) => {
+      log.warn('GER correction failed:', err)
+    }).finally(() => {
+      if (this.pendingTimestamp === timestamp) {
+        this.pendingTimestamp = null
+      }
+    })
+  }
+
+  /** Reset state (e.g., on pipeline stop) */
+  reset(): void {
+    this.pendingTimestamp = null
+  }
+
+  private async runCorrection(
+    sttText: string,
+    language: Language,
+    targetLanguage: Language,
+    timestamp: number,
+    speakerId?: string
+  ): Promise<void> {
+    const t0 = performance.now()
+
+    const glossaryEntries = this.deps.getGlossary()
+    const glossary = glossaryEntries.length > 0
+      ? glossaryEntries.map((g) => ({ source: g.source, target: g.target }))
+      : undefined
+
+    // Send GER request to the SLM worker with a timeout race
+    const correctedText = await Promise.race([
+      workerPool.sendRequest(
+        {
+          type: 'ger-correct',
+          text: sttText,
+          language,
+          glossary
+        },
+        'ger-correct'
+      ),
+      new Promise<string>((_resolve, reject) =>
+        setTimeout(() => reject(new Error('GER timed out')), GER_TIMEOUT_MS)
+      )
+    ])
+
+    const gerMs = performance.now() - t0
+    log.info(`GER: ${gerMs.toFixed(0)}ms "${sttText}" → "${correctedText}"`)
+
+    // Only proceed if the correction actually changed the text
+    const trimmedOriginal = sttText.trim()
+    const trimmedCorrected = correctedText.trim()
+    if (!trimmedCorrected || trimmedCorrected === trimmedOriginal) {
+      log.info('GER: no change, skipping re-translation')
+      return
+    }
+
+    // Re-translate the corrected text
+    const translator = this.deps.getTranslator()
+    if (!translator) {
+      log.warn('GER: no translator available for re-translation')
+      return
+    }
+
+    const translatedText = await translator.translate(
+      trimmedCorrected,
+      language,
+      targetLanguage
+    )
+
+    const result: TranslationResult = {
+      sourceText: trimmedCorrected,
+      translatedText,
+      sourceLanguage: language,
+      targetLanguage: targetLanguage,
+      timestamp,
+      isInterim: false,
+      speakerId,
+      translationStage: 'ger-corrected'
+    }
+
+    log.info(`GER corrected: "${trimmedOriginal}" → "${trimmedCorrected}" → "${translatedText}"`)
+    this.deps.emitter.emit('ger-corrected', result)
+  }
+}

--- a/src/pipeline/StreamingProcessor.ts
+++ b/src/pipeline/StreamingProcessor.ts
@@ -9,6 +9,7 @@ import type { STTEngine } from '../engines/types'
 import type { LocalAgreement } from './LocalAgreement'
 import type { ContextBuffer } from './ContextBuffer'
 import type { SpeakerTracker } from './SpeakerTracker'
+import type { GERProcessor } from './GERProcessor'
 import { createLogger } from '../main/logger'
 
 const log = createLogger('pipeline:stream')
@@ -29,6 +30,8 @@ export interface StreamingDeps {
   /** Notify that processing count changed */
   incrementProcessing(): void
   decrementProcessing(): void
+  /** GER processor for async STT post-correction */
+  getGER?(): GERProcessor | null
 }
 
 /**
@@ -210,6 +213,20 @@ export class StreamingProcessor {
       }
 
       this.deps.emitter.emit('result', result)
+
+      // Fire-and-forget GER correction on finalized result (async, non-blocking)
+      const ger = this.deps.getGER?.()
+      if (ger) {
+        ger.maybeCorrect(
+          agreement.confirmedText,
+          sttResult.confidence,
+          sttResult.language,
+          targetLang,
+          result.timestamp,
+          speakerId
+        )
+      }
+
       return result
     } catch (err) {
       this.deps.agreement.reset()

--- a/src/pipeline/TranslationPipeline.ts
+++ b/src/pipeline/TranslationPipeline.ts
@@ -14,6 +14,7 @@ import { ContextBuffer } from './ContextBuffer'
 import { SpeakerTracker } from './SpeakerTracker'
 import { EngineManager } from './EngineManager'
 import { StreamingProcessor } from './StreamingProcessor'
+import { GERProcessor } from './GERProcessor'
 import { MemoryMonitor } from './MemoryMonitor'
 import { createLogger } from '../main/logger'
 
@@ -24,6 +25,8 @@ export interface PipelineEvents {
   'interim-result': (result: TranslationResult) => void
   /** Draft result from hybrid translation mode — shown immediately before LLM refinement */
   'draft-result': (result: TranslationResult) => void
+  /** GER-corrected result — async post-correction of STT errors (#409) */
+  'ger-corrected': (result: TranslationResult) => void
   error: (error: Error) => void
   'engine-loading': (message: string) => void
   'engine-ready': () => void
@@ -96,6 +99,7 @@ export class TranslationPipeline extends EventEmitter {
   private engineManager = new EngineManager()
   private memoryMonitor = new MemoryMonitor()
   private streaming: StreamingProcessor
+  private ger: GERProcessor
 
   constructor() {
     super()
@@ -116,7 +120,13 @@ export class TranslationPipeline extends EventEmitter {
           for (const resolve of this.processingDoneResolvers) resolve()
           this.processingDoneResolvers = []
         }
-      }
+      },
+      getGER: () => this.ger
+    })
+    this.ger = new GERProcessor({
+      emitter: this,
+      getTranslator: () => this.engineManager.translator,
+      getGlossary: () => this.glossary
     })
   }
 
@@ -182,6 +192,11 @@ export class TranslationPipeline extends EventEmitter {
   setSimulMt(enabled: boolean, waitK: number): void {
     this.simulMtEnabled = enabled
     this.simulMtWaitK = Math.max(1, Math.min(waitK, 10))
+  }
+
+  /** Enable or disable GER (Generative Error Correction) post-processing (#409) */
+  setGEREnabled(enabled: boolean): void {
+    this.ger.setEnabled(enabled)
   }
 
   // --- Engine registration (delegated to EngineManager) ---
@@ -256,6 +271,7 @@ export class TranslationPipeline extends EventEmitter {
     this.memoryMonitor.stop()
     this.setState(PipelineState.IDLE)
     this.streaming.reset()
+    this.ger.reset()
     this.agreement.reset()
     this.contextBuffer.reset()
     this.speakerTracker.reset()
@@ -341,6 +357,16 @@ export class TranslationPipeline extends EventEmitter {
       log.info(`Translate: ${translateMs}ms → "${translated}"`)
 
       this.contextBuffer.add(sttResult.text, translated, speakerId)
+
+      // Fire-and-forget GER correction (async, non-blocking)
+      this.ger.maybeCorrect(
+        sttResult.text,
+        sttResult.confidence,
+        sttResult.language,
+        targetLang,
+        Date.now(),
+        speakerId
+      )
 
       return {
         sourceText: sttResult.text,


### PR DESCRIPTION
## Description

Adds Generative Error Correction (GER) as an async, non-blocking STT post-processing stage. GER uses the shared SLM UtilityProcess to selectively correct proper nouns, numbers, units, and glossary terms in STT output without blocking the main translation pipeline.

### Async design
```
STT result → Translation (immediate, uncorrected) → Display
         ↘ GER (async, background) → Re-translate if changed → Update display
```

### Changes
- **`STTResult.confidence`** — optional confidence field for STT engines to report
- **`GERProcessor`** (`src/pipeline/GERProcessor.ts`) — async post-correction orchestrator
  - Glossary-driven: focuses correction on known terms
  - Confidence-gated: only triggers below `GER_CONFIDENCE_THRESHOLD` (0.7)
  - Timeout-bounded: aborts if correction takes > 2s
  - Fire-and-forget: never blocks the pipeline
- **`slm-worker.ts`** — new `ger-correct` message type with targeted correction prompt
- **`worker-pool.ts`** — `ger-correct` request type added
- **`TranslationPipeline`** — `setGEREnabled()` method, GER integration in cascade mode
- **`StreamingProcessor`** — GER trigger on `finalizeStreaming()` results
- **`TranslationResult.translationStage`** — new `'ger-corrected'` stage
- **`constants.ts`** — GER constants (threshold, timeout, min text length)

### Experimental status
GER is disabled by default and not exposed in the UI. Enable programmatically via `pipeline.setGEREnabled(true)`.

Closes #409