### PR TITLE
#451 Remove unused eslint-disable directive in SherpaOnnxEngine

### DIFF
--- a/src/engines/stt/SherpaOnnxEngine.ts
+++ b/src/engines/stt/SherpaOnnxEngine.ts
@@ -156,7 +156,6 @@ export class SherpaOnnxEngine implements STTEngine {
     }
 
     // Dynamic require to avoid hard dependency — sherpa-onnx-node is optional.
-    // eslint-disable-next-line @typescript-eslint/no-var-requires
     let sherpaOnnx: SherpaOnnxModule
     try {
       sherpaOnnx = require('sherpa-onnx-node') as SherpaOnnxModule


### PR DESCRIPTION
## Description

Remove the unused `// eslint-disable-next-line @typescript-eslint/no-var-requires` directive in `SherpaOnnxEngine.ts` (line 159). The rule is no longer triggered, so the directive was flagged as unnecessary by ESLint.

Closes #451