### PR TITLE
#427 Fix subtitle overlay padding clipping on narrow screens

### DIFF
--- a/src/renderer/components/SubtitleOverlay.tsx
+++ b/src/renderer/components/SubtitleOverlay.tsx
@@ -140,7 +140,7 @@ function SubtitleOverlay(): React.JSX.Element {
         display: 'flex',
         flexDirection: 'column',
         justifyContent: config.position === 'top' ? 'flex-start' : 'flex-end',
-        padding: '1rem 3rem',
+        padding: '1rem clamp(1rem, 5%, 3rem)',
         fontFamily:
           '"Hiragino Sans", "Hiragino Kaku Gothic ProN", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif',
         userSelect: 'none'


### PR DESCRIPTION
## Summary
- Replace fixed `1rem 3rem` padding with responsive `1rem clamp(1rem, 5%, 3rem)` in SubtitleOverlay container
- Horizontal padding now scales between 1rem and 3rem based on viewport width, preventing text clipping on narrow screens or split view

## Test plan
- [ ] Resize subtitle overlay window to narrow width and verify text is not clipped
- [ ] Verify padding looks correct at normal/wide widths (should match previous 3rem)
- [ ] Test in split-view mode on macOS

Closes #427