### PR TITLE
#448 Extract applyGlossary utility from translators

### DIFF
--- a/src/engines/translator/CT2OpusMTTranslator.ts
+++ b/src/engines/translator/CT2OpusMTTranslator.ts
@@ -2,6 +2,7 @@ import { join } from 'path'
 import type { TranslatorEngine, Language, TranslateContext } from '../types'
 import { SubprocessBridge, type SpawnConfig, type InitResult } from '../SubprocessBridge'
 import { CT2_OPUS_MT_TRANSLATE_TIMEOUT_MS, CT2_OPUS_MT_INIT_TIMEOUT_MS } from '../constants'
+import { applyGlossary } from './glossary-utils'
 
 /**
  * CTranslate2-accelerated OPUS-MT translator (#242).
@@ -82,14 +83,7 @@ export class CT2OpusMTTranslator extends SubprocessBridge implements TranslatorE
     }
 
     // Apply glossary term replacements before translation
-    let input = text
-    if (context?.glossary?.length) {
-      for (const entry of context.glossary) {
-        if (entry.source?.trim() && input.includes(entry.source)) {
-          input = input.replaceAll(entry.source, entry.target)
-        }
-      }
-    }
+    const input = applyGlossary(text, context?.glossary)
 
     const direction = from === 'ja' ? 'ja-en' : 'en-ja'
 

--- a/src/engines/translator/GeminiTranslator.ts
+++ b/src/engines/translator/GeminiTranslator.ts
@@ -1,6 +1,7 @@
 import type { TranslatorEngine, Language, TranslateContext } from '../types'
 import { LANG_NAMES_EN } from '../language-names'
 import { apiFetch, DEFAULT_TIMEOUT_MS } from './api-utils'
+import { formatGlossaryPrompt } from './glossary-utils'
 import { createLogger } from '../../main/logger'
 
 const log = createLogger('gemini')
@@ -42,9 +43,9 @@ export class GeminiTranslator implements TranslatorEngine {
 
     // Build context-enhanced prompt
     const contextParts: string[] = []
-    if (context?.glossary && context.glossary.length > 0) {
-      const entries = context.glossary.map((g) => `  "${g.source}" → "${g.target}"`).join('\n')
-      contextParts.push(`Use these fixed translations for specific terms:\n${entries}`)
+    const glossaryPrompt = formatGlossaryPrompt(context?.glossary)
+    if (glossaryPrompt) {
+      contextParts.push(glossaryPrompt)
     }
     if (context?.previousSegments && context.previousSegments.length > 0) {
       const history = context.previousSegments

--- a/src/engines/translator/OpusMTTranslator.ts
+++ b/src/engines/translator/OpusMTTranslator.ts
@@ -2,6 +2,7 @@ import { app } from 'electron'
 import { join } from 'path'
 import type { TranslatorEngine, Language, TranslateContext } from '../types'
 import { isHallucination } from './hallucination-filter'
+import { applyGlossary } from './glossary-utils'
 import { createLogger } from '../../main/logger'
 
 const log = createLogger('opus-mt')
@@ -70,14 +71,7 @@ export class OpusMTTranslator implements TranslatorEngine {
     if (trimmed.length < 3) return ''
 
     // Apply glossary term replacements before translation
-    let input = text
-    if (context?.glossary?.length) {
-      for (const entry of context.glossary) {
-        if (entry.source?.trim() && input.includes(entry.source)) {
-          input = input.replaceAll(entry.source, entry.target)
-        }
-      }
-    }
+    const input = applyGlossary(text, context?.glossary)
 
     const pipe = from === 'ja' ? this.jaToEn : this.enToJa
     if (!pipe) {

--- a/src/engines/translator/glossary-utils.ts
+++ b/src/engines/translator/glossary-utils.ts
@@ -1,0 +1,34 @@
+import type { GlossaryEntry } from '../types'
+
+/**
+ * Apply glossary term replacements to input text.
+ * Each glossary entry's source term is replaced with its target term.
+ * Skips entries with empty/whitespace-only source terms.
+ */
+export function applyGlossary(input: string, glossary: GlossaryEntry[] | undefined): string {
+  if (!glossary?.length) return input
+
+  let result = input
+  for (const entry of glossary) {
+    if (entry.source?.trim() && result.includes(entry.source)) {
+      result = result.replaceAll(entry.source, entry.target)
+    }
+  }
+  return result
+}
+
+/**
+ * Format glossary entries as a prompt section for LLM-based translators.
+ * Returns an empty string if glossary is empty or undefined.
+ */
+export function formatGlossaryPrompt(glossary: GlossaryEntry[] | undefined): string {
+  if (!glossary || glossary.length === 0) return ''
+
+  const entries = glossary
+    .filter((g) => g.source && g.target)
+    .map((g) => `  "${g.source}" → "${g.target}"`)
+    .join('\n')
+  if (!entries) return ''
+
+  return `Use these fixed translations for specific terms:\n${entries}`
+}

--- a/src/main/slm-worker.ts
+++ b/src/main/slm-worker.ts
@@ -16,6 +16,7 @@
 
 import type { Llama, LlamaModel, LlamaContext, LlamaContextSequence } from 'node-llama-cpp'
 import { LANG_NAMES_EN, LANG_NAMES_ZH } from '../engines/language-names'
+import { formatGlossaryPrompt } from '../engines/translator/glossary-utils'
 import { createLogger } from './logger'
 
 const log = createLogger('slm-worker')
@@ -125,12 +126,9 @@ function buildContextPrompt(ctx?: {
   const parts: string[] = []
 
   // Glossary terms
-  if (ctx.glossary && ctx.glossary.length > 0) {
-    const entries = ctx.glossary
-      .filter((g) => g.source && g.target)
-      .map((g) => `  "${g.source}" → "${g.target}"`)
-      .join('\n')
-    parts.push(`Use these fixed translations for specific terms:\n${entries}`)
+  const glossaryPrompt = formatGlossaryPrompt(ctx.glossary)
+  if (glossaryPrompt) {
+    parts.push(glossaryPrompt)
   }
 
   // Previous segments for coherence


### PR DESCRIPTION
## Description

Extract duplicated glossary logic into shared utility functions in `src/engines/translator/glossary-utils.ts`:

- `applyGlossary(input, glossary)` — replaceAll-based term substitution used by OpusMTTranslator and CT2OpusMTTranslator
- `formatGlossaryPrompt(glossary)` — prompt formatting used by GeminiTranslator and slm-worker

Updated 4 files to use the shared utilities:
- `OpusMTTranslator.ts`
- `CT2OpusMTTranslator.ts`
- `GeminiTranslator.ts`
- `slm-worker.ts`

Closes #448