### PR TITLE
#421 Split useSettingsState into domain-specific hooks

### DIFF
--- a/src/renderer/hooks/settingsCastUtils.ts
+++ b/src/renderer/hooks/settingsCastUtils.ts
@@ -1,0 +1,11 @@
+/**
+ * Runtime type-safe extractors for IPC settings.
+ * These avoid unsafe `as` casts when reading unknown values from the store.
+ */
+
+export const str = (v: unknown, def: string): string => (typeof v === 'string' ? v : def)
+export const num = (v: unknown, def: number): number => (typeof v === 'number' ? v : def)
+export const bool = (v: unknown, def: boolean): boolean => (typeof v === 'boolean' ? v : def)
+export const arr = <T>(v: unknown, def: T[]): T[] => (Array.isArray(v) ? v : def)
+export const rec = (v: unknown): Record<string, unknown> | null =>
+  typeof v === 'object' && v !== null && !Array.isArray(v) ? (v as Record<string, unknown>) : null

--- a/src/renderer/hooks/useDisplaySettings.ts
+++ b/src/renderer/hooks/useDisplaySettings.ts
@@ -1,0 +1,60 @@
+import { useEffect, useRef, useState } from 'react'
+import { num } from './settingsCastUtils'
+import type { DisplayInfo } from '../components/settings/shared'
+
+export interface DisplaySettingsState {
+  displays: DisplayInfo[]
+  selectedDisplay: number
+  handleDisplayChange: (displayId: number) => void
+}
+
+export function useDisplaySettings(): DisplaySettingsState {
+  const [displays, setDisplays] = useState<DisplayInfo[]>([])
+  const [selectedDisplay, setSelectedDisplay] = useState<number>(0)
+
+  // Guard: display-related callbacks must wait until settings are fully loaded
+  const settingsLoadedRef = useRef(false)
+  const selectedDisplayRef = useRef(selectedDisplay)
+
+  // Load saved display selection on mount
+  useEffect(() => {
+    window.api.getSettings().then((s) => {
+      if (s.selectedDisplay !== undefined) {
+        const savedDisplay = num(s.selectedDisplay, 0)
+        setSelectedDisplay(savedDisplay)
+        selectedDisplayRef.current = savedDisplay
+      }
+      settingsLoadedRef.current = true
+    })
+  }, [])
+
+  // Load displays and listen for display changes
+  useEffect(() => {
+    const refreshDisplays = (): void => {
+      window.api.getDisplays().then((d) => {
+        setDisplays(d)
+        // Skip auto-selection until settings are loaded (saved value takes priority)
+        if (!settingsLoadedRef.current) return
+        // Only auto-select if the current display was disconnected
+        const currentStillExists = d.some((disp: DisplayInfo) => disp.id === selectedDisplayRef.current)
+        if (!currentStillExists) {
+          const external = d.find((disp: DisplayInfo) => disp.label.includes('External'))
+          const fallback = external?.id ?? d[0]?.id ?? 0
+          setSelectedDisplay(fallback)
+          selectedDisplayRef.current = fallback
+        }
+      })
+    }
+    refreshDisplays()
+    const unsubscribe = window.api.onDisplaysChanged(refreshDisplays)
+    return () => unsubscribe?.()
+  }, [])
+
+  const handleDisplayChange = (displayId: number): void => {
+    setSelectedDisplay(displayId)
+    selectedDisplayRef.current = displayId
+    window.api.moveSubtitleToDisplay(displayId)
+  }
+
+  return { displays, selectedDisplay, handleDisplayChange }
+}

--- a/src/renderer/hooks/useEngineSettings.ts
+++ b/src/renderer/hooks/useEngineSettings.ts
@@ -1,0 +1,101 @@
+import { useEffect, useState } from 'react'
+import { str, bool, num, arr } from './settingsCastUtils'
+import type { EngineMode } from '../components/settings/shared'
+import { API_ENGINE_MODES } from '../components/settings/shared'
+
+export interface EngineSettingsState {
+  engineMode: EngineMode
+  setEngineMode: (v: EngineMode) => void
+  gpuInfo: { hasGpu: boolean; gpuNames: string[] } | null
+
+  apiKey: string
+  setApiKey: (v: string) => void
+  deeplApiKey: string
+  setDeeplApiKey: (v: string) => void
+  geminiApiKey: string
+  setGeminiApiKey: (v: string) => void
+  microsoftApiKey: string
+  setMicrosoftApiKey: (v: string) => void
+  microsoftRegion: string
+  setMicrosoftRegion: (v: string) => void
+
+  slmKvCacheQuant: boolean
+  setSlmKvCacheQuant: (v: boolean) => void
+  simulMtEnabled: boolean
+  setSimulMtEnabled: (v: boolean) => void
+  simulMtWaitK: number
+  setSimulMtWaitK: (v: number) => void
+
+  glossaryTerms: Array<{ source: string; target: string }>
+  setGlossaryTerms: (v: Array<{ source: string; target: string }>) => void
+}
+
+export interface EngineSettingsInit {
+  setShowAdvanced: (v: boolean) => void
+  setShowApiOptions: (v: boolean) => void
+}
+
+export function useEngineSettings(init: EngineSettingsInit): EngineSettingsState {
+  const [engineMode, setEngineMode] = useState<EngineMode>('offline-opus')
+  const [gpuInfo, setGpuInfo] = useState<{ hasGpu: boolean; gpuNames: string[] } | null>(null)
+  const [apiKey, setApiKey] = useState('')
+  const [deeplApiKey, setDeeplApiKey] = useState('')
+  const [geminiApiKey, setGeminiApiKey] = useState('')
+  const [microsoftApiKey, setMicrosoftApiKey] = useState('')
+  const [microsoftRegion, setMicrosoftRegion] = useState('')
+  const [slmKvCacheQuant, setSlmKvCacheQuant] = useState(true)
+  const [simulMtEnabled, setSimulMtEnabled] = useState(false)
+  const [simulMtWaitK, setSimulMtWaitK] = useState(3)
+  const [glossaryTerms, setGlossaryTerms] = useState<Array<{ source: string; target: string }>>([])
+
+  // Load engine-related settings on mount
+  useEffect(() => {
+    window.api.getSettings().then((s) => {
+      if (s.translationEngine) setEngineMode(str(s.translationEngine, 'offline-opus') as EngineMode)
+      if (s.googleApiKey) setApiKey(str(s.googleApiKey, ''))
+      if (s.deeplApiKey) setDeeplApiKey(str(s.deeplApiKey, ''))
+      if (s.geminiApiKey) setGeminiApiKey(str(s.geminiApiKey, ''))
+      if (s.microsoftApiKey) setMicrosoftApiKey(str(s.microsoftApiKey, ''))
+      if (s.microsoftRegion) setMicrosoftRegion(str(s.microsoftRegion, ''))
+      if (s.slmKvCacheQuant !== undefined) setSlmKvCacheQuant(bool(s.slmKvCacheQuant, true))
+      if (s.glossaryTerms) setGlossaryTerms(arr<{ source: string; target: string }>(s.glossaryTerms, []))
+      if (s.simulMtEnabled !== undefined) setSimulMtEnabled(bool(s.simulMtEnabled, false))
+      if (s.simulMtWaitK !== undefined) setSimulMtWaitK(num(s.simulMtWaitK, 3))
+
+      // Auto-expand API section if an API engine is saved
+      const engine = str(s.translationEngine, '')
+      if (engine && API_ENGINE_MODES.includes(engine as EngineMode)) {
+        init.setShowAdvanced(true)
+        init.setShowApiOptions(true)
+      }
+    })
+  }, [])
+
+  // Detect GPU — fall back to OPUS-MT if no GPU
+  useEffect(() => {
+    window.api.detectGpu().then((info) => {
+      setGpuInfo(info)
+      if (!info.hasGpu) {
+        window.api.getSettings().then((s) => {
+          if (!s.translationEngine) {
+            setEngineMode('offline-opus')
+          }
+        })
+      }
+    }).catch(() => setGpuInfo({ hasGpu: false, gpuNames: [] }))
+  }, [])
+
+  return {
+    engineMode, setEngineMode,
+    gpuInfo,
+    apiKey, setApiKey,
+    deeplApiKey, setDeeplApiKey,
+    geminiApiKey, setGeminiApiKey,
+    microsoftApiKey, setMicrosoftApiKey,
+    microsoftRegion, setMicrosoftRegion,
+    slmKvCacheQuant, setSlmKvCacheQuant,
+    simulMtEnabled, setSimulMtEnabled,
+    simulMtWaitK, setSimulMtWaitK,
+    glossaryTerms, setGlossaryTerms
+  }
+}

--- a/src/renderer/hooks/useLanguageSettings.ts
+++ b/src/renderer/hooks/useLanguageSettings.ts
@@ -1,0 +1,51 @@
+import { useEffect, useState } from 'react'
+import { str } from './settingsCastUtils'
+import type { Language, SourceLanguage, SttEngineType, WhisperVariantType } from '../components/settings/shared'
+
+export interface LanguageSettingsState {
+  sourceLanguage: SourceLanguage
+  setSourceLanguage: (v: SourceLanguage) => void
+  targetLanguage: Language
+  setTargetLanguage: (v: Language) => void
+  sttEngine: SttEngineType
+  setSttEngine: (v: SttEngineType) => void
+  whisperVariant: WhisperVariantType
+  setWhisperVariant: (v: WhisperVariantType) => void
+  platform: string
+}
+
+export function useLanguageSettings(): LanguageSettingsState {
+  const [sourceLanguage, setSourceLanguage] = useState<SourceLanguage>('auto')
+  const [targetLanguage, setTargetLanguage] = useState<Language>('en')
+  const [sttEngine, setSttEngine] = useState<SttEngineType>('mlx-whisper')
+  const [whisperVariant, setWhisperVariant] = useState<WhisperVariantType>('kotoba-v2.0')
+  const [platform, setPlatform] = useState<string>('darwin')
+
+  // Load language/STT settings on mount
+  useEffect(() => {
+    window.api.getSettings().then((s) => {
+      if (s.sttEngine) setSttEngine(str(s.sttEngine, 'mlx-whisper') as SttEngineType)
+      if (s.whisperVariant) setWhisperVariant(str(s.whisperVariant, 'kotoba-v2.0') as WhisperVariantType)
+      if (s.sourceLanguage) setSourceLanguage(str(s.sourceLanguage, 'auto') as SourceLanguage)
+      if (s.targetLanguage) setTargetLanguage(str(s.targetLanguage, 'en') as Language)
+    })
+
+    // Set platform-aware STT default (mlx-whisper on macOS)
+    window.api.getPlatform().then((p) => {
+      setPlatform(p)
+      window.api.getSettings().then((s) => {
+        if (!s.sttEngine && p === 'darwin') {
+          setSttEngine('mlx-whisper')
+        }
+      })
+    }).catch((e) => console.warn('[settings] Failed to load platform/settings:', e))
+  }, [])
+
+  return {
+    sourceLanguage, setSourceLanguage,
+    targetLanguage, setTargetLanguage,
+    sttEngine, setSttEngine,
+    whisperVariant, setWhisperVariant,
+    platform
+  }
+}

--- a/src/renderer/hooks/useSessionSettings.ts
+++ b/src/renderer/hooks/useSessionSettings.ts
@@ -1,0 +1,152 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { bool } from './settingsCastUtils'
+import type { UseAudioCaptureReturn } from './useAudioCapture'
+import type { UseNoiseSuppressionReturn } from './useNoiseSuppression'
+import { useNoiseSuppression } from './useNoiseSuppression'
+import { useAudioCapture } from './useAudioCapture'
+
+export interface SessionSettingsState {
+  status: string
+  setStatus: (v: string) => void
+  isRunning: boolean
+  setIsRunning: (v: boolean) => void
+  isStarting: boolean
+  setIsStarting: (v: boolean) => void
+  sessionDuration: string
+  sessions: Array<{ id: string; startedAt: number; engineMode: string; entryCount: number }>
+
+  lastTranscriptPath: string | null
+  setLastTranscriptPath: (v: string | null) => void
+  summaryText: string | null
+  setSummaryText: (v: string | null) => void
+  isSummarizing: boolean
+  setIsSummarizing: (v: boolean) => void
+
+  crashedSession: { config: Record<string, unknown>; startedAt: number } | null
+  setCrashedSession: (v: { config: Record<string, unknown>; startedAt: number } | null) => void
+
+  startSessionTimer: () => void
+  stopSessionTimer: () => void
+
+  audio: UseAudioCaptureReturn
+  noiseSuppression: UseNoiseSuppressionReturn
+}
+
+export function useSessionSettings(): SessionSettingsState {
+  const [status, setStatus] = useState('Ready')
+  const [isRunning, setIsRunning] = useState(false)
+  const [isStarting, setIsStarting] = useState(false)
+  const [sessionDuration, setSessionDuration] = useState('')
+  const sessionTimerRef = useRef<ReturnType<typeof setInterval> | null>(null)
+  const sessionStartRef = useRef<number | null>(null)
+  const [sessions, setSessions] = useState<Array<{ id: string; startedAt: number; engineMode: string; entryCount: number }>>([])
+
+  const [lastTranscriptPath, setLastTranscriptPath] = useState<string | null>(null)
+  const [summaryText, setSummaryText] = useState<string | null>(null)
+  const [isSummarizing, setIsSummarizing] = useState(false)
+
+  const [crashedSession, setCrashedSession] = useState<{ config: Record<string, unknown>; startedAt: number } | null>(null)
+
+  // Noise suppression + audio capture
+  const noiseSuppression = useNoiseSuppression()
+  const audio = useAudioCapture(noiseSuppression.enabled ? noiseSuppression : undefined)
+
+  // --- Timer helpers ---
+  const formatDuration = useCallback((ms: number): string => {
+    const totalSec = Math.floor(ms / 1000)
+    const h = Math.floor(totalSec / 3600)
+    const m = Math.floor((totalSec % 3600) / 60)
+    const s = totalSec % 60
+    if (h > 0) return `${h}:${String(m).padStart(2, '0')}:${String(s).padStart(2, '0')}`
+    return `${m}:${String(s).padStart(2, '0')}`
+  }, [])
+
+  const startSessionTimer = useCallback(() => {
+    sessionStartRef.current = Date.now()
+    sessionTimerRef.current = setInterval(() => {
+      if (sessionStartRef.current) {
+        setSessionDuration(formatDuration(Date.now() - sessionStartRef.current))
+      }
+    }, 1000)
+  }, [formatDuration])
+
+  const stopSessionTimer = useCallback(() => {
+    if (sessionTimerRef.current) {
+      clearInterval(sessionTimerRef.current)
+      sessionTimerRef.current = null
+    }
+    sessionStartRef.current = null
+    setSessionDuration('')
+  }, [])
+
+  // Load noise suppression setting and check crashed session on mount
+  useEffect(() => {
+    window.api.getSettings().then((s) => {
+      if (s.noiseSuppressionEnabled !== undefined) noiseSuppression.setEnabled(bool(s.noiseSuppressionEnabled, false))
+      if (s.selectedMicrophone) audio.setSelectedDevice(typeof s.selectedMicrophone === 'string' ? s.selectedMicrophone : '')
+    })
+
+    // Check for crashed session
+    window.api.getCrashedSession().then((session) => {
+      if (session) {
+        setCrashedSession(session)
+        setStatus('Previous session ended unexpectedly. Resume?')
+      }
+    })
+  }, [])
+
+  // Load session history
+  useEffect(() => {
+    window.api.listSessions().then(setSessions).catch((e) => console.warn('[settings] Failed to load sessions:', e))
+  }, [isRunning])
+
+  // Handle audio: streaming chunks during speech, final segment on speech end
+  useEffect(() => {
+    const unsub1 = audio.onAudioChunk((chunk) => {
+      window.api.processAudio(Array.from(chunk))
+    })
+    const unsub2 = audio.onStreamingChunk((buffer) => {
+      window.api.processAudioStreaming(Array.from(buffer))
+    })
+    const unsub3 = audio.onSpeechSegmentEnd((finalBuffer) => {
+      window.api.finalizeStreaming(Array.from(finalBuffer))
+    })
+
+    return () => {
+      unsub1()
+      unsub2()
+      unsub3()
+    }
+  }, [])
+
+  // Listen for status updates from main process
+  useEffect(() => {
+    const unsubscribe = window.api.onStatusUpdate((message) => {
+      setStatus(message)
+    })
+    return () => unsubscribe?.()
+  }, [])
+
+  // Cleanup session timer on unmount
+  useEffect(() => {
+    return () => {
+      if (sessionTimerRef.current) {
+        clearInterval(sessionTimerRef.current)
+      }
+    }
+  }, [])
+
+  return {
+    status, setStatus,
+    isRunning, setIsRunning,
+    isStarting, setIsStarting,
+    sessionDuration,
+    sessions,
+    lastTranscriptPath, setLastTranscriptPath,
+    summaryText, setSummaryText,
+    isSummarizing, setIsSummarizing,
+    crashedSession, setCrashedSession,
+    startSessionTimer, stopSessionTimer,
+    audio, noiseSuppression
+  }
+}

--- a/src/renderer/hooks/useSettingsState.ts
+++ b/src/renderer/hooks/useSettingsState.ts
@@ -1,10 +1,12 @@
-import { useCallback, useEffect, useRef, useState } from 'react'
-import { useAudioCapture } from './useAudioCapture'
-import { useNoiseSuppression } from './useNoiseSuppression'
+import { useState } from 'react'
 import type { UseAudioCaptureReturn } from './useAudioCapture'
 import type { UseNoiseSuppressionReturn } from './useNoiseSuppression'
+import { useEngineSettings } from './useEngineSettings'
+import { useDisplaySettings } from './useDisplaySettings'
+import { useSubtitleSettings } from './useSubtitleSettings'
+import { useLanguageSettings } from './useLanguageSettings'
+import { useSessionSettings } from './useSessionSettings'
 import {
-  API_ENGINE_MODES,
   withIpcTimeout,
   resolveEngineMode,
   buildEngineConfig
@@ -18,14 +20,6 @@ import type {
   SubtitlePositionType,
   WhisperVariantType
 } from '../components/settings/shared'
-
-// Runtime type-safe extractors for IPC settings (no unsafe `as` casts)
-const str = (v: unknown, def: string): string => (typeof v === 'string' ? v : def)
-const num = (v: unknown, def: number): number => (typeof v === 'number' ? v : def)
-const bool = (v: unknown, def: boolean): boolean => (typeof v === 'boolean' ? v : def)
-const arr = <T>(v: unknown, def: T[]): T[] => (Array.isArray(v) ? v : def)
-const rec = (v: unknown): Record<string, unknown> | null =>
-  typeof v === 'object' && v !== null && !Array.isArray(v) ? (v as Record<string, unknown>) : null
 
 export interface SettingsState {
   // Engine
@@ -125,401 +119,190 @@ export interface SettingsState {
 }
 
 export function useSettingsState(): SettingsState {
-  const [engineMode, setEngineMode] = useState<EngineMode>('offline-opus')
-  const [gpuInfo, setGpuInfo] = useState<{ hasGpu: boolean; gpuNames: string[] } | null>(null)
-  const [apiKey, setApiKey] = useState('')
-  const [deeplApiKey, setDeeplApiKey] = useState('')
-  const [geminiApiKey, setGeminiApiKey] = useState('')
-  const [microsoftApiKey, setMicrosoftApiKey] = useState('')
-  const [microsoftRegion, setMicrosoftRegion] = useState('')
-  const [displays, setDisplays] = useState<DisplayInfo[]>([])
-  const [selectedDisplay, setSelectedDisplay] = useState<number>(0)
-  const [status, setStatus] = useState('Ready')
-  const [isRunning, setIsRunning] = useState(false)
-  const [sessionDuration, setSessionDuration] = useState('')
-  const sessionTimerRef = useRef<ReturnType<typeof setInterval> | null>(null)
-  const sessionStartRef = useRef<number | null>(null)
-
-  const [isStarting, setIsStarting] = useState(false)
-
-  const [sourceLanguage, setSourceLanguage] = useState<SourceLanguage>('auto')
-  const [targetLanguage, setTargetLanguage] = useState<Language>('en')
-
-  const [sttEngine, setSttEngine] = useState<SttEngineType>('mlx-whisper')
-  const [whisperVariant, setWhisperVariant] = useState<WhisperVariantType>('kotoba-v2.0')
-
-  const [subtitleFontSize, setSubtitleFontSize] = useState(30)
-  const [subtitleSourceColor, setSubtitleSourceColor] = useState('#ffffff')
-  const [subtitleTranslatedColor, setSubtitleTranslatedColor] = useState('#7dd3fc')
-  const [subtitleBgOpacity, setSubtitleBgOpacity] = useState(78)
-  const [subtitlePosition, setSubtitlePosition] = useState<SubtitlePositionType>('bottom')
-
-  const [sessions, setSessions] = useState<Array<{ id: string; startedAt: number; engineMode: string; entryCount: number }>>([])
-
-  const [slmKvCacheQuant, setSlmKvCacheQuant] = useState(true)
-  const [simulMtEnabled, setSimulMtEnabled] = useState(false)
-  const [simulMtWaitK, setSimulMtWaitK] = useState(3)
-
-  const [glossaryTerms, setGlossaryTerms] = useState<Array<{ source: string; target: string }>>([])
-
-  const [platform, setPlatform] = useState<string>('darwin')
-
-  const [lastTranscriptPath, setLastTranscriptPath] = useState<string | null>(null)
-  const [summaryText, setSummaryText] = useState<string | null>(null)
-  const [isSummarizing, setIsSummarizing] = useState(false)
-
+  // UI state (trivial, kept in composer)
   const [showAdvanced, setShowAdvanced] = useState(false)
   const [showApiOptions, setShowApiOptions] = useState(false)
 
-  const [crashedSession, setCrashedSession] = useState<{ config: Record<string, unknown>; startedAt: number } | null>(null)
-
-  // Guard: display-related callbacks must wait until settings are fully loaded
-  const settingsLoadedRef = useRef(false)
-  const selectedDisplayRef = useRef(selectedDisplay)
-
-  // Noise suppression + audio capture
-  const noiseSuppression = useNoiseSuppression()
-  const audio = useAudioCapture(noiseSuppression.enabled ? noiseSuppression : undefined)
-
-  // --- Timer helpers ---
-  const formatDuration = useCallback((ms: number): string => {
-    const totalSec = Math.floor(ms / 1000)
-    const h = Math.floor(totalSec / 3600)
-    const m = Math.floor((totalSec % 3600) / 60)
-    const s = totalSec % 60
-    if (h > 0) return `${h}:${String(m).padStart(2, '0')}:${String(s).padStart(2, '0')}`
-    return `${m}:${String(s).padStart(2, '0')}`
-  }, [])
-
-  const startSessionTimer = useCallback(() => {
-    sessionStartRef.current = Date.now()
-    sessionTimerRef.current = setInterval(() => {
-      if (sessionStartRef.current) {
-        setSessionDuration(formatDuration(Date.now() - sessionStartRef.current))
-      }
-    }, 1000)
-  }, [formatDuration])
-
-  const stopSessionTimer = useCallback(() => {
-    if (sessionTimerRef.current) {
-      clearInterval(sessionTimerRef.current)
-      sessionTimerRef.current = null
-    }
-    sessionStartRef.current = null
-    setSessionDuration('')
-  }, [])
-
-  // --- Effects: Load settings on mount ---
-  useEffect(() => {
-    window.api.getSettings().then((s) => {
-      if (s.translationEngine) setEngineMode(str(s.translationEngine, 'offline-opus') as EngineMode)
-      if (s.googleApiKey) setApiKey(str(s.googleApiKey, ''))
-      if (s.deeplApiKey) setDeeplApiKey(str(s.deeplApiKey, ''))
-      if (s.geminiApiKey) setGeminiApiKey(str(s.geminiApiKey, ''))
-      if (s.microsoftApiKey) setMicrosoftApiKey(str(s.microsoftApiKey, ''))
-      if (s.microsoftRegion) setMicrosoftRegion(str(s.microsoftRegion, ''))
-      if (s.selectedMicrophone) audio.setSelectedDevice(str(s.selectedMicrophone, ''))
-      if (s.sttEngine) setSttEngine(str(s.sttEngine, 'mlx-whisper') as SttEngineType)
-      if (s.whisperVariant) setWhisperVariant(str(s.whisperVariant, 'kotoba-v2.0') as WhisperVariantType)
-      if (s.slmKvCacheQuant !== undefined) setSlmKvCacheQuant(bool(s.slmKvCacheQuant, true))
-      if (s.glossaryTerms) setGlossaryTerms(arr<{ source: string; target: string }>(s.glossaryTerms, []))
-      if (s.simulMtEnabled !== undefined) setSimulMtEnabled(bool(s.simulMtEnabled, false))
-      if (s.simulMtWaitK !== undefined) setSimulMtWaitK(num(s.simulMtWaitK, 3))
-      if (s.sourceLanguage) setSourceLanguage(str(s.sourceLanguage, 'auto') as SourceLanguage)
-      if (s.targetLanguage) setTargetLanguage(str(s.targetLanguage, 'en') as Language)
-      if (s.noiseSuppressionEnabled !== undefined) noiseSuppression.setEnabled(bool(s.noiseSuppressionEnabled, false))
-      const sub = rec(s.subtitleSettings)
-      if (sub) {
-        if (sub.fontSize) setSubtitleFontSize(num(sub.fontSize, 30))
-        if (sub.sourceTextColor) setSubtitleSourceColor(str(sub.sourceTextColor, '#ffffff'))
-        if (sub.translatedTextColor) setSubtitleTranslatedColor(str(sub.translatedTextColor, '#7dd3fc'))
-        if (sub.backgroundOpacity !== undefined) setSubtitleBgOpacity(num(sub.backgroundOpacity, 78))
-        if (sub.position) setSubtitlePosition(str(sub.position, 'bottom') as SubtitlePositionType)
-      }
-
-      // Restore saved display selection
-      if (s.selectedDisplay !== undefined) {
-        const savedDisplay = num(s.selectedDisplay, 0)
-        setSelectedDisplay(savedDisplay)
-        selectedDisplayRef.current = savedDisplay
-      }
-
-      // Auto-expand API section if an API engine is saved
-      const engine = str(s.translationEngine, '')
-      if (engine && API_ENGINE_MODES.includes(engine as EngineMode)) {
-        setShowAdvanced(true)
-        setShowApiOptions(true)
-      }
-
-      settingsLoadedRef.current = true
-    })
-
-    // Set platform-aware STT default (mlx-whisper on macOS)
-    window.api.getPlatform().then((p) => {
-      setPlatform(p)
-      window.api.getSettings().then((s) => {
-        if (!s.sttEngine && p === 'darwin') {
-          setSttEngine('mlx-whisper')
-        }
-      })
-    }).catch((e) => console.warn('[settings] Failed to load platform/settings:', e))
-
-    // Check for crashed session
-    window.api.getCrashedSession().then((session) => {
-      if (session) {
-        setCrashedSession(session)
-        setStatus('Previous session ended unexpectedly. Resume?')
-      }
-    })
-  }, [])
-
-  // Load session history
-  useEffect(() => {
-    window.api.listSessions().then(setSessions).catch((e) => console.warn('[settings] Failed to load sessions:', e))
-  }, [isRunning])
-
-  // Detect GPU — fall back to OPUS-MT if no GPU
-  useEffect(() => {
-    window.api.detectGpu().then((info) => {
-      setGpuInfo(info)
-      if (!info.hasGpu) {
-        window.api.getSettings().then((s) => {
-          if (!s.translationEngine) {
-            setEngineMode('offline-opus')
-          }
-        })
-      }
-    }).catch(() => setGpuInfo({ hasGpu: false, gpuNames: [] }))
-  }, [])
-
-  // Load displays and listen for display changes
-  useEffect(() => {
-    const refreshDisplays = (): void => {
-      window.api.getDisplays().then((d) => {
-        setDisplays(d)
-        // Skip auto-selection until settings are loaded (saved value takes priority)
-        if (!settingsLoadedRef.current) return
-        // Only auto-select if the current display was disconnected
-        const currentStillExists = d.some((disp: DisplayInfo) => disp.id === selectedDisplayRef.current)
-        if (!currentStillExists) {
-          const external = d.find((disp: DisplayInfo) => disp.label.includes('External'))
-          const fallback = external?.id ?? d[0]?.id ?? 0
-          setSelectedDisplay(fallback)
-          selectedDisplayRef.current = fallback
-        }
-      })
-    }
-    refreshDisplays()
-    const unsubscribe = window.api.onDisplaysChanged(refreshDisplays)
-    return () => unsubscribe?.()
-  }, [])
-
-  // Handle audio: streaming chunks during speech, final segment on speech end
-  useEffect(() => {
-    const unsub1 = audio.onAudioChunk((chunk) => {
-      window.api.processAudio(Array.from(chunk))
-    })
-    const unsub2 = audio.onStreamingChunk((buffer) => {
-      window.api.processAudioStreaming(Array.from(buffer))
-    })
-    const unsub3 = audio.onSpeechSegmentEnd((finalBuffer) => {
-      window.api.finalizeStreaming(Array.from(finalBuffer))
-    })
-
-    return () => {
-      unsub1()
-      unsub2()
-      unsub3()
-    }
-
-  }, [])
-
-  // Listen for status updates from main process
-  useEffect(() => {
-    const unsubscribe = window.api.onStatusUpdate((message) => {
-      setStatus(message)
-    })
-    return () => unsubscribe?.()
-  }, [])
-
-  // Cleanup session timer on unmount
-  useEffect(() => {
-    return () => {
-      if (sessionTimerRef.current) {
-        clearInterval(sessionTimerRef.current)
-      }
-    }
-  }, [])
+  // Domain-specific hooks
+  const engine = useEngineSettings({ setShowAdvanced, setShowApiOptions })
+  const display = useDisplaySettings()
+  const subtitle = useSubtitleSettings()
+  const language = useLanguageSettings()
+  const session = useSessionSettings()
 
   // --- Actions ---
-  const apiKeys = { apiKey, deeplApiKey, geminiApiKey, microsoftApiKey, microsoftRegion }
+  const apiKeys = {
+    apiKey: engine.apiKey,
+    deeplApiKey: engine.deeplApiKey,
+    geminiApiKey: engine.geminiApiKey,
+    microsoftApiKey: engine.microsoftApiKey,
+    microsoftRegion: engine.microsoftRegion
+  }
 
   const handleStart = async (): Promise<void> => {
-    if (isStarting) return
-    setIsStarting(true)
+    if (session.isStarting) return
+    session.setIsStarting(true)
 
     try {
-      setStatus('Starting pipeline...')
+      session.setStatus('Starting pipeline...')
 
       await withIpcTimeout(window.api.saveSettings({
-        translationEngine: engineMode,
-        googleApiKey: apiKey,
-        deeplApiKey,
-        geminiApiKey,
-        microsoftApiKey,
-        microsoftRegion,
-        selectedMicrophone: audio.selectedDevice,
-        selectedDisplay,
-        sttEngine,
-        whisperVariant,
-        slmKvCacheQuant,
-        simulMtEnabled,
-        simulMtWaitK,
-        sourceLanguage,
-        targetLanguage,
-        noiseSuppressionEnabled: noiseSuppression.enabled
+        translationEngine: engine.engineMode,
+        googleApiKey: engine.apiKey,
+        deeplApiKey: engine.deeplApiKey,
+        geminiApiKey: engine.geminiApiKey,
+        microsoftApiKey: engine.microsoftApiKey,
+        microsoftRegion: engine.microsoftRegion,
+        selectedMicrophone: session.audio.selectedDevice,
+        selectedDisplay: display.selectedDisplay,
+        sttEngine: language.sttEngine,
+        whisperVariant: language.whisperVariant,
+        slmKvCacheQuant: engine.slmKvCacheQuant,
+        simulMtEnabled: engine.simulMtEnabled,
+        simulMtWaitK: engine.simulMtWaitK,
+        sourceLanguage: language.sourceLanguage,
+        targetLanguage: language.targetLanguage,
+        noiseSuppressionEnabled: session.noiseSuppression.enabled
       }), 10_000, 'saveSettings')
 
-      const resolvedMode = resolveEngineMode(engineMode, apiKeys, gpuInfo)
-      const config = buildEngineConfig(resolvedMode, sttEngine, apiKeys)
+      const resolvedMode = resolveEngineMode(engine.engineMode, apiKeys, engine.gpuInfo)
+      const config = buildEngineConfig(resolvedMode, language.sttEngine, apiKeys)
 
       const result = await withIpcTimeout(window.api.pipelineStart(config), 120_000, 'pipelineStart')
       if (result.error) {
-        setStatus(`Error: ${result.error}`)
-        setIsStarting(false)
+        session.setStatus(`Error: ${result.error}`)
+        session.setIsStarting(false)
         return
       }
 
-      await audio.start()
-      setIsRunning(true)
-      startSessionTimer()
-      setStatus('Listening...')
+      await session.audio.start()
+      session.setIsRunning(true)
+      session.startSessionTimer()
+      session.setStatus('Listening...')
     } catch (err) {
-      setStatus(`Error: ${err}`)
-      setIsRunning(false)
-      stopSessionTimer()
+      session.setStatus(`Error: ${err}`)
+      session.setIsRunning(false)
+      session.stopSessionTimer()
     } finally {
-      setIsStarting(false)
+      session.setIsStarting(false)
     }
   }
 
   const handleStop = async (): Promise<void> => {
     try {
-      audio.stop()
-      stopSessionTimer()
+      session.audio.stop()
+      session.stopSessionTimer()
       const result = await withIpcTimeout(window.api.pipelineStop(), 10_000, 'pipelineStop')
-      setStatus(result.logPath ? `Saved: ${result.logPath}` : 'Stopped')
+      session.setStatus(result.logPath ? `Saved: ${result.logPath}` : 'Stopped')
 
       if (result.logPath) {
-        setLastTranscriptPath(result.logPath)
+        session.setLastTranscriptPath(result.logPath)
       }
     } catch (err) {
-      setStatus(`Stop error: ${err}`)
+      session.setStatus(`Stop error: ${err}`)
     } finally {
-      setIsRunning(false)
+      session.setIsRunning(false)
     }
   }
 
   const handleResume = async (): Promise<void> => {
-    if (!crashedSession || isStarting) return
-    setIsStarting(true)
+    if (!session.crashedSession || session.isStarting) return
+    session.setIsStarting(true)
 
     try {
-      setStatus('Resuming previous session...')
-      const result = await withIpcTimeout(window.api.pipelineStart(crashedSession.config), 120_000, 'pipelineStart')
+      session.setStatus('Resuming previous session...')
+      const result = await withIpcTimeout(window.api.pipelineStart(session.crashedSession.config), 120_000, 'pipelineStart')
       if (result.error) {
-        setStatus(`Resume failed: ${result.error}`)
-        setIsStarting(false)
+        session.setStatus(`Resume failed: ${result.error}`)
+        session.setIsStarting(false)
         return
       }
-      await audio.start()
-      setIsRunning(true)
-      setCrashedSession(null)
-      startSessionTimer()
-      setStatus('Listening... (resumed)')
+      await session.audio.start()
+      session.setIsRunning(true)
+      session.setCrashedSession(null)
+      session.startSessionTimer()
+      session.setStatus('Listening... (resumed)')
     } catch (err) {
-      setStatus(`Resume failed: ${err}`)
-      setIsRunning(false)
-      audio.stop()
-      stopSessionTimer()
+      session.setStatus(`Resume failed: ${err}`)
+      session.setIsRunning(false)
+      session.audio.stop()
+      session.stopSessionTimer()
     } finally {
-      setIsStarting(false)
+      session.setIsStarting(false)
     }
   }
 
   const handleDismissResume = (): void => {
-    setCrashedSession(null)
-    setStatus('Ready')
-  }
-
-  const pushSubtitleSettings = (overrides: Record<string, unknown> = {}): void => {
-    const settings = {
-      fontSize: subtitleFontSize,
-      sourceTextColor: subtitleSourceColor,
-      translatedTextColor: subtitleTranslatedColor,
-      backgroundOpacity: subtitleBgOpacity,
-      position: subtitlePosition,
-      ...overrides
-    }
-    window.api.saveSubtitleSettings(settings)
-  }
-
-  const handleDisplayChange = (displayId: number): void => {
-    setSelectedDisplay(displayId)
-    selectedDisplayRef.current = displayId
-    window.api.moveSubtitleToDisplay(displayId)
+    session.setCrashedSession(null)
+    session.setStatus('Ready')
   }
 
   const handleGenerateSummary = async (): Promise<void> => {
-    if (!lastTranscriptPath) return
-    setIsSummarizing(true)
-    setStatus('Generating meeting summary...')
-    const result = await withIpcTimeout(window.api.generateSummary(lastTranscriptPath), 120_000, 'generateSummary')
-    setIsSummarizing(false)
+    if (!session.lastTranscriptPath) return
+    session.setIsSummarizing(true)
+    session.setStatus('Generating meeting summary...')
+    const result = await withIpcTimeout(window.api.generateSummary(session.lastTranscriptPath), 120_000, 'generateSummary')
+    session.setIsSummarizing(false)
     if (result.summary) {
-      setSummaryText(result.summary)
-      setStatus('Summary generated')
+      session.setSummaryText(result.summary)
+      session.setStatus('Summary generated')
     } else {
-      setStatus(`Summary failed: ${result.error}`)
+      session.setStatus(`Summary failed: ${result.error}`)
     }
   }
 
   return {
-    engineMode, setEngineMode,
-    gpuInfo,
-    apiKey, setApiKey,
-    deeplApiKey, setDeeplApiKey,
-    geminiApiKey, setGeminiApiKey,
-    microsoftApiKey, setMicrosoftApiKey,
-    microsoftRegion, setMicrosoftRegion,
-    displays, selectedDisplay, handleDisplayChange,
-    status, setStatus,
-    isRunning, isStarting,
-    sessionDuration,
-    sessions,
-    sourceLanguage, setSourceLanguage,
-    targetLanguage, setTargetLanguage,
-    sttEngine, setSttEngine,
-    whisperVariant, setWhisperVariant,
-    subtitleFontSize, setSubtitleFontSize,
-    subtitleSourceColor, setSubtitleSourceColor,
-    subtitleTranslatedColor, setSubtitleTranslatedColor,
-    subtitleBgOpacity, setSubtitleBgOpacity,
-    subtitlePosition, setSubtitlePosition,
-    slmKvCacheQuant, setSlmKvCacheQuant,
-    simulMtEnabled, setSimulMtEnabled,
-    simulMtWaitK, setSimulMtWaitK,
-    glossaryTerms, setGlossaryTerms,
-    platform,
-    lastTranscriptPath,
-    summaryText,
-    isSummarizing,
-    crashedSession,
+    // Engine
+    engineMode: engine.engineMode, setEngineMode: engine.setEngineMode,
+    gpuInfo: engine.gpuInfo,
+    apiKey: engine.apiKey, setApiKey: engine.setApiKey,
+    deeplApiKey: engine.deeplApiKey, setDeeplApiKey: engine.setDeeplApiKey,
+    geminiApiKey: engine.geminiApiKey, setGeminiApiKey: engine.setGeminiApiKey,
+    microsoftApiKey: engine.microsoftApiKey, setMicrosoftApiKey: engine.setMicrosoftApiKey,
+    microsoftRegion: engine.microsoftRegion, setMicrosoftRegion: engine.setMicrosoftRegion,
+    slmKvCacheQuant: engine.slmKvCacheQuant, setSlmKvCacheQuant: engine.setSlmKvCacheQuant,
+    simulMtEnabled: engine.simulMtEnabled, setSimulMtEnabled: engine.setSimulMtEnabled,
+    simulMtWaitK: engine.simulMtWaitK, setSimulMtWaitK: engine.setSimulMtWaitK,
+    glossaryTerms: engine.glossaryTerms, setGlossaryTerms: engine.setGlossaryTerms,
+
+    // Display
+    displays: display.displays, selectedDisplay: display.selectedDisplay,
+    handleDisplayChange: display.handleDisplayChange,
+
+    // Subtitle
+    subtitleFontSize: subtitle.subtitleFontSize, setSubtitleFontSize: subtitle.setSubtitleFontSize,
+    subtitleSourceColor: subtitle.subtitleSourceColor, setSubtitleSourceColor: subtitle.setSubtitleSourceColor,
+    subtitleTranslatedColor: subtitle.subtitleTranslatedColor, setSubtitleTranslatedColor: subtitle.setSubtitleTranslatedColor,
+    subtitleBgOpacity: subtitle.subtitleBgOpacity, setSubtitleBgOpacity: subtitle.setSubtitleBgOpacity,
+    subtitlePosition: subtitle.subtitlePosition, setSubtitlePosition: subtitle.setSubtitlePosition,
+    pushSubtitleSettings: subtitle.pushSubtitleSettings,
+
+    // Language
+    sourceLanguage: language.sourceLanguage, setSourceLanguage: language.setSourceLanguage,
+    targetLanguage: language.targetLanguage, setTargetLanguage: language.setTargetLanguage,
+    sttEngine: language.sttEngine, setSttEngine: language.setSttEngine,
+    whisperVariant: language.whisperVariant, setWhisperVariant: language.setWhisperVariant,
+    platform: language.platform,
+
+    // Session
+    status: session.status, setStatus: session.setStatus,
+    isRunning: session.isRunning, isStarting: session.isStarting,
+    sessionDuration: session.sessionDuration,
+    sessions: session.sessions,
+    lastTranscriptPath: session.lastTranscriptPath,
+    summaryText: session.summaryText,
+    isSummarizing: session.isSummarizing,
+    crashedSession: session.crashedSession,
+
+    // Audio + noise suppression
+    audio: session.audio, noiseSuppression: session.noiseSuppression,
+
+    // UI state
     showAdvanced, setShowAdvanced,
     showApiOptions, setShowApiOptions,
-    audio, noiseSuppression,
+
+    // Actions
     handleStart, handleStop, handleResume, handleDismissResume,
-    pushSubtitleSettings,
     handleGenerateSummary
   }
 }

--- a/src/renderer/hooks/useSubtitleSettings.ts
+++ b/src/renderer/hooks/useSubtitleSettings.ts
@@ -1,0 +1,60 @@
+import { useEffect, useState } from 'react'
+import { num, rec, str } from './settingsCastUtils'
+import type { SubtitlePositionType } from '../components/settings/shared'
+
+export interface SubtitleSettingsState {
+  subtitleFontSize: number
+  setSubtitleFontSize: (v: number) => void
+  subtitleSourceColor: string
+  setSubtitleSourceColor: (v: string) => void
+  subtitleTranslatedColor: string
+  setSubtitleTranslatedColor: (v: string) => void
+  subtitleBgOpacity: number
+  setSubtitleBgOpacity: (v: number) => void
+  subtitlePosition: SubtitlePositionType
+  setSubtitlePosition: (v: SubtitlePositionType) => void
+  pushSubtitleSettings: (overrides?: Record<string, unknown>) => void
+}
+
+export function useSubtitleSettings(): SubtitleSettingsState {
+  const [subtitleFontSize, setSubtitleFontSize] = useState(30)
+  const [subtitleSourceColor, setSubtitleSourceColor] = useState('#ffffff')
+  const [subtitleTranslatedColor, setSubtitleTranslatedColor] = useState('#7dd3fc')
+  const [subtitleBgOpacity, setSubtitleBgOpacity] = useState(78)
+  const [subtitlePosition, setSubtitlePosition] = useState<SubtitlePositionType>('bottom')
+
+  // Load subtitle settings on mount
+  useEffect(() => {
+    window.api.getSettings().then((s) => {
+      const sub = rec(s.subtitleSettings)
+      if (sub) {
+        if (sub.fontSize) setSubtitleFontSize(num(sub.fontSize, 30))
+        if (sub.sourceTextColor) setSubtitleSourceColor(str(sub.sourceTextColor, '#ffffff'))
+        if (sub.translatedTextColor) setSubtitleTranslatedColor(str(sub.translatedTextColor, '#7dd3fc'))
+        if (sub.backgroundOpacity !== undefined) setSubtitleBgOpacity(num(sub.backgroundOpacity, 78))
+        if (sub.position) setSubtitlePosition(str(sub.position, 'bottom') as SubtitlePositionType)
+      }
+    })
+  }, [])
+
+  const pushSubtitleSettings = (overrides: Record<string, unknown> = {}): void => {
+    const settings = {
+      fontSize: subtitleFontSize,
+      sourceTextColor: subtitleSourceColor,
+      translatedTextColor: subtitleTranslatedColor,
+      backgroundOpacity: subtitleBgOpacity,
+      position: subtitlePosition,
+      ...overrides
+    }
+    window.api.saveSubtitleSettings(settings)
+  }
+
+  return {
+    subtitleFontSize, setSubtitleFontSize,
+    subtitleSourceColor, setSubtitleSourceColor,
+    subtitleTranslatedColor, setSubtitleTranslatedColor,
+    subtitleBgOpacity, setSubtitleBgOpacity,
+    subtitlePosition, setSubtitlePosition,
+    pushSubtitleSettings
+  }
+}


### PR DESCRIPTION
## Description

Refactor the monolithic `useSettingsState` hook (525 lines, 20+ useState) into focused domain-specific hooks:

- **`useEngineSettings`** — engine mode, API keys, SLM options, glossary, GPU detection
- **`useDisplaySettings`** — display list, selection, and change handling
- **`useSubtitleSettings`** — subtitle font/color/opacity/position and push to overlay
- **`useLanguageSettings`** — source/target language, STT engine/variant, platform detection
- **`useSessionSettings`** — pipeline running state, session timer, crash recovery, audio capture, noise suppression
- **`settingsCastUtils`** — shared safe-cast helpers (`str`/`num`/`bool`/`arr`/`rec`)

`useSettingsState` is now a thin composer that delegates to domain hooks and orchestrates pipeline actions (start/stop/resume/summary). The `SettingsState` interface and return type are unchanged — no consumer changes needed.

Closes #421