### PR TITLE
Fix draft text style to differentiate from labels

### DIFF
--- a/src/renderer/components/SubtitleOverlay.tsx
+++ b/src/renderer/components/SubtitleOverlay.tsx
@@ -178,7 +178,8 @@ function SubtitleOverlay(): React.JSX.Element {
               fontWeight: 600,
               lineHeight: 1.4,
               textShadow: '0 1px 3px rgba(0,0,0,0.5)',
-              fontStyle: line.isInterim ? 'italic' : 'normal'
+              fontStyle: line.isInterim || line.isDraft ? 'italic' : 'normal',
+              opacity: line.isDraft ? 0.85 : 1
             }}
           >
             {line.speakerId && (
@@ -191,13 +192,14 @@ function SubtitleOverlay(): React.JSX.Element {
           {line.translatedText && (
             <div
               style={{
-                color: line.isInterim ? '#94a3b8' : line.isDraft ? '#a1a1aa' : config.translatedTextColor,
+                color: line.isInterim ? '#94a3b8' : line.isDraft ? '#b4b4bb' : config.translatedTextColor,
                 fontSize: `${translatedFontSize}px`,
                 fontWeight: 600,
                 lineHeight: 1.4,
                 marginTop: '2px',
                 textShadow: '0 1px 3px rgba(0,0,0,0.5)',
-                fontStyle: line.isInterim ? 'italic' : 'normal'
+                fontStyle: line.isInterim || line.isDraft ? 'italic' : 'normal',
+                opacity: line.isDraft ? 0.85 : 1
               }}
             >
               {line.translatedText}


### PR DESCRIPTION
## Summary
- Add `fontStyle: 'italic'` and `opacity: 0.85` to draft text (both source and translated) so it is visually distinct from label text
- Bump draft translated text color from `#a1a1aa` to `#b4b4bb` for better contrast

Closes #458

## Test plan
- [ ] Start pipeline and observe draft (in-progress) subtitle lines
- [ ] Verify draft text appears italic with slight transparency
- [ ] Verify finalized text remains normal style with full opacity
- [ ] Verify interim text still shows italic as before