### PR TITLE
#435 Remove unused constants in SubprocessBridge

### DIFF
--- a/src/engines/SubprocessBridge.ts
+++ b/src/engines/SubprocessBridge.ts
@@ -2,11 +2,9 @@ import { spawn, type ChildProcess } from 'child_process'
 import { existsSync, realpathSync } from 'fs'
 import { join } from 'path'
 import {
-  BRIDGE_DISPOSE_GRACE_MS,
   BRIDGE_STDERR_MAX_LINES,
   BRIDGE_STDERR_WINDOW_MS,
-  BRIDGE_MAX_PENDING_REQUESTS,
-  BRIDGE_PENDING_TIMEOUT_MS
+  BRIDGE_MAX_PENDING_REQUESTS
 } from './constants'
 import { createLogger, type Logger } from '../main/logger'
 


### PR DESCRIPTION
## Summary
- Remove unused imports `BRIDGE_DISPOSE_GRACE_MS` and `BRIDGE_PENDING_TIMEOUT_MS` from `SubprocessBridge.ts`
- Both constants were imported but never referenced in the file

## Test plan
- [x] `npm run lint` passes
- [x] `npm run typecheck` passes

Closes #435