### PR TITLE
#442 Fix low contrast API toggle button text

### DIFF
--- a/src/renderer/components/settings/TranslatorSettings.tsx
+++ b/src/renderer/components/settings/TranslatorSettings.tsx
@@ -173,7 +173,7 @@ export function TranslatorSettings({
             style={{
               background: 'transparent',
               border: 'none',
-              color: '#64748b',
+              color: '#cbd5e1',
               fontSize: '11px',
               fontWeight: 600,
               textTransform: 'uppercase',


### PR DESCRIPTION
## Description

Change API toggle button text color from `#64748b` (slate-500) to `#cbd5e1` (slate-300) for better contrast against the dark settings panel background.

Closes #442