### PR TITLE
#428 Fix pipeline event listener leak on re-init

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -37,8 +37,10 @@ const ctx: AppContext = {
 }
 
 async function initPipeline(): Promise<void> {
-  // Dispose previous pipeline to prevent listener accumulation on reinitialization (#383)
+  // Remove all event listeners and dispose previous pipeline to prevent
+  // listener accumulation on reinitialization (#383, #428)
   if (ctx.pipeline) {
+    ctx.pipeline.removeAllListeners()
     await ctx.pipeline.dispose()
     ctx.pipeline = null
   }


### PR DESCRIPTION
## Description

Pipeline event listeners (`result`, `interim-result`, `draft-result`, `error`, `engine-loading`, `engine-ready`) were registered in `initPipeline()` but never removed when the pipeline was disposed and re-created. Each re-init accumulated duplicate listeners, causing duplicate result forwarding and potential memory leaks.

Fix: Call `removeAllListeners()` on the old pipeline before disposing it.

Closes #428