### PR TITLE
#449 Remove stale model types gemma2-jpn, alma-ja from ModelType

### DIFF
--- a/src/main/slm-worker.ts
+++ b/src/main/slm-worker.ts
@@ -20,7 +20,7 @@ import { createLogger } from './logger'
 
 const log = createLogger('slm-worker')
 
-type ModelType = 'translategemma' | 'hunyuan-mt' | 'hunyuan-mt-15' | 'gemma2-jpn' | 'alma-ja'
+type ModelType = 'translategemma' | 'hunyuan-mt' | 'hunyuan-mt-15'
 
 /** Messages sent from main process to this worker */
 type WorkerInboundMessage =
@@ -180,7 +180,7 @@ function buildTranslationPrompt(
     return `${contextSection}Translate the following segment into ${toLang}, without additional explanation.\n\n${text}`
   }
 
-  // TranslateGemma, gemma2-jpn, alma-ja: simple translation prompt
+  // TranslateGemma: simple translation prompt
   return `${contextSection}Translate the following text from ${fromLang} to ${toLang}. Output only the translation, nothing else.\n\n${text}`
 }
 


### PR DESCRIPTION
## Description

Remove stale `gemma2-jpn` and `alma-ja` entries from the `ModelType` union in `slm-worker.ts`. These models were previously removed from the project (benchmark failures) but their type entries remained.

- Removed `'gemma2-jpn' | 'alma-ja'` from `ModelType` union type
- Updated comment referencing these models in `buildPrompt()`

Closes #449