### PR TITLE
#447 Fix export button touch target size

### DIFF
--- a/src/renderer/components/settings/SessionControls.tsx
+++ b/src/renderer/components/settings/SessionControls.tsx
@@ -165,7 +165,8 @@ export function SessionControls({
                     }
                   }}
                   style={{
-                    padding: '4px 8px',
+                    padding: '8px 12px',
+                    minHeight: '44px',
                     fontSize: '11px',
                     background: '#334155',
                     color: '#94a3b8',


### PR DESCRIPTION
## Description

Increased export button padding from `4px 8px` to `8px 12px` and added `minHeight: 44px` to meet the minimum touch target guideline. The previous ~24px height was too small for comfortable interaction.

Closes #447