### PR TITLE
#446 Fix error message overflow in UpdateStatus

### DIFF
--- a/src/renderer/components/settings/UpdateStatus.tsx
+++ b/src/renderer/components/settings/UpdateStatus.tsx
@@ -163,8 +163,8 @@ export function UpdateStatus(): React.JSX.Element {
         )}
 
         {update.state === 'error' && (
-          <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
-            <span style={{ fontSize: '12px', color: '#ef4444' }}>
+          <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', maxWidth: '100%' }}>
+            <span style={{ fontSize: '12px', color: '#ef4444', wordBreak: 'break-word', minWidth: 0 }}>
               Update check failed{update.error ? `: ${update.error}` : ''}
             </span>
             <button


### PR DESCRIPTION
## Description
Add `wordBreak: 'break-word'` and `minWidth: 0` to the error message `<span>`, and `maxWidth: '100%'` to its flex container, preventing long error text from overflowing horizontally.

Closes #446