### PR TITLE
#434 Add runtime validation for SubtitleSettings IPC data

### DIFF
--- a/src/main/ipc-handlers.ts
+++ b/src/main/ipc-handlers.ts
@@ -22,7 +22,7 @@ import { WsAudioServer } from './ws-audio-server'
 import type { AppContext } from './app-context'
 import type { EngineConfig } from '../engines/types'
 import { DEFAULT_WS_PORT, SAMPLE_RATE } from './constants'
-import { validateSessionId, validateSearchQuery, validatePathWithinDir, VALID_EXPORT_FORMATS } from './ipc-validators'
+import { validateSessionId, validateSearchQuery, validatePathWithinDir, validateSubtitleSettings, VALID_EXPORT_FORMATS } from './ipc-validators'
 import type { ExportFormat } from './ipc-validators'
 
 const log = createLogger('ipc')
@@ -252,8 +252,13 @@ export function registerIpcHandlers(ctx: AppContext): void {
   })
 
   ipcMain.handle('save-subtitle-settings', (_event, settings: Record<string, unknown>) => {
-    store.set('subtitleSettings', settings as unknown as SubtitleSettings)
-    ctx.subtitleWindow?.webContents.send('subtitle-settings-changed', settings)
+    const validationError = validateSubtitleSettings(settings)
+    if (validationError) {
+      throw new Error(`Invalid subtitle settings: ${validationError}`)
+    }
+    const validated = settings as unknown as SubtitleSettings
+    store.set('subtitleSettings', validated)
+    ctx.subtitleWindow?.webContents.send('subtitle-settings-changed', validated)
   })
 
   ipcMain.handle('save-settings', (_event, settings: Record<string, unknown>) => {

--- a/src/main/ipc-validators.test.ts
+++ b/src/main/ipc-validators.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeAll, afterAll } from 'vitest'
 import { mkdirSync, writeFileSync, symlinkSync, rmSync } from 'fs'
 import { join } from 'path'
 import { tmpdir } from 'os'
-import { validateSessionId, validateSearchQuery, validatePathWithinDir } from './ipc-validators'
+import { validateSessionId, validateSearchQuery, validatePathWithinDir, validateSubtitleSettings } from './ipc-validators'
 
 describe('validateSessionId', () => {
   it('accepts valid session IDs', () => {
@@ -113,5 +113,51 @@ describe('validateSearchQuery', () => {
   it('rejects queries exceeding max length', () => {
     const longQuery = 'a'.repeat(257)
     expect(validateSearchQuery(longQuery)).toBe('Search query exceeds max length (256)')
+  })
+})
+
+describe('validateSubtitleSettings', () => {
+  const validSettings = {
+    fontSize: 28,
+    sourceTextColor: '#ffffff',
+    translatedTextColor: '#00ff00',
+    backgroundOpacity: 0.8,
+    position: 'bottom'
+  }
+
+  it('accepts valid subtitle settings', () => {
+    expect(validateSubtitleSettings(validSettings)).toBeNull()
+    expect(validateSubtitleSettings({ ...validSettings, position: 'top' })).toBeNull()
+  })
+
+  it('rejects non-object input', () => {
+    expect(validateSubtitleSettings(null)).toBe('Subtitle settings must be an object')
+    expect(validateSubtitleSettings(undefined)).toBe('Subtitle settings must be an object')
+    expect(validateSubtitleSettings('string')).toBe('Subtitle settings must be an object')
+    expect(validateSubtitleSettings(42)).toBe('Subtitle settings must be an object')
+  })
+
+  it('rejects invalid fontSize', () => {
+    expect(validateSubtitleSettings({ ...validSettings, fontSize: 'big' })).toBe('fontSize must be a finite number')
+    expect(validateSubtitleSettings({ ...validSettings, fontSize: NaN })).toBe('fontSize must be a finite number')
+    expect(validateSubtitleSettings({ ...validSettings, fontSize: Infinity })).toBe('fontSize must be a finite number')
+  })
+
+  it('rejects invalid sourceTextColor', () => {
+    expect(validateSubtitleSettings({ ...validSettings, sourceTextColor: 123 })).toBe('sourceTextColor must be a string')
+  })
+
+  it('rejects invalid translatedTextColor', () => {
+    expect(validateSubtitleSettings({ ...validSettings, translatedTextColor: null })).toBe('translatedTextColor must be a string')
+  })
+
+  it('rejects invalid backgroundOpacity', () => {
+    expect(validateSubtitleSettings({ ...validSettings, backgroundOpacity: 'half' })).toBe('backgroundOpacity must be a finite number')
+    expect(validateSubtitleSettings({ ...validSettings, backgroundOpacity: NaN })).toBe('backgroundOpacity must be a finite number')
+  })
+
+  it('rejects invalid position', () => {
+    expect(validateSubtitleSettings({ ...validSettings, position: 'left' })).toBe('position must be one of: top, bottom')
+    expect(validateSubtitleSettings({ ...validSettings, position: 123 })).toBe('position must be one of: top, bottom')
   })
 })

--- a/src/main/ipc-validators.ts
+++ b/src/main/ipc-validators.ts
@@ -54,6 +54,33 @@ export function validateSearchQuery(query: unknown): string | null {
   return null
 }
 
+/** Valid subtitle position values */
+const VALID_SUBTITLE_POSITIONS = ['top', 'bottom'] as const
+
+/**
+ * Validate subtitle settings from IPC input.
+ * Returns an error string if invalid, or null if valid.
+ */
+export function validateSubtitleSettings(data: unknown): string | null {
+  if (data == null || typeof data !== 'object') return 'Subtitle settings must be an object'
+
+  const obj = data as Record<string, unknown>
+
+  if (typeof obj.fontSize !== 'number' || !Number.isFinite(obj.fontSize)) {
+    return 'fontSize must be a finite number'
+  }
+  if (typeof obj.sourceTextColor !== 'string') return 'sourceTextColor must be a string'
+  if (typeof obj.translatedTextColor !== 'string') return 'translatedTextColor must be a string'
+  if (typeof obj.backgroundOpacity !== 'number' || !Number.isFinite(obj.backgroundOpacity)) {
+    return 'backgroundOpacity must be a finite number'
+  }
+  if (!VALID_SUBTITLE_POSITIONS.includes(obj.position as (typeof VALID_SUBTITLE_POSITIONS)[number])) {
+    return `position must be one of: ${VALID_SUBTITLE_POSITIONS.join(', ')}`
+  }
+
+  return null
+}
+
 /** Valid export formats */
 export const VALID_EXPORT_FORMATS = ['text', 'srt', 'markdown'] as const
 export type ExportFormat = (typeof VALID_EXPORT_FORMATS)[number]


### PR DESCRIPTION
## Summary
- Add `validateSubtitleSettings()` runtime type guard in `ipc-validators.ts` that checks all 5 fields (`fontSize`, `sourceTextColor`, `translatedTextColor`, `backgroundOpacity`, `position`)
- Replace unsafe `as unknown as SubtitleSettings` cast in `save-subtitle-settings` IPC handler with validation-first approach that throws on invalid data
- Add comprehensive tests covering valid input, non-object input, and each invalid field case

## Test plan
- [x] `npm run lint` passes
- [x] `npm run typecheck` passes
- [x] `npm run test` passes (127 tests, including new validator tests)

Closes #434