### PR TITLE
#456 Add scroll indicator to session history

### DIFF
--- a/src/renderer/components/settings/SessionControls.tsx
+++ b/src/renderer/components/settings/SessionControls.tsx
@@ -142,7 +142,22 @@ export function SessionControls({
       {/* Session History */}
       {sessions.length > 0 && (
         <Section label="Session History">
-          <div style={{ maxHeight: '200px', overflowY: 'auto' }}>
+          <style>{`
+            .session-history-scroll::-webkit-scrollbar {
+              width: 6px;
+            }
+            .session-history-scroll::-webkit-scrollbar-track {
+              background: transparent;
+            }
+            .session-history-scroll::-webkit-scrollbar-thumb {
+              background: #475569;
+              border-radius: 3px;
+            }
+            .session-history-scroll::-webkit-scrollbar-thumb:hover {
+              background: #64748b;
+            }
+          `}</style>
+          <div className="session-history-scroll" style={{ maxHeight: '200px', overflowY: 'auto' }}>
             {sessions.slice(0, 10).map((s) => (
               <div key={s.id} style={{
                 display: 'flex',


### PR DESCRIPTION
## Summary
- Add custom WebKit scrollbar styling to the session history list (thin 6px thumb in slate-600/500 colors matching the dark theme)
- The scrollable area (`maxHeight: 200px, overflowY: auto`) now has a visible scroll indicator so users know content is scrollable

## Test plan
- [ ] Open Settings panel with more than ~4 sessions in history
- [ ] Verify a thin dark scrollbar thumb appears on the right side
- [ ] Verify scrollbar thumb highlights slightly on hover

Closes #456