### PR TITLE
#444 Fix speaker ID text overflow in subtitle overlay

### DIFF
--- a/src/renderer/components/SubtitleOverlay.tsx
+++ b/src/renderer/components/SubtitleOverlay.tsx
@@ -182,7 +182,7 @@ function SubtitleOverlay(): React.JSX.Element {
             }}
           >
             {line.speakerId && (
-              <span style={{ fontSize: '0.7em', opacity: 0.7, marginRight: '8px' }}>
+              <span style={{ fontSize: '0.7em', opacity: 0.7, marginRight: '8px', maxWidth: '120px', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', display: 'inline-block', verticalAlign: 'middle' }}>
                 [{line.speakerId}]
               </span>
             )}


### PR DESCRIPTION
## Summary
- Add `maxWidth`, `overflow: hidden`, `textOverflow: ellipsis`, `whiteSpace: nowrap` to the speaker ID `<span>` in SubtitleOverlay to prevent long speaker IDs from overflowing
- Also add `display: inline-block` and `verticalAlign: middle` so the truncation properties take effect on the inline element

Closes #444