### PR TITLE
#425 Increase glossary remove button touch target

### DIFF
--- a/src/renderer/components/settings/TranslatorSettings.tsx
+++ b/src/renderer/components/settings/TranslatorSettings.tsx
@@ -327,8 +327,9 @@ export function TranslatorSettings({
                   }}
                   disabled={disabled}
                   style={{
-                    padding: '2px 6px',
-                    fontSize: '11px',
+                    padding: '8px 16px',
+                    minHeight: '44px',
+                    fontSize: '12px',
                     background: '#334155',
                     color: '#ef4444',
                     border: 'none',


### PR DESCRIPTION
## Description

Increased the glossary term "Remove" button touch target from ~20px to 44px minimum height, improving usability on touch and pointer devices.

- Changed padding from `2px 6px` to `8px 16px`
- Added `minHeight: 44px` to meet accessibility tap target guidelines
- Bumped fontSize from 11px to 12px for readability

Closes #425