### PR TITLE
#436 Add runtime validation for plugin manifest

### DIFF
--- a/src/engines/plugin-loader.test.ts
+++ b/src/engines/plugin-loader.test.ts
@@ -1,0 +1,163 @@
+import { describe, it, expect } from 'vitest'
+import { validateManifest } from './plugin-loader'
+
+function validManifest(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    name: 'test-plugin',
+    version: '1.0.0',
+    description: 'A test plugin',
+    engineType: 'stt',
+    engineId: 'test-stt',
+    entryPoint: 'index.js',
+    ...overrides
+  }
+}
+
+describe('validateManifest', () => {
+  it('accepts a valid manifest', () => {
+    expect(validateManifest(validManifest())).toBeNull()
+  })
+
+  it('accepts valid manifest with optional fields', () => {
+    expect(
+      validateManifest(
+        validManifest({
+          supportedLanguages: ['en', 'ja'],
+          author: 'Test Author',
+          homepage: 'https://example.com'
+        })
+      )
+    ).toBeNull()
+  })
+
+  it('accepts all engine types', () => {
+    for (const engineType of ['stt', 'translator', 'e2e']) {
+      expect(validateManifest(validManifest({ engineType }))).toBeNull()
+    }
+  })
+
+  // Non-object inputs
+  it('rejects null', () => {
+    expect(validateManifest(null)).toBe('Manifest must be a non-null object')
+  })
+
+  it('rejects array', () => {
+    expect(validateManifest([])).toBe('Manifest must be a non-null object')
+  })
+
+  it('rejects string', () => {
+    expect(validateManifest('string')).toBe('Manifest must be a non-null object')
+  })
+
+  // Required string fields
+  it.each(['name', 'version', 'description', 'engineId', 'entryPoint'])(
+    'rejects missing %s',
+    (field) => {
+      const m = validManifest()
+      delete m[field]
+      expect(validateManifest(m)).toContain(`"${field}" must be a string`)
+    }
+  )
+
+  it.each(['name', 'version', 'description', 'engineId', 'entryPoint'])(
+    'rejects empty %s',
+    (field) => {
+      expect(validateManifest(validManifest({ [field]: '' }))).toContain('must not be empty')
+    }
+  )
+
+  it.each(['name', 'version', 'description', 'engineId', 'entryPoint'])(
+    'rejects whitespace-only %s',
+    (field) => {
+      expect(validateManifest(validManifest({ [field]: '   ' }))).toContain('must not be empty')
+    }
+  )
+
+  // Version format
+  it('rejects invalid version format', () => {
+    expect(validateManifest(validManifest({ version: 'abc' }))).toContain('semver')
+  })
+
+  it('accepts version with prerelease', () => {
+    expect(validateManifest(validManifest({ version: '1.0.0-beta.1' }))).toBeNull()
+  })
+
+  // engineType
+  it('rejects invalid engineType', () => {
+    expect(validateManifest(validManifest({ engineType: 'invalid' }))).toContain(
+      '"engineType" must be one of'
+    )
+  })
+
+  it('rejects missing engineType', () => {
+    const m = validManifest()
+    delete m.engineType
+    expect(validateManifest(m)).toContain('"engineType" must be a string')
+  })
+
+  // engineId format
+  it('rejects engineId with special characters', () => {
+    expect(validateManifest(validManifest({ engineId: 'bad/id' }))).toContain(
+      'alphanumeric characters'
+    )
+  })
+
+  it('accepts engineId with hyphens and underscores', () => {
+    expect(validateManifest(validManifest({ engineId: 'my-engine_v2' }))).toBeNull()
+  })
+
+  // entryPoint path traversal
+  it('rejects entryPoint with path traversal', () => {
+    expect(validateManifest(validManifest({ entryPoint: '../escape.js' }))).toContain(
+      'traversal'
+    )
+  })
+
+  it('rejects entryPoint starting with absolute path', () => {
+    expect(validateManifest(validManifest({ entryPoint: '/etc/passwd' }))).toContain(
+      'relative path'
+    )
+  })
+
+  it('rejects entryPoint starting with backslash', () => {
+    expect(validateManifest(validManifest({ entryPoint: '\\windows\\bad' }))).toContain(
+      'relative path'
+    )
+  })
+
+  it('accepts nested entryPoint', () => {
+    expect(validateManifest(validManifest({ entryPoint: 'dist/index.js' }))).toBeNull()
+  })
+
+  // supportedLanguages
+  it('rejects non-array supportedLanguages', () => {
+    expect(validateManifest(validManifest({ supportedLanguages: 'en' }))).toContain(
+      'array of strings'
+    )
+  })
+
+  it('rejects supportedLanguages with non-string items', () => {
+    expect(validateManifest(validManifest({ supportedLanguages: ['en', 42] }))).toContain(
+      'non-empty strings'
+    )
+  })
+
+  it('rejects supportedLanguages with empty strings', () => {
+    expect(validateManifest(validManifest({ supportedLanguages: ['en', ''] }))).toContain(
+      'non-empty strings'
+    )
+  })
+
+  // Optional string fields
+  it('rejects non-string author', () => {
+    expect(validateManifest(validManifest({ author: 123 }))).toContain(
+      '"author" must be a string'
+    )
+  })
+
+  it('rejects non-string homepage', () => {
+    expect(validateManifest(validManifest({ homepage: true }))).toContain(
+      '"homepage" must be a string'
+    )
+  })
+})

--- a/src/engines/plugin-loader.ts
+++ b/src/engines/plugin-loader.ts
@@ -43,11 +43,13 @@ export function discoverPlugins(): LoadedPlugin[] {
     if (!existsSync(manifestPath)) continue
 
     try {
-      const manifest: PluginManifest = JSON.parse(readFileSync(manifestPath, 'utf-8'))
-      if (!validateManifest(manifest)) {
-        log.warn(`Invalid manifest in ${dir.name}, skipping`)
+      const raw: unknown = JSON.parse(readFileSync(manifestPath, 'utf-8'))
+      const error = validateManifest(raw)
+      if (error) {
+        log.warn(`Invalid manifest in ${dir.name}: ${error}`)
         continue
       }
+      const manifest = raw as PluginManifest
 
       plugins.push({
         manifest,
@@ -61,18 +63,77 @@ export function discoverPlugins(): LoadedPlugin[] {
   return plugins
 }
 
-/** Validate a plugin manifest has required fields */
-function validateManifest(manifest: unknown): manifest is PluginManifest {
-  if (typeof manifest !== 'object' || manifest === null) return false
+const VALID_ENGINE_TYPES = ['stt', 'translator', 'e2e'] as const
+const VERSION_RE = /^\d+\.\d+\.\d+/
+const SAFE_ID_RE = /^[a-zA-Z0-9_-]+$/
+
+/**
+ * Validate a plugin manifest has required fields with correct types.
+ * Returns null on success, or a human-readable error string on failure.
+ */
+export function validateManifest(manifest: unknown): string | null {
+  if (typeof manifest !== 'object' || manifest === null || Array.isArray(manifest)) {
+    return 'Manifest must be a non-null object'
+  }
+
   const m = manifest as Record<string, unknown>
-  return (
-    typeof m.name === 'string' &&
-    typeof m.version === 'string' &&
-    typeof m.engineType === 'string' &&
-    ['stt', 'translator', 'e2e'].includes(m.engineType as string) &&
-    typeof m.engineId === 'string' &&
-    typeof m.entryPoint === 'string'
-  )
+
+  // Required string fields
+  const requiredStrings: Array<{ key: string; label: string }> = [
+    { key: 'name', label: 'name' },
+    { key: 'version', label: 'version' },
+    { key: 'description', label: 'description' },
+    { key: 'engineId', label: 'engineId' },
+    { key: 'entryPoint', label: 'entryPoint' }
+  ]
+
+  for (const { key, label } of requiredStrings) {
+    if (typeof m[key] !== 'string') return `"${label}" must be a string`
+    if ((m[key] as string).trim().length === 0) return `"${label}" must not be empty`
+  }
+
+  // Version format
+  if (!VERSION_RE.test(m.version as string)) {
+    return '"version" must follow semver (e.g. "1.0.0")'
+  }
+
+  // engineType enum
+  if (typeof m.engineType !== 'string') return '"engineType" must be a string'
+  if (!(VALID_ENGINE_TYPES as readonly string[]).includes(m.engineType as string)) {
+    return `"engineType" must be one of: ${VALID_ENGINE_TYPES.join(', ')}`
+  }
+
+  // engineId must be safe (no special chars)
+  if (!SAFE_ID_RE.test(m.engineId as string)) {
+    return '"engineId" must contain only alphanumeric characters, hyphens, or underscores'
+  }
+
+  // entryPoint must not contain path traversal
+  const entry = m.entryPoint as string
+  if (entry.includes('..') || entry.startsWith('/') || entry.startsWith('\\')) {
+    return '"entryPoint" must be a relative path without traversal'
+  }
+
+  // Optional: supportedLanguages
+  if (m.supportedLanguages !== undefined) {
+    if (!Array.isArray(m.supportedLanguages)) {
+      return '"supportedLanguages" must be an array of strings'
+    }
+    for (const lang of m.supportedLanguages) {
+      if (typeof lang !== 'string' || lang.trim().length === 0) {
+        return '"supportedLanguages" must contain only non-empty strings'
+      }
+    }
+  }
+
+  // Optional string fields
+  for (const key of ['author', 'homepage']) {
+    if (m[key] !== undefined && typeof m[key] !== 'string') {
+      return `"${key}" must be a string if provided`
+    }
+  }
+
+  return null
 }
 
 /**


### PR DESCRIPTION
## Summary
- Replace the loose boolean `validateManifest` with a detailed validator that returns human-readable error strings
- Validate all required fields (name, version, description, engineType, engineId, entryPoint) for type, non-emptiness, and format
- Enforce semver format for version, safe characters for engineId, path-traversal prevention for entryPoint
- Validate optional fields (supportedLanguages array items, author, homepage)
- Log specific validation error when skipping invalid plugins
- Add comprehensive test suite (25 cases) covering valid manifests, missing/empty fields, bad formats, and edge cases

## Test plan
- [x] `npm run lint` passes
- [x] `npm run typecheck` passes
- [x] `npm run test` passes (120 tests including 25 new plugin-loader tests)

Closes #436