### PR TITLE
#422 Extract LlamaWorkerTranslator base class for LLM translator engines

### DIFF
--- a/src/engines/translator/HunyuanMT15Translator.ts
+++ b/src/engines/translator/HunyuanMT15Translator.ts
@@ -1,7 +1,6 @@
-import { join } from 'path'
-import type { TranslatorEngine, Language, TranslateContext } from '../types'
-import { getGGUFDir, downloadGGUF, getHunyuanMT15Variants } from '../model-downloader'
-import { workerPool } from '../../main/worker-pool'
+import { getHunyuanMT15Variants } from '../model-downloader'
+import { LlamaWorkerTranslator } from './LlamaWorkerTranslator'
+import type { GGUFVariantConfig } from './LlamaWorkerTranslator'
 
 /**
  * HY-MT1.5-1.8B translator via node-llama-cpp UtilityProcess.
@@ -9,88 +8,19 @@ import { workerPool } from '../../main/worker-pool'
  * 1.8B parameter model (~1.1GB Q4_K_M) supporting 36 languages.
  * License: Tencent Hunyuan Community License (Apache 2.0 based, commercial OK < 100M MAU).
  */
-export class HunyuanMT15Translator implements TranslatorEngine {
+export class HunyuanMT15Translator extends LlamaWorkerTranslator {
   readonly id = 'hunyuan-mt-15'
   readonly name = 'HY-MT1.5-1.8B (Offline)'
-  readonly isOffline = true
 
-  private initialized = false
-  private initPromise: Promise<void> | null = null
-  private onProgress?: (message: string) => void
-  private variant: string
-  private kvCacheQuant: boolean
-  private modelPath: string = ''
-
-  constructor(options?: { onProgress?: (message: string) => void; variant?: string; kvCacheQuant?: boolean }) {
-    this.onProgress = options?.onProgress
-    this.variant = options?.variant ?? 'Q4_K_M'
-    this.kvCacheQuant = options?.kvCacheQuant ?? true
+  protected getVariants(): Record<string, GGUFVariantConfig> {
+    return getHunyuanMT15Variants()
   }
 
-  async initialize(): Promise<void> {
-    if (this.initPromise) return this.initPromise
-    this.initPromise = this.doInitialize()
-    return this.initPromise
+  protected getModelSizeLabel(): string {
+    return 'HY-MT1.5-1.8B'
   }
 
-  private async doInitialize(): Promise<void> {
-    if (this.initialized) return
-
-    // Download model if needed
-    const variants = getHunyuanMT15Variants()
-    const variantConfig = variants[this.variant] ?? variants['Q4_K_M']!
-    this.modelPath = join(getGGUFDir(), variantConfig.filename)
-    await downloadGGUF(variantConfig.filename, variantConfig.url, this.onProgress, variantConfig.sha256)
-
-    this.onProgress?.('Starting HY-MT1.5-1.8B worker...')
-
-    await workerPool.acquire({
-      modelPath: this.modelPath,
-      kvCacheQuant: this.kvCacheQuant,
-      modelType: 'hunyuan-mt-15'
-    }, this.onProgress)
-
-    this.onProgress?.('HY-MT1.5-1.8B model loaded')
-    this.initialized = true
-  }
-
-  async translate(text: string, from: Language, to: Language, context?: TranslateContext): Promise<string> {
-    if (!text.trim()) return ''
-    if (from === to) return text
-    if (!this.initialized) {
-      throw new Error('[hunyuan-mt-15-worker] Not initialized')
-    }
-
-    return workerPool.sendRequest(
-      { type: 'translate', text, from, to, context },
-      'translate'
-    )
-  }
-
-  async translateIncremental(
-    text: string,
-    previousOutput: string,
-    from: Language,
-    to: Language,
-    context?: TranslateContext
-  ): Promise<string> {
-    if (!text.trim()) return previousOutput || ''
-    if (from === to) return text
-    if (!this.initialized) {
-      throw new Error('[hunyuan-mt-15-worker] Not initialized')
-    }
-
-    return workerPool.sendRequest(
-      { type: 'translate-incremental', text, previousOutput, from, to, context },
-      'translate-incremental'
-    )
-  }
-
-  async dispose(): Promise<void> {
-    if (this.initialized) {
-      await workerPool.release()
-      this.initialized = false
-    }
-    this.initPromise = null
+  protected getExtraInitOptions() {
+    return { modelType: 'hunyuan-mt-15' as const }
   }
 }

--- a/src/engines/translator/HunyuanMTTranslator.ts
+++ b/src/engines/translator/HunyuanMTTranslator.ts
@@ -1,10 +1,6 @@
-import { join } from 'path'
-import type { TranslatorEngine, Language, TranslateContext } from '../types'
-import { getGGUFDir, downloadGGUF, getHunyuanMTVariants } from '../model-downloader'
-import { workerPool } from '../../main/worker-pool'
-import { createLogger } from '../../main/logger'
-
-const log = createLogger('hunyuan-mt')
+import { getHunyuanMTVariants } from '../model-downloader'
+import { LlamaWorkerTranslator } from './LlamaWorkerTranslator'
+import type { GGUFVariantConfig } from './LlamaWorkerTranslator'
 
 /**
  * Hunyuan-MT-7B translator via node-llama-cpp UtilityProcess.
@@ -12,92 +8,19 @@ const log = createLogger('hunyuan-mt')
  * WMT25 winner: 30/31 categories, 33 languages, 15-65% improvement over Google Translate.
  * License: Tencent Hunyuan Community License (Apache 2.0 based, commercial OK < 100M MAU).
  */
-export class HunyuanMTTranslator implements TranslatorEngine {
+export class HunyuanMTTranslator extends LlamaWorkerTranslator {
   readonly id = 'hunyuan-mt'
   readonly name = 'Hunyuan-MT 7B (Offline)'
-  readonly isOffline = true
 
-  private initialized = false
-  private initPromise: Promise<void> | null = null
-  private onProgress?: (message: string) => void
-  private variant: string
-  private kvCacheQuant: boolean
-  private modelPath: string = ''
-
-  constructor(options?: { onProgress?: (message: string) => void; variant?: string; kvCacheQuant?: boolean }) {
-    this.onProgress = options?.onProgress
-    this.variant = options?.variant ?? 'Q4_K_M'
-    this.kvCacheQuant = options?.kvCacheQuant ?? true
+  protected getVariants(): Record<string, GGUFVariantConfig> {
+    return getHunyuanMTVariants()
   }
 
-  async initialize(): Promise<void> {
-    if (this.initPromise) return this.initPromise
-    this.initPromise = this.doInitialize()
-    return this.initPromise
+  protected getModelSizeLabel(): string {
+    return 'Hunyuan-MT 7B'
   }
 
-  private async doInitialize(): Promise<void> {
-    if (this.initialized) return
-
-    // Download model if needed
-    const variants = getHunyuanMTVariants()
-    const variantConfig = variants[this.variant] ?? variants['Q4_K_M']!
-    this.modelPath = join(getGGUFDir(), variantConfig.filename)
-    await downloadGGUF(variantConfig.filename, variantConfig.url, this.onProgress, variantConfig.sha256)
-
-    this.onProgress?.('Starting Hunyuan-MT 7B worker...')
-
-    await workerPool.acquire({
-      modelPath: this.modelPath,
-      kvCacheQuant: this.kvCacheQuant,
-      modelType: 'hunyuan-mt'
-    }, this.onProgress)
-
-    this.onProgress?.('Hunyuan-MT 7B model loaded')
-    this.initialized = true
-  }
-
-  async translate(text: string, from: Language, to: Language, context?: TranslateContext): Promise<string> {
-    if (!text.trim()) return ''
-    if (from === to) return text
-    if (!this.initialized) {
-      throw new Error('[hunyuan-mt-worker] Not initialized')
-    }
-
-    const t0 = performance.now()
-    const result = await workerPool.sendRequest(
-      { type: 'translate', text, from, to, context },
-      'translate'
-    )
-    const ms = performance.now() - t0
-    log.info(`translate ${from}→${to} inputLen=${text.length} outputLen=${result.length} time=${ms.toFixed(0)}ms`)
-    return result
-  }
-
-  async translateIncremental(
-    text: string,
-    previousOutput: string,
-    from: Language,
-    to: Language,
-    context?: TranslateContext
-  ): Promise<string> {
-    if (!text.trim()) return previousOutput || ''
-    if (from === to) return text
-    if (!this.initialized) {
-      throw new Error('[hunyuan-mt-worker] Not initialized')
-    }
-
-    return workerPool.sendRequest(
-      { type: 'translate-incremental', text, previousOutput, from, to, context },
-      'translate-incremental'
-    )
-  }
-
-  async dispose(): Promise<void> {
-    if (this.initialized) {
-      await workerPool.release()
-      this.initialized = false
-    }
-    this.initPromise = null
+  protected getExtraInitOptions() {
+    return { modelType: 'hunyuan-mt' as const }
   }
 }

--- a/src/engines/translator/LlamaWorkerTranslator.ts
+++ b/src/engines/translator/LlamaWorkerTranslator.ts
@@ -1,0 +1,148 @@
+import { join } from 'path'
+import type { TranslatorEngine, Language, TranslateContext } from '../types'
+import { getGGUFDir, downloadGGUF } from '../model-downloader'
+import type { WorkerInitOptions } from '../../main/worker-pool'
+import { workerPool } from '../../main/worker-pool'
+import { createLogger } from '../../main/logger'
+
+export interface GGUFVariantConfig {
+  filename: string
+  url: string
+  sha256?: string
+}
+
+/**
+ * Abstract base class for LLM-based translator engines that run via
+ * the shared node-llama-cpp UtilityProcess worker pool.
+ *
+ * Subclasses provide model-specific configuration via template methods;
+ * the lifecycle (initialize → download → acquire worker → translate → dispose)
+ * is handled entirely by this base class.
+ */
+export abstract class LlamaWorkerTranslator implements TranslatorEngine {
+  abstract readonly id: string
+  abstract readonly name: string
+  readonly isOffline = true
+
+  protected initialized = false
+  private initPromise: Promise<void> | null = null
+  protected onProgress?: (message: string) => void
+  protected variant: string
+  protected kvCacheQuant: boolean
+  protected modelPath: string = ''
+  private _log: ReturnType<typeof createLogger> | null = null
+
+  constructor(options?: { onProgress?: (message: string) => void; variant?: string; kvCacheQuant?: boolean }) {
+    this.onProgress = options?.onProgress
+    this.variant = options?.variant ?? 'Q4_K_M'
+    this.kvCacheQuant = options?.kvCacheQuant ?? true
+  }
+
+  private get log(): ReturnType<typeof createLogger> {
+    if (!this._log) this._log = createLogger(this.id)
+    return this._log
+  }
+
+  // ── Template methods (override in subclasses) ──────────────────────
+
+  /** Return the GGUF variant config map for the current model */
+  protected abstract getVariants(): Record<string, GGUFVariantConfig>
+
+  /** Human-readable label shown in progress messages (e.g. "Hunyuan-MT 7B") */
+  protected abstract getModelSizeLabel(): string
+
+  /** Extra WorkerInitOptions fields (e.g. modelType, draftModelPath) */
+  protected getExtraInitOptions(): Partial<WorkerInitOptions> {
+    return {}
+  }
+
+  /**
+   * Hook called after model download but before worker acquire.
+   * Subclasses can use this to prepare additional resources (e.g. draft models).
+   */
+  protected async afterDownload(): Promise<void> {
+    // no-op by default
+  }
+
+  /** Hook called after worker reports model loaded */
+  protected getLoadedSuffix(): string {
+    return ''
+  }
+
+  // ── Lifecycle ──────────────────────────────────────────────────────
+
+  async initialize(): Promise<void> {
+    if (this.initPromise) return this.initPromise
+    this.initPromise = this.doInitialize()
+    return this.initPromise
+  }
+
+  private async doInitialize(): Promise<void> {
+    if (this.initialized) return
+
+    // Download model if needed
+    const variants = this.getVariants()
+    const variantConfig = variants[this.variant] ?? variants['Q4_K_M']!
+    this.modelPath = join(getGGUFDir(), variantConfig.filename)
+    await downloadGGUF(variantConfig.filename, variantConfig.url, this.onProgress, variantConfig.sha256)
+
+    await this.afterDownload()
+
+    const label = this.getModelSizeLabel()
+    this.onProgress?.(`Starting ${label} worker...`)
+
+    await workerPool.acquire({
+      modelPath: this.modelPath,
+      kvCacheQuant: this.kvCacheQuant,
+      ...this.getExtraInitOptions()
+    }, this.onProgress)
+
+    const suffix = this.getLoadedSuffix()
+    this.onProgress?.(`${label} model loaded${suffix}`)
+    this.initialized = true
+  }
+
+  async translate(text: string, from: Language, to: Language, context?: TranslateContext): Promise<string> {
+    if (!text.trim()) return ''
+    if (from === to) return text
+    if (!this.initialized) {
+      throw new Error(`[${this.id}-worker] Not initialized`)
+    }
+
+    const t0 = performance.now()
+    const result = await workerPool.sendRequest(
+      { type: 'translate', text, from, to, context },
+      'translate'
+    )
+    const ms = performance.now() - t0
+    this.log.info(`translate ${from}→${to} inputLen=${text.length} outputLen=${result.length} time=${ms.toFixed(0)}ms`)
+    return result
+  }
+
+  async translateIncremental(
+    text: string,
+    previousOutput: string,
+    from: Language,
+    to: Language,
+    context?: TranslateContext
+  ): Promise<string> {
+    if (!text.trim()) return previousOutput || ''
+    if (from === to) return text
+    if (!this.initialized) {
+      throw new Error(`[${this.id}-worker] Not initialized`)
+    }
+
+    return workerPool.sendRequest(
+      { type: 'translate-incremental', text, previousOutput, from, to, context },
+      'translate-incremental'
+    )
+  }
+
+  async dispose(): Promise<void> {
+    if (this.initialized) {
+      await workerPool.release()
+      this.initialized = false
+    }
+    this.initPromise = null
+  }
+}

--- a/src/engines/translator/SLMTranslator.ts
+++ b/src/engines/translator/SLMTranslator.ts
@@ -1,103 +1,60 @@
 import { join } from 'path'
-import type { TranslatorEngine, Language, TranslateContext } from '../types'
-import { getGGUFDir, downloadGGUF, getGGUFVariants, isGGUFDownloaded } from '../model-downloader'
+import { getGGUFDir, getGGUFVariants, isGGUFDownloaded } from '../model-downloader'
 import type { SLMModelSize } from '../model-downloader'
+import type { WorkerInitOptions } from '../../main/worker-pool'
 import { workerPool } from '../../main/worker-pool'
+import { LlamaWorkerTranslator } from './LlamaWorkerTranslator'
+import type { GGUFVariantConfig } from './LlamaWorkerTranslator'
 
-export class SLMTranslator implements TranslatorEngine {
+export class SLMTranslator extends LlamaWorkerTranslator {
   readonly id = 'slm-translate'
   readonly name: string
-  readonly isOffline = true
 
-  private initialized = false
-  private initPromise: Promise<void> | null = null
-  private onProgress?: (message: string) => void
-  private variant: string
   private modelSize: SLMModelSize
-  private kvCacheQuant: boolean
   private speculativeDecoding: boolean
-  private modelPath: string = ''
+  private draftModelPath: string | undefined
 
-  constructor(options?: { onProgress?: (message: string) => void; variant?: string; modelSize?: SLMModelSize; kvCacheQuant?: boolean; speculativeDecoding?: boolean }) {
-    this.onProgress = options?.onProgress
+  constructor(options?: {
+    onProgress?: (message: string) => void
+    variant?: string
+    modelSize?: SLMModelSize
+    kvCacheQuant?: boolean
+    speculativeDecoding?: boolean
+  }) {
+    super(options)
     this.modelSize = options?.modelSize ?? '4b'
-    this.variant = options?.variant ?? 'Q4_K_M'
-    this.kvCacheQuant = options?.kvCacheQuant ?? true
     this.speculativeDecoding = options?.speculativeDecoding ?? false
     this.name = `TranslateGemma ${this.modelSize.toUpperCase()} (Offline)`
   }
 
-  async initialize(): Promise<void> {
-    if (this.initPromise) return this.initPromise
-    this.initPromise = this.doInitialize()
-    return this.initPromise
+  protected getVariants(): Record<string, GGUFVariantConfig> {
+    return getGGUFVariants(this.modelSize)
   }
 
-  private async doInitialize(): Promise<void> {
-    if (this.initialized) return
+  protected getModelSizeLabel(): string {
+    return `TranslateGemma ${this.modelSize.toUpperCase()}`
+  }
 
-    // Download model if needed
-    const variants = getGGUFVariants(this.modelSize)
-    const variantConfig = variants[this.variant] ?? variants['Q4_K_M']!
-    this.modelPath = join(getGGUFDir(), variantConfig.filename)
-    await downloadGGUF(variantConfig.filename, variantConfig.url, this.onProgress, variantConfig.sha256)
-
+  protected async afterDownload(): Promise<void> {
     // Resolve draft model path for speculative decoding (4B draft + 12B verifier)
-    let draftModelPath: string | undefined
     if (this.speculativeDecoding && this.modelSize === '12b') {
       const draftVariants = getGGUFVariants('4b')
       const draftVariantConfig = draftVariants['Q4_K_M']!
       if (isGGUFDownloaded(draftVariantConfig.filename)) {
-        draftModelPath = join(getGGUFDir(), draftVariantConfig.filename)
+        this.draftModelPath = join(getGGUFDir(), draftVariantConfig.filename)
         this.onProgress?.('Speculative decoding enabled: 4B draft + 12B verifier')
       } else {
         this.onProgress?.('Speculative decoding skipped: 4B draft model not downloaded')
       }
     }
-
-    this.onProgress?.(`Starting TranslateGemma ${this.modelSize.toUpperCase()} worker...`)
-
-    await workerPool.acquire({
-      modelPath: this.modelPath,
-      kvCacheQuant: this.kvCacheQuant,
-      draftModelPath
-    }, this.onProgress)
-
-    const specLabel = draftModelPath ? ' (speculative decoding)' : ''
-    this.onProgress?.(`TranslateGemma ${this.modelSize.toUpperCase()} model loaded${specLabel}`)
-    this.initialized = true
   }
 
-  async translate(text: string, from: Language, to: Language, context?: TranslateContext): Promise<string> {
-    if (!text.trim()) return ''
-    if (from === to) return text
-    if (!this.initialized) {
-      throw new Error('[slm-worker] Not initialized')
-    }
-
-    return workerPool.sendRequest(
-      { type: 'translate', text, from, to, context },
-      'translate'
-    )
+  protected getExtraInitOptions(): Partial<WorkerInitOptions> {
+    return { draftModelPath: this.draftModelPath }
   }
 
-  async translateIncremental(
-    text: string,
-    previousOutput: string,
-    from: Language,
-    to: Language,
-    context?: TranslateContext
-  ): Promise<string> {
-    if (!text.trim()) return previousOutput || ''
-    if (from === to) return text
-    if (!this.initialized) {
-      throw new Error('[slm-worker] Not initialized')
-    }
-
-    return workerPool.sendRequest(
-      { type: 'translate-incremental', text, previousOutput, from, to, context },
-      'translate-incremental'
-    )
+  protected getLoadedSuffix(): string {
+    return this.draftModelPath ? ' (speculative decoding)' : ''
   }
 
   async summarize(transcript: string): Promise<string> {
@@ -109,13 +66,5 @@ export class SLMTranslator implements TranslatorEngine {
       { type: 'summarize', transcript },
       'summarize'
     )
-  }
-
-  async dispose(): Promise<void> {
-    if (this.initialized) {
-      await workerPool.release()
-      this.initialized = false
-    }
-    this.initPromise = null
   }
 }


### PR DESCRIPTION
## Description

Extract a `LlamaWorkerTranslator` abstract base class that encapsulates the shared lifecycle pattern (initialize → download GGUF → acquire worker pool → translate → dispose) used by all three LLM-based translator engines.

**Before:** `HunyuanMTTranslator`, `HunyuanMT15Translator`, and `SLMTranslator` each duplicated ~80 lines of identical initialization, translation, incremental translation, and disposal logic.

**After:** The base class handles all common behavior. Subclasses only override template methods:
- `getVariants()` — return GGUF variant config
- `getModelSizeLabel()` — human-readable label for progress messages
- `getExtraInitOptions()` — model-specific worker init options (e.g. `modelType`, `draftModelPath`)
- `afterDownload()` — post-download hook (used by SLMTranslator for speculative decoding)
- `getLoadedSuffix()` — suffix for "model loaded" message

`SLMTranslator` retains its unique `summarize()` method and speculative decoding logic.

Net result: **-244 lines added, +194 lines** (50 lines removed).

Closes #422