### PR TITLE
#424 Add role=progressbar to volume meter

### DIFF
--- a/src/renderer/components/settings/AudioSettings.tsx
+++ b/src/renderer/components/settings/AudioSettings.tsx
@@ -30,6 +30,11 @@ export function AudioSettings({ audio, disabled, noiseSuppressionEnabled, onNois
       {/* Volume meter */}
       <div style={{ marginTop: '6px', height: '4px', background: '#1e293b', borderRadius: '2px' }}>
         <div
+          role="progressbar"
+          aria-label="Volume level"
+          aria-valuenow={Math.round(audio.volume * 100)}
+          aria-valuemin={0}
+          aria-valuemax={100}
           style={{
             height: '100%',
             width: `${audio.volume * 100}%`,


### PR DESCRIPTION
## Summary
- Add `role="progressbar"`, `aria-label="Volume level"`, `aria-valuenow`, `aria-valuemin`, and `aria-valuemax` to the volume meter div in AudioSettings

## Test plan
- [ ] Verify volume meter is announced correctly by screen readers
- [ ] Confirm lint and typecheck pass

Closes #424