### PR TITLE
#452 Convert hardcoded px height to rem in colorInputStyle

### DIFF
--- a/src/renderer/components/settings/shared.ts
+++ b/src/renderer/components/settings/shared.ts
@@ -91,7 +91,7 @@ export const sliderLabelStyle: React.CSSProperties = {
 
 export const colorInputStyle: React.CSSProperties = {
   width: '100%',
-  height: '32px',
+  height: '2rem',
   padding: '2px',
   background: '#1e293b',
   border: '1px solid #334155',


### PR DESCRIPTION
## Summary
- Convert `height: '32px'` to `height: '2rem'` in `colorInputStyle` (`src/renderer/components/settings/shared.ts`)

Closes #452