### PR TITLE
#433 Fix event listener accumulation in worker-pool

### DIFF
--- a/src/main/worker-pool.ts
+++ b/src/main/worker-pool.ts
@@ -186,22 +186,32 @@ class WorkerPool {
 
   private initModel(options: WorkerInitOptions): Promise<void> {
     return new Promise<void>((resolve, reject) => {
-      const timeout = setTimeout(() => {
+      let settled = false
+
+      const cleanup = (): void => {
         this.worker?.removeListener('message', initHandler)
+      }
+
+      const timeout = setTimeout(() => {
+        if (settled) return
+        settled = true
+        cleanup()
         reject(new Error('Worker initialization timed out'))
       }, WORKER_INIT_TIMEOUT_MS)
 
       const initHandler = (msg: WorkerMessage): void => {
-        if (!this.worker) return
+        if (settled || !this.worker) return
 
         if (msg.type === 'ready') {
+          settled = true
           clearTimeout(timeout)
-          this.worker?.removeListener('message', initHandler)
+          cleanup()
           this.currentModelPath = options.modelPath
           resolve()
         } else if (msg.type === 'error') {
+          settled = true
           clearTimeout(timeout)
-          this.worker?.removeListener('message', initHandler)
+          cleanup()
           reject(new Error(msg.message))
         }
       }
@@ -224,12 +234,25 @@ class WorkerPool {
         return
       }
 
-      const timeout = setTimeout(resolve, WORKER_DISPOSE_GRACE_MS)
+      let settled = false
+
+      const cleanup = (): void => {
+        this.worker?.removeListener('message', disposeHandler)
+      }
+
+      const timeout = setTimeout(() => {
+        if (settled) return
+        settled = true
+        cleanup()
+        resolve()
+      }, WORKER_DISPOSE_GRACE_MS)
 
       const disposeHandler = (msg: WorkerMessage): void => {
+        if (settled) return
         if (msg.type === 'disposed') {
+          settled = true
           clearTimeout(timeout)
-          this.worker?.removeListener('message', disposeHandler)
+          cleanup()
           this.currentModelPath = null
           resolve()
         }
@@ -278,7 +301,7 @@ class WorkerPool {
     try {
       await new Promise<void>((resolve) => {
         const timeout = setTimeout(resolve, WORKER_DISPOSE_GRACE_MS)
-        this.worker!.on('message', (msg: WorkerMessage) => {
+        this.worker!.once('message', (msg: WorkerMessage) => {
           if (msg.type === 'disposed') {
             clearTimeout(timeout)
             resolve()


### PR DESCRIPTION
## Description

Fix event listener accumulation in `worker-pool.ts` where `worker.on('message', ...)` handlers were not guaranteed to be removed in all code paths.

### Changes

- **`initModel()`**: Added `settled` flag and `cleanup()` helper to guarantee listener removal whether the promise resolves via ready message, error message, or timeout
- **`disposeModel()`**: Same pattern — the timeout path previously called `resolve()` directly without removing the `disposeHandler` listener, causing accumulation on repeated hot-swaps
- **`killWorker()`**: Changed `worker.on()` to `worker.once()` for the one-shot dispose handler since the worker is killed immediately after

Closes #433