### PR TITLE
Set HY-MT1.5-1.8B as default offline translator

### DIFF
--- a/src/main/store.ts
+++ b/src/main/store.ts
@@ -76,7 +76,7 @@ export interface AppSettings {
 export const store = new Store<AppSettings>({
   encryptionKey: 'live-translate-v1',
   defaults: {
-    translationEngine: 'offline-opus',
+    translationEngine: 'offline-hymt15',
     googleApiKey: '',
     microsoftApiKey: '',
     microsoftRegion: '',

--- a/src/renderer/components/settings/TranslatorSettings.tsx
+++ b/src/renderer/components/settings/TranslatorSettings.tsx
@@ -78,13 +78,26 @@ export function TranslatorSettings({
           <input
             type="radio"
             name="engine"
+            checked={engineMode === 'offline-hymt15'}
+            onChange={() => onEngineModeChange('offline-hymt15')}
+            disabled={disabled}
+          />
+          <div>
+            <div style={{ fontWeight: 500 }}>HY-MT 1.5 (Recommended)</div>
+            <div style={{ fontSize: '12px', color: '#94a3b8' }}>Fast + high quality, 36 languages, ~1GB — surpasses Google/DeepL</div>
+          </div>
+        </label>
+        <label style={radioLabelStyle}>
+          <input
+            type="radio"
+            name="engine"
             checked={engineMode === 'offline-opus'}
             onChange={() => onEngineModeChange('offline-opus')}
             disabled={disabled}
           />
           <div>
-            <div style={{ fontWeight: 500 }}>OPUS-MT (Recommended)</div>
-            <div style={{ fontSize: '12px', color: '#94a3b8' }}>~200ms latency, ONNX accelerated — best speed/quality balance</div>
+            <div style={{ fontWeight: 500 }}>OPUS-MT (Lightweight)</div>
+            <div style={{ fontSize: '12px', color: '#94a3b8' }}>~200ms latency, ONNX accelerated — minimal resource usage</div>
           </div>
         </label>
         <label style={radioLabelStyle}>

--- a/src/renderer/components/settings/shared.ts
+++ b/src/renderer/components/settings/shared.ts
@@ -25,7 +25,7 @@ export const LANGUAGE_LABELS: Record<Language, string> = {
 
 export const ALL_LANGUAGES = Object.keys(LANGUAGE_LABELS) as Language[]
 
-export type EngineMode = 'auto' | 'rotation' | 'online' | 'online-deepl' | 'online-gemini' | 'offline-opus' | 'offline-hunyuan-mt' | 'offline-hybrid'
+export type EngineMode = 'auto' | 'rotation' | 'online' | 'online-deepl' | 'online-gemini' | 'offline-opus' | 'offline-hymt15' | 'offline-hunyuan-mt' | 'offline-hybrid'
 
 export type SttEngineType = 'whisper-local' | 'mlx-whisper'
 export type WhisperVariantType = 'kotoba-v2.0' | 'large-v3-turbo' | 'distil-large-v3' | 'base' | 'small'
@@ -105,12 +105,13 @@ export const colorInputStyle: React.CSSProperties = {
 export const API_ENGINE_MODES: EngineMode[] = ['rotation', 'online', 'online-deepl', 'online-gemini']
 
 /** LLM-based engine modes that support KV cache / SimulMT options */
-export const LLM_ENGINE_MODES: EngineMode[] = ['offline-hunyuan-mt', 'offline-hybrid']
+export const LLM_ENGINE_MODES: EngineMode[] = ['offline-hymt15', 'offline-hunyuan-mt', 'offline-hybrid']
 
 /** Display name for each engine mode */
 export function getEngineDisplayName(mode: EngineMode): string {
   switch (mode) {
-    case 'offline-opus': return 'OPUS-MT (Fast Offline)'
+    case 'offline-opus': return 'OPUS-MT (Lightweight)'
+    case 'offline-hymt15': return 'HY-MT 1.5 (Recommended)'
     case 'offline-hunyuan-mt': return 'Hunyuan-MT 7B (High Quality)'
     case 'offline-hybrid': return 'Hybrid (OPUS-MT + TranslateGemma)'
     case 'rotation': return 'API Auto Rotation'
@@ -150,7 +151,7 @@ export function resolveEngineMode(
   const hasKeys = !!(apiKeys.apiKey || apiKeys.deeplApiKey || apiKeys.geminiApiKey || (apiKeys.microsoftApiKey && apiKeys.microsoftRegion))
   if (hasKeys) return 'rotation'
   if (gpuInfo?.hasGpu) return 'offline-hunyuan-mt'
-  return 'offline-opus' // maps to opus-mt (ONNX-based)
+  return 'offline-hymt15' // HY-MT1.5-1.8B — fast + high quality, ~1GB
 }
 
 /** Build pipeline config from resolved engine mode and settings */
@@ -177,6 +178,8 @@ export function buildEngineConfig(
       return { ...base, translatorEngineId: 'deepl-translate', deeplApiKey: apiKeys.deeplApiKey }
     case 'online-gemini':
       return { ...base, translatorEngineId: 'gemini-translate', geminiApiKey: apiKeys.geminiApiKey }
+    case 'offline-hymt15':
+      return { ...base, translatorEngineId: 'hunyuan-mt-15' }
     case 'offline-hunyuan-mt':
       return { ...base, translatorEngineId: 'hunyuan-mt' }
     case 'offline-hybrid':

--- a/src/renderer/hooks/useEngineSettings.ts
+++ b/src/renderer/hooks/useEngineSettings.ts
@@ -36,7 +36,7 @@ export interface EngineSettingsInit {
 }
 
 export function useEngineSettings(init: EngineSettingsInit): EngineSettingsState {
-  const [engineMode, setEngineMode] = useState<EngineMode>('offline-opus')
+  const [engineMode, setEngineMode] = useState<EngineMode>('offline-hymt15')
   const [gpuInfo, setGpuInfo] = useState<{ hasGpu: boolean; gpuNames: string[] } | null>(null)
   const [apiKey, setApiKey] = useState('')
   const [deeplApiKey, setDeeplApiKey] = useState('')
@@ -51,7 +51,7 @@ export function useEngineSettings(init: EngineSettingsInit): EngineSettingsState
   // Load engine-related settings on mount
   useEffect(() => {
     window.api.getSettings().then((s) => {
-      if (s.translationEngine) setEngineMode(str(s.translationEngine, 'offline-opus') as EngineMode)
+      if (s.translationEngine) setEngineMode(str(s.translationEngine, 'offline-hymt15') as EngineMode)
       if (s.googleApiKey) setApiKey(str(s.googleApiKey, ''))
       if (s.deeplApiKey) setDeeplApiKey(str(s.deeplApiKey, ''))
       if (s.geminiApiKey) setGeminiApiKey(str(s.geminiApiKey, ''))
@@ -71,14 +71,14 @@ export function useEngineSettings(init: EngineSettingsInit): EngineSettingsState
     })
   }, [])
 
-  // Detect GPU — fall back to OPUS-MT if no GPU
+  // Detect GPU — fall back to HY-MT1.5 if no GPU
   useEffect(() => {
     window.api.detectGpu().then((info) => {
       setGpuInfo(info)
       if (!info.hasGpu) {
         window.api.getSettings().then((s) => {
           if (!s.translationEngine) {
-            setEngineMode('offline-opus')
+            setEngineMode('offline-hymt15')
           }
         })
       }


### PR DESCRIPTION
## Description
Change the default offline translation engine from OPUS-MT to HY-MT1.5-1.8B.

HY-MT1.5-1.8B provides significantly better translation quality (surpasses Google/DeepL in human evaluation) while using similar memory (~1GB quantized). The engine infrastructure was already fully implemented — this change updates the UI default and labeling.

OPUS-MT remains available as a lightweight fallback option.

Closes #503