### PR TITLE
#419 Fix path traversal vulnerability in transcript path validation

### DIFF
--- a/src/main/ipc-handlers.ts
+++ b/src/main/ipc-handlers.ts
@@ -22,7 +22,7 @@ import { WsAudioServer } from './ws-audio-server'
 import type { AppContext } from './app-context'
 import type { EngineConfig } from '../engines/types'
 import { DEFAULT_WS_PORT, SAMPLE_RATE } from './constants'
-import { validateSessionId, validateSearchQuery, VALID_EXPORT_FORMATS } from './ipc-validators'
+import { validateSessionId, validateSearchQuery, validatePathWithinDir, VALID_EXPORT_FORMATS } from './ipc-validators'
 import type { ExportFormat } from './ipc-validators'
 
 const log = createLogger('ipc')
@@ -290,15 +290,14 @@ export function registerIpcHandlers(ctx: AppContext): void {
   // #124: Generate meeting summary from transcript
   ipcMain.handle('generate-summary', async (_event, transcriptPath: string) => {
     try {
-      // #150: Validate path is within expected logs directory
-      const { resolve } = await import('path')
+      // #150: Validate path is within expected logs directory (symlink-safe)
       const { readFileSync } = await import('fs')
       const logsDir = app.getPath('userData')
-      const resolved = resolve(transcriptPath)
-      if (!resolved.startsWith(logsDir)) {
+      const pathResult = validatePathWithinDir(transcriptPath, logsDir)
+      if ('error' in pathResult) {
         return { error: 'Invalid transcript path' }
       }
-      const transcript = readFileSync(resolved, 'utf-8')
+      const transcript = readFileSync(pathResult.path, 'utf-8')
 
       if (!transcript.trim()) {
         return { error: 'Transcript is empty' }

--- a/src/main/ipc-validators.test.ts
+++ b/src/main/ipc-validators.test.ts
@@ -1,5 +1,8 @@
-import { describe, it, expect } from 'vitest'
-import { validateSessionId, validateSearchQuery } from './ipc-validators'
+import { describe, it, expect, beforeAll, afterAll } from 'vitest'
+import { mkdirSync, writeFileSync, symlinkSync, rmSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+import { validateSessionId, validateSearchQuery, validatePathWithinDir } from './ipc-validators'
 
 describe('validateSessionId', () => {
   it('accepts valid session IDs', () => {
@@ -35,6 +38,60 @@ describe('validateSessionId', () => {
     expect(validateSessionId('id with spaces')).toBe('Session ID contains invalid characters')
     expect(validateSessionId('id:colon')).toBe('Session ID contains invalid characters')
     expect(validateSessionId('id.dot')).toBe('Session ID contains invalid characters')
+  })
+})
+
+describe('validatePathWithinDir', () => {
+  const testDir = join(tmpdir(), 'path-traversal-test-' + process.pid)
+  const innerDir = join(testDir, 'inner')
+  const outsideDir = join(tmpdir(), 'path-traversal-outside-' + process.pid)
+
+  beforeAll(() => {
+    mkdirSync(innerDir, { recursive: true })
+    mkdirSync(outsideDir, { recursive: true })
+    writeFileSync(join(innerDir, 'valid.txt'), 'ok')
+    writeFileSync(join(outsideDir, 'secret.txt'), 'secret')
+    // Create symlink inside testDir pointing outside
+    symlinkSync(join(outsideDir, 'secret.txt'), join(innerDir, 'symlink-escape.txt'))
+  })
+
+  afterAll(() => {
+    rmSync(testDir, { recursive: true, force: true })
+    rmSync(outsideDir, { recursive: true, force: true })
+  })
+
+  it('accepts a valid path within the base directory', () => {
+    const result = validatePathWithinDir(join(innerDir, 'valid.txt'), testDir)
+    expect(result).toHaveProperty('path')
+    expect((result as { path: string }).path).toContain('valid.txt')
+  })
+
+  it('rejects path traversal via ../', () => {
+    const result = validatePathWithinDir(join(testDir, '..', 'etc', 'passwd'), testDir)
+    expect(result).toHaveProperty('error')
+  })
+
+  it('rejects symlink that escapes the base directory', () => {
+    const result = validatePathWithinDir(join(innerDir, 'symlink-escape.txt'), testDir)
+    expect(result).toHaveProperty('error')
+  })
+
+  it('rejects non-existent path', () => {
+    const result = validatePathWithinDir(join(testDir, 'nonexistent.txt'), testDir)
+    expect(result).toHaveProperty('error')
+  })
+
+  it('rejects path with prefix trick (e.g. /base-dir-evil)', () => {
+    // Create a sibling dir whose name starts with testDir name
+    const trickDir = testDir + '-evil'
+    mkdirSync(trickDir, { recursive: true })
+    writeFileSync(join(trickDir, 'trick.txt'), 'trick')
+    try {
+      const result = validatePathWithinDir(join(trickDir, 'trick.txt'), testDir)
+      expect(result).toHaveProperty('error')
+    } finally {
+      rmSync(trickDir, { recursive: true, force: true })
+    }
   })
 })
 

--- a/src/main/ipc-validators.ts
+++ b/src/main/ipc-validators.ts
@@ -1,3 +1,36 @@
+import { resolve, relative } from 'path'
+import { realpathSync } from 'fs'
+
+/**
+ * Validate that a file path resolves to within the given base directory,
+ * resolving symlinks to prevent symlink-based traversal attacks.
+ * Returns the resolved real path if valid, or an error string.
+ */
+export function validatePathWithinDir(filePath: string, baseDir: string): { path: string } | { error: string } {
+  const resolved = resolve(filePath)
+
+  let realPath: string
+  try {
+    realPath = realpathSync(resolved)
+  } catch {
+    return { error: 'Invalid path' }
+  }
+
+  let realBase: string
+  try {
+    realBase = realpathSync(baseDir)
+  } catch {
+    return { error: 'Invalid base directory' }
+  }
+
+  const rel = relative(realBase, realPath)
+  if (rel.startsWith('..') || resolve(realBase, rel) !== realPath) {
+    return { error: 'Path is outside allowed directory' }
+  }
+
+  return { path: realPath }
+}
+
 /** Max length for session IDs */
 const SESSION_ID_MAX_LENGTH = 128
 


### PR DESCRIPTION
## Description

Fix path traversal vulnerability in the `generate-summary` IPC handler where `startsWith()` string check could be bypassed via symlinks or prefix tricks.

### Changes
- Extract reusable `validatePathWithinDir()` helper in `ipc-validators.ts` that uses `realpathSync()` + `path.relative()` for symlink-safe validation
- Replace vulnerable `startsWith()` check in `ipc-handlers.ts` with the new helper
- Add 5 test cases: valid path, `../` traversal, symlink escape, non-existent path, prefix trick (`/base-dir-evil`)
- Audited all other path validations in the file — `SessionManager` already uses `sanitizeId()` regex, no other vulnerable patterns found

Closes #419