### PR TITLE
Fix silently swallowed error in UpdateStatus

### DIFF
--- a/src/renderer/components/settings/UpdateStatus.tsx
+++ b/src/renderer/components/settings/UpdateStatus.tsx
@@ -14,7 +14,9 @@ export function UpdateStatus(): React.JSX.Element {
 
   useEffect(() => {
     // Load current status on mount
-    window.api.updateGetStatus().then(setUpdate).catch(() => {})
+    window.api.updateGetStatus().then(setUpdate).catch((err: unknown) => {
+      console.warn('Failed to fetch update status:', err)
+    })
 
     // Listen for status changes from main process
     const unsub = window.api.onUpdateStatus(setUpdate)


### PR DESCRIPTION
## Summary
- Replace empty `.catch(() => {})` with `console.warn` in `UpdateStatus.tsx` so update status fetch errors are logged instead of silently swallowed

## Test plan
- [ ] Verify lint and typecheck pass
- [ ] Simulate update status fetch failure and confirm warning appears in console

Closes #454