### PR TITLE
#439 Fix silent request eviction in worker-pool

### DIFF
--- a/src/main/worker-pool.ts
+++ b/src/main/worker-pool.ts
@@ -314,7 +314,14 @@ class WorkerPool {
       const oldest = this.pending.get(oldestKey)!
       this.pending.delete(oldestKey)
       clearTimeout(oldest.timer)
-      oldest.reject(new Error('Evicted: worker pending request limit exceeded'))
+      log.warn(
+        `Evicting oldest pending request ${oldestKey} — queue full (${WORKER_MAX_PENDING_REQUESTS})`
+      )
+      oldest.reject(
+        new Error(
+          `Evicted: pending request limit exceeded (max ${WORKER_MAX_PENDING_REQUESTS})`
+        )
+      )
     }
   }
 }


### PR DESCRIPTION
## Description

When pending requests exceed `WORKER_MAX_PENDING_REQUESTS`, the oldest request was evicted without any log output. While the promise was already being rejected, there was no warning log to help diagnose queue pressure issues.

- Add `log.warn` when evicting a pending request, including the request ID and queue limit
- Include the max limit in the rejection error message for clarity

Closes #439