### PR TITLE
Add aria-live to subtitle overlay for screen reader support

### DIFF
--- a/src/renderer/components/SubtitleOverlay.tsx
+++ b/src/renderer/components/SubtitleOverlay.tsx
@@ -131,6 +131,9 @@ function SubtitleOverlay(): React.JSX.Element {
 
   return (
     <div
+      role="region"
+      aria-live="polite"
+      aria-label="Subtitles"
       style={{
         width: '100%',
         height: '100%',


### PR DESCRIPTION
## Summary
- Add `role="region"`, `aria-live="polite"`, and `aria-label="Subtitles"` to the subtitle container div in `SubtitleOverlay.tsx`
- Enables screen readers to announce dynamic subtitle updates and provides a named landmark for navigation

## Test plan
- [ ] Verify subtitle overlay still renders correctly with no visual changes
- [ ] Confirm screen reader (e.g., VoiceOver) announces new subtitle lines as they appear
- [ ] Verify the subtitle region appears as a landmark in accessibility navigation

Closes #423