### PR TITLE
#437 Remove unused writeFile import in model-downloader

### DIFF
--- a/src/engines/model-downloader.ts
+++ b/src/engines/model-downloader.ts
@@ -1,7 +1,6 @@
 import { app } from 'electron'
 import { join } from 'path'
 import { existsSync, mkdirSync, unlinkSync, statSync, createWriteStream } from 'fs'
-import { writeFile } from 'fs/promises'
 import { createHash } from 'crypto'
 import { createLogger } from '../main/logger'
 


### PR DESCRIPTION
## Description

Remove the unused `writeFile` import from `fs/promises` in `src/engines/model-downloader.ts` (line 4). The import was never used in the file.

Closes #437