### PR TITLE
#459 Show empty state when audio device list is empty

### DIFF
--- a/src/renderer/components/settings/AudioSettings.tsx
+++ b/src/renderer/components/settings/AudioSettings.tsx
@@ -21,11 +21,17 @@ export function AudioSettings({ audio, disabled, noiseSuppressionEnabled, onNois
         disabled={disabled}
         aria-label="Microphone device"
       >
-        {audio.devices.map((d) => (
-          <option key={d.deviceId} value={d.deviceId}>
-            {d.label}
+        {audio.devices.length === 0 ? (
+          <option value="" disabled>
+            No audio devices found
           </option>
-        ))}
+        ) : (
+          audio.devices.map((d) => (
+            <option key={d.deviceId} value={d.deviceId}>
+              {d.label}
+            </option>
+          ))
+        )}
       </select>
       {/* Volume meter */}
       <div style={{ marginTop: '6px', height: '4px', background: '#1e293b', borderRadius: '2px' }}>


### PR DESCRIPTION
## Summary
- Display "No audio devices found" disabled option when `audio.devices` is empty instead of rendering an empty dropdown

## Test plan
- [ ] Verify dropdown shows "No audio devices found" when no devices are available
- [ ] Verify normal device list renders correctly when devices exist

Closes #459