### PR TITLE
#441 Fix glossary null safety in slm-worker buildContextPrompt

### DIFF
--- a/src/main/slm-worker.ts
+++ b/src/main/slm-worker.ts
@@ -126,7 +126,10 @@ function buildContextPrompt(ctx?: {
 
   // Glossary terms
   if (ctx.glossary && ctx.glossary.length > 0) {
-    const entries = ctx.glossary.map((g) => `  "${g.source}" → "${g.target}"`).join('\n')
+    const entries = ctx.glossary
+      .filter((g) => g.source && g.target)
+      .map((g) => `  "${g.source}" → "${g.target}"`)
+      .join('\n')
     parts.push(`Use these fixed translations for specific terms:\n${entries}`)
   }
 


### PR DESCRIPTION
## Description

Filter out glossary entries with null/undefined `source` or `target` before mapping in `buildContextPrompt()`. Without this fix, null entries produce literal `"undefined"` strings in the LLM context prompt.

Closes #441