### PR TITLE
#440 Add warning logs for suppressed errors in useNoiseSuppression cleanup

### DIFF
--- a/src/renderer/hooks/useNoiseSuppression.ts
+++ b/src/renderer/hooks/useNoiseSuppression.ts
@@ -54,18 +54,18 @@ export function useNoiseSuppression(): UseNoiseSuppressionReturn {
   const destroy = useCallback(async () => {
     try {
       workletNodeRef.current?.disconnect()
-    } catch { /* ignore */ }
+    } catch (e) { console.warn('[noise-suppression] Failed to disconnect worklet node:', e) }
     try {
       sourceNodeRef.current?.disconnect()
-    } catch { /* ignore */ }
+    } catch (e) { console.warn('[noise-suppression] Failed to disconnect source node:', e) }
 
     if (coreRef.current) {
-      try { coreRef.current.destroy() } catch { /* ignore */ }
+      try { coreRef.current.destroy() } catch (e) { console.warn('[noise-suppression] Failed to destroy core:', e) }
       coreRef.current = null
     }
 
     if (audioCtxRef.current && audioCtxRef.current.state !== 'closed') {
-      try { await audioCtxRef.current.close() } catch { /* ignore */ }
+      try { await audioCtxRef.current.close() } catch (e) { console.warn('[noise-suppression] Failed to close AudioContext:', e) }
     }
 
     audioCtxRef.current = null


### PR DESCRIPTION
## Description

Replace 4 silent `catch { /* ignore */ }` blocks in `useNoiseSuppression.ts` cleanup with `console.warn` logging, making it easier to debug cleanup failures.

Closes #440

## Test plan

- [ ] Verify lint and typecheck pass
- [ ] Confirm noise suppression cleanup errors are logged to console during development