### PR TITLE
Add distil-large-v3 model variant for faster STT

### DIFF
--- a/src/engines/model-downloader.ts
+++ b/src/engines/model-downloader.ts
@@ -11,7 +11,7 @@ export const MODEL_URL =
   'https://huggingface.co/kotoba-tech/kotoba-whisper-v2.0-ggml/resolve/main/ggml-kotoba-whisper-v2.0-q5_0.bin'
 
 /** Whisper model variant identifier */
-export type WhisperVariant = 'kotoba-v2.0' | 'large-v3-turbo' | 'base' | 'small'
+export type WhisperVariant = 'kotoba-v2.0' | 'large-v3-turbo' | 'distil-large-v3' | 'base' | 'small'
 
 /** Whisper model variant configuration */
 export interface WhisperVariantConfig {
@@ -37,6 +37,13 @@ export const WHISPER_VARIANTS: Record<WhisperVariant, WhisperVariantConfig> = {
     sizeMB: 600,
     label: 'Large v3 Turbo (OpenAI)',
     description: 'Multilingual, 6x faster than large-v3, ~600MB'
+  },
+  'distil-large-v3': {
+    filename: 'ggml-distil-large-v3.bin',
+    url: 'https://huggingface.co/distil-whisper/distil-large-v3-ggml/resolve/main/ggml-distil-large-v3.bin',
+    sizeMB: 1500,
+    label: 'Distil Large v3 (HuggingFace)',
+    description: 'Distilled large-v3, 5x faster, within 1% WER, ~1.5GB'
   },
   'small': {
     filename: 'ggml-small.bin',

--- a/src/renderer/components/settings/STTSettings.tsx
+++ b/src/renderer/components/settings/STTSettings.tsx
@@ -48,12 +48,18 @@ export function STTSettings({
           >
             <option value="kotoba-v2.0">Kotoba Whisper v2.0 (Japanese-optimized, ~540MB)</option>
             <option value="large-v3-turbo">Large v3 Turbo (Multilingual, 6x faster, ~600MB)</option>
+            <option value="distil-large-v3">Distil Large v3 (5x faster, ~1.5GB)</option>
             <option value="small">Small (Fast mode, ~466MB)</option>
             <option value="base">Base (Fastest mode, ~142MB)</option>
           </select>
           {whisperVariant === 'large-v3-turbo' && (
             <div style={{ marginTop: '4px', fontSize: '11px', color: '#94a3b8' }}>
               OpenAI large-v3-turbo: 809M params, 4 decoder layers, within 1-2% WER of large-v3.
+            </div>
+          )}
+          {whisperVariant === 'distil-large-v3' && (
+            <div style={{ marginTop: '4px', fontSize: '11px', color: '#94a3b8' }}>
+              HuggingFace distil-large-v3: 756M params, 2 decoder layers, 5x faster with only 1% WER degradation vs large-v3.
             </div>
           )}
           {whisperVariant === 'small' && (

--- a/src/renderer/components/settings/shared.ts
+++ b/src/renderer/components/settings/shared.ts
@@ -28,7 +28,7 @@ export const ALL_LANGUAGES = Object.keys(LANGUAGE_LABELS) as Language[]
 export type EngineMode = 'auto' | 'rotation' | 'online' | 'online-deepl' | 'online-gemini' | 'offline-opus' | 'offline-hunyuan-mt' | 'offline-hybrid'
 
 export type SttEngineType = 'whisper-local' | 'mlx-whisper'
-export type WhisperVariantType = 'kotoba-v2.0' | 'large-v3-turbo' | 'base' | 'small'
+export type WhisperVariantType = 'kotoba-v2.0' | 'large-v3-turbo' | 'distil-large-v3' | 'base' | 'small'
 export type SubtitlePositionType = 'top' | 'bottom'
 
 export interface DisplayInfo {
@@ -130,6 +130,7 @@ export function getSttDisplayName(sttEngine: SttEngineType, whisperVariant: Whis
       const variantLabels: Record<string, string> = {
         'kotoba-v2.0': 'kotoba-v2.0',
         'large-v3-turbo': 'large-v3-turbo',
+        'distil-large-v3': 'distil-large-v3',
         'small': 'small, fast',
         'base': 'base, fastest'
       }


### PR DESCRIPTION
## Description
Add distil-large-v3 GGML model as a new Whisper variant option. Distil-large-v3 is 5x faster than large-v3 with only 1% WER degradation, making it ideal for real-time use.

Closes #502