### PR TITLE
#429 Refactor shared mutable ctx to getter/setter pattern

### DIFF
--- a/src/main/app-context.ts
+++ b/src/main/app-context.ts
@@ -4,8 +4,11 @@ import type { TranscriptLogger } from '../logger/TranscriptLogger'
 import type { WsAudioServer } from './ws-audio-server'
 
 /**
- * Shared mutable state accessed by all main-process modules.
- * Passed by reference so mutations are visible across modules.
+ * Shared application state accessed by all main-process modules.
+ *
+ * Properties are implemented as getters/setters backed by a private store
+ * so that closures always read the current instance — never a stale
+ * reference captured at registration time.
  */
 export interface AppContext {
   mainWindow: BrowserWindow | null
@@ -13,4 +16,61 @@ export interface AppContext {
   pipeline: TranslationPipeline | null
   logger: TranscriptLogger | null
   wsAudioServer: WsAudioServer | null
+}
+
+/** Backing store for AppContext getter/setter properties */
+interface AppContextStore {
+  mainWindow: BrowserWindow | null
+  subtitleWindow: BrowserWindow | null
+  pipeline: TranslationPipeline | null
+  logger: TranscriptLogger | null
+  wsAudioServer: WsAudioServer | null
+}
+
+/**
+ * Create an AppContext whose properties are getter/setter pairs.
+ * This prevents stale references: even if a consumer destructures or
+ * caches `ctx`, property access always reads from the backing store.
+ */
+export function createAppContext(): AppContext {
+  const store: AppContextStore = {
+    mainWindow: null,
+    subtitleWindow: null,
+    pipeline: null,
+    logger: null,
+    wsAudioServer: null
+  }
+
+  return Object.defineProperties({} as AppContext, {
+    mainWindow: {
+      get: () => store.mainWindow,
+      set: (v: BrowserWindow | null) => { store.mainWindow = v },
+      enumerable: true,
+      configurable: false
+    },
+    subtitleWindow: {
+      get: () => store.subtitleWindow,
+      set: (v: BrowserWindow | null) => { store.subtitleWindow = v },
+      enumerable: true,
+      configurable: false
+    },
+    pipeline: {
+      get: () => store.pipeline,
+      set: (v: TranslationPipeline | null) => { store.pipeline = v },
+      enumerable: true,
+      configurable: false
+    },
+    logger: {
+      get: () => store.logger,
+      set: (v: TranscriptLogger | null) => { store.logger = v },
+      enumerable: true,
+      configurable: false
+    },
+    wsAudioServer: {
+      get: () => store.wsAudioServer,
+      set: (v: WsAudioServer | null) => { store.wsAudioServer = v },
+      enumerable: true,
+      configurable: false
+    }
+  })
 }

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -21,20 +21,14 @@ import { registerAudioHandlers } from './audio-handlers'
 import { registerIpcHandlers } from './ipc-handlers'
 import { createLogger } from './logger'
 import { initAutoUpdater, registerUpdateHandlers, disposeAutoUpdater } from './auto-updater'
-import type { AppContext } from './app-context'
+import { createAppContext } from './app-context'
 import type { STTEngine, TranslatorEngine, E2ETranslationEngine, TranslationResult } from '../engines/types'
 import type { WhisperVariant } from '../engines/model-downloader'
 
 const log = createLogger('main')
 
-// Shared mutable state
-const ctx: AppContext = {
-  mainWindow: null,
-  subtitleWindow: null,
-  pipeline: null,
-  logger: null,
-  wsAudioServer: null
-}
+// Shared state — getter/setter backed so closures never hold stale references (#429)
+const ctx = createAppContext()
 
 async function initPipeline(): Promise<void> {
   // Remove all event listeners and dispose previous pipeline to prevent


### PR DESCRIPTION
## Description

Replace the plain `ctx` object in `src/main/index.ts` with a getter/setter-backed object created by `createAppContext()`. This ensures that closures registered during `initPipeline()` and IPC handler setup always read the **current** instance of `pipeline`, `mainWindow`, etc. — never a stale reference from a previous initialization cycle.

### Changes
- `src/main/app-context.ts`: Add `createAppContext()` factory that uses `Object.defineProperties` with getter/setter pairs backed by a private store
- `src/main/index.ts`: Replace plain object literal with `createAppContext()` call

### What stays the same
- `AppContext` interface is unchanged — all consumer modules (`ipc-handlers.ts`, `audio-handlers.ts`, `window-manager.ts`, `auto-updater.ts`) work without modification
- Property assignment (`ctx.pipeline = ...`) works identically

Closes #429