### PR TITLE
Add LFM2-350M ultra-fast JA↔EN translator

### DIFF
--- a/src/engines/model-downloader.ts
+++ b/src/engines/model-downloader.ts
@@ -153,6 +153,33 @@ export function getHunyuanMT15Variants(): Record<string, GGUFVariant> {
   return HUNYUAN_MT_15_VARIANTS
 }
 
+/** LFM2-350M-ENJP-MT GGUF variants (official Liquid AI quantizations) */
+export const LFM2_VARIANTS: Record<string, GGUFVariant> = {
+  'Q4_K_M': {
+    filename: 'LFM2-350M-ENJP-MT-Q4_K_M.gguf',
+    url: 'https://huggingface.co/LiquidAI/LFM2-350M-ENJP-MT-GGUF/resolve/main/LFM2-350M-ENJP-MT-Q4_K_M.gguf',
+    sizeMB: 229,
+    label: 'Q4_K_M (Recommended, ~229MB)'
+  },
+  'Q6_K': {
+    filename: 'LFM2-350M-ENJP-MT-Q6_K.gguf',
+    url: 'https://huggingface.co/LiquidAI/LFM2-350M-ENJP-MT-GGUF/resolve/main/LFM2-350M-ENJP-MT-Q6_K.gguf',
+    sizeMB: 293,
+    label: 'Q6_K (Balanced, ~293MB)'
+  },
+  'Q8_0': {
+    filename: 'LFM2-350M-ENJP-MT-Q8_0.gguf',
+    url: 'https://huggingface.co/LiquidAI/LFM2-350M-ENJP-MT-GGUF/resolve/main/LFM2-350M-ENJP-MT-Q8_0.gguf',
+    sizeMB: 379,
+    label: 'Q8_0 (Best quality, ~379MB)'
+  }
+}
+
+/** Get LFM2-350M-ENJP-MT GGUF variants */
+export function getLFM2Variants(): Record<string, GGUFVariant> {
+  return LFM2_VARIANTS
+}
+
 export const GGUF_VARIANTS_4B: Record<string, GGUFVariant> = {
   'Q4_K_M': {
     filename: 'translategemma-4b-it.Q4_K_M.gguf',

--- a/src/engines/translator/LFM2Translator.ts
+++ b/src/engines/translator/LFM2Translator.ts
@@ -1,0 +1,26 @@
+import { getLFM2Variants } from '../model-downloader'
+import { LlamaWorkerTranslator } from './LlamaWorkerTranslator'
+import type { GGUFVariantConfig } from './LlamaWorkerTranslator'
+
+/**
+ * LFM2-350M-ENJP-MT translator via node-llama-cpp UtilityProcess.
+ * Uses the shared worker pool instead of spawning its own process.
+ * 350M parameter Liquid AI model (~230MB Q4_K_M) for ultra-fast JA↔EN translation.
+ * License: Liquid Foundation Model License 1.0.
+ */
+export class LFM2Translator extends LlamaWorkerTranslator {
+  readonly id = 'lfm2'
+  readonly name = 'LFM2-350M (Ultra-fast)'
+
+  protected getVariants(): Record<string, GGUFVariantConfig> {
+    return getLFM2Variants()
+  }
+
+  protected getModelSizeLabel(): string {
+    return 'LFM2-350M'
+  }
+
+  protected getExtraInitOptions() {
+    return { modelType: 'lfm2' as const }
+  }
+}

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -9,6 +9,7 @@ import { OpusMTTranslator } from '../engines/translator/OpusMTTranslator'
 import { SLMTranslator } from '../engines/translator/SLMTranslator'
 import { HunyuanMTTranslator } from '../engines/translator/HunyuanMTTranslator'
 import { HunyuanMT15Translator } from '../engines/translator/HunyuanMT15Translator'
+import { LFM2Translator } from '../engines/translator/LFM2Translator'
 import { ANETranslator } from '../engines/translator/ANETranslator'
 import { HybridTranslator } from '../engines/translator/HybridTranslator'
 import { discoverPlugins, loadPluginEngine } from '../engines/plugin-loader'
@@ -79,6 +80,11 @@ async function initPipeline(): Promise<void> {
     speculativeDecoding: store.get('slmSpeculativeDecoding')
   }))
   ctx.pipeline.registerTranslator('hunyuan-mt', () => new HunyuanMTTranslator({
+    onProgress: (msg) => ctx.mainWindow?.webContents.send('status-update', msg),
+    kvCacheQuant: store.get('slmKvCacheQuant')
+  }))
+  // LFM2-350M ultra-fast JA↔EN translator — 350M params, ~230MB
+  ctx.pipeline.registerTranslator('lfm2', () => new LFM2Translator({
     onProgress: (msg) => ctx.mainWindow?.webContents.send('status-update', msg),
     kvCacheQuant: store.get('slmKvCacheQuant')
   }))

--- a/src/main/slm-worker.ts
+++ b/src/main/slm-worker.ts
@@ -21,7 +21,7 @@ import { createLogger } from './logger'
 
 const log = createLogger('slm-worker')
 
-type ModelType = 'translategemma' | 'hunyuan-mt' | 'hunyuan-mt-15'
+type ModelType = 'translategemma' | 'hunyuan-mt' | 'hunyuan-mt-15' | 'lfm2'
 
 /** Messages sent from main process to this worker */
 type WorkerInboundMessage =
@@ -161,6 +161,13 @@ function buildTranslationPrompt(
   const toLang = LANG_NAMES_EN[to] ?? to
   const contextSection = buildContextPrompt(translateContext)
 
+  if (activeModelType === 'lfm2') {
+    // LFM2 uses a simple system prompt via chat template;
+    // the system message is set by node-llama-cpp's chat session,
+    // so we just return the user text as the prompt body.
+    return `${contextSection}${text}`
+  }
+
   if (activeModelType === 'hunyuan-mt-15') {
     const isChinese = from === 'zh' || from === 'zh-Hant' || to === 'zh' || to === 'zh-Hant'
     if (isChinese) {
@@ -185,8 +192,17 @@ function buildTranslationPrompt(
   return `${contextSection}Translate the following text from ${fromLang} to ${toLang}. Output only the translation, nothing else.\n\n${text}`
 }
 
+/** Get the system prompt for LFM2 based on target language */
+function getLFM2SystemPrompt(to: string): string {
+  const toLang = LANG_NAMES_EN[to] ?? to
+  return `Translate to ${toLang}.`
+}
+
 /** Get inference parameters based on model type */
-function getInferenceParams(): { temperature: number; maxTokens: number; topK?: number; topP?: number; repeatPenalty?: { penalty: number } } {
+function getInferenceParams(): { temperature: number; maxTokens: number; topK?: number; topP?: number; minP?: number; repeatPenalty?: { penalty: number } } {
+  if (activeModelType === 'lfm2') {
+    return { temperature: 0.5, maxTokens: 512, topP: 1.0, minP: 0.1, repeatPenalty: { penalty: 1.05 } }
+  }
   if (activeModelType === 'hunyuan-mt' || activeModelType === 'hunyuan-mt-15') {
     return { temperature: 0.7, maxTokens: 512, topK: 20, topP: 0.6, repeatPenalty: { penalty: 1.05 } }
   }
@@ -213,7 +229,8 @@ async function createContextSequence(): Promise<LlamaContextSequence> {
 /** Run translation inference and return the result */
 async function runInference(
   prompt: string,
-  previousOutput?: string
+  previousOutput?: string,
+  systemPrompt?: string
 ): Promise<{ response: string; inferenceMs: number; contextMs: number }> {
   const { LlamaChatSession } = await import('node-llama-cpp')
 
@@ -221,7 +238,10 @@ async function runInference(
   const contextSequence = await createContextSequence()
   const contextMs = performance.now() - t0
 
-  const session = new LlamaChatSession({ contextSequence })
+  const session = new LlamaChatSession({
+    contextSequence,
+    ...(systemPrompt && { systemPrompt })
+  })
 
   const inferenceParams = getInferenceParams()
   const t1 = performance.now()
@@ -267,7 +287,8 @@ async function handleTranslate(
     const prompt = buildTranslationPrompt(text, from, to, translateContext)
     const promptMs = performance.now() - t0
 
-    const { response, inferenceMs, contextMs } = await runInference(prompt)
+    const systemPrompt = activeModelType === 'lfm2' ? getLFM2SystemPrompt(to) : undefined
+    const { response, inferenceMs, contextMs } = await runInference(prompt, undefined, systemPrompt)
     const memAfter = process.memoryUsage()
     const totalMs = performance.now() - t0
 
@@ -315,7 +336,8 @@ async function handleTranslateIncremental(
     const t0 = performance.now()
     const prompt = buildTranslationPrompt(text, from, to, translateContext)
     const promptMs = performance.now() - t0
-    const { response, inferenceMs, contextMs } = await runInference(prompt, previousOutput)
+    const systemPrompt = activeModelType === 'lfm2' ? getLFM2SystemPrompt(to) : undefined
+    const { response, inferenceMs, contextMs } = await runInference(prompt, previousOutput, systemPrompt)
     const memAfter = process.memoryUsage()
     const totalMs = performance.now() - t0
 

--- a/src/renderer/components/settings/TranslatorSettings.tsx
+++ b/src/renderer/components/settings/TranslatorSettings.tsx
@@ -91,6 +91,19 @@ export function TranslatorSettings({
           <input
             type="radio"
             name="engine"
+            checked={engineMode === 'offline-lfm2'}
+            onChange={() => onEngineModeChange('offline-lfm2')}
+            disabled={disabled}
+          />
+          <div>
+            <div style={{ fontWeight: 500 }}>LFM2 (Ultra-fast, JA↔EN)</div>
+            <div style={{ fontSize: '12px', color: '#94a3b8' }}>350M params, ~230MB — GPT-4o-class quality at minimal cost</div>
+          </div>
+        </label>
+        <label style={radioLabelStyle}>
+          <input
+            type="radio"
+            name="engine"
             checked={engineMode === 'offline-opus'}
             onChange={() => onEngineModeChange('offline-opus')}
             disabled={disabled}

--- a/src/renderer/components/settings/shared.ts
+++ b/src/renderer/components/settings/shared.ts
@@ -25,7 +25,7 @@ export const LANGUAGE_LABELS: Record<Language, string> = {
 
 export const ALL_LANGUAGES = Object.keys(LANGUAGE_LABELS) as Language[]
 
-export type EngineMode = 'auto' | 'rotation' | 'online' | 'online-deepl' | 'online-gemini' | 'offline-opus' | 'offline-hymt15' | 'offline-hunyuan-mt' | 'offline-hybrid'
+export type EngineMode = 'auto' | 'rotation' | 'online' | 'online-deepl' | 'online-gemini' | 'offline-opus' | 'offline-hymt15' | 'offline-hunyuan-mt' | 'offline-hybrid' | 'offline-lfm2'
 
 export type SttEngineType = 'whisper-local' | 'mlx-whisper'
 export type WhisperVariantType = 'kotoba-v2.0' | 'large-v3-turbo' | 'distil-large-v3' | 'base' | 'small'
@@ -105,7 +105,7 @@ export const colorInputStyle: React.CSSProperties = {
 export const API_ENGINE_MODES: EngineMode[] = ['rotation', 'online', 'online-deepl', 'online-gemini']
 
 /** LLM-based engine modes that support KV cache / SimulMT options */
-export const LLM_ENGINE_MODES: EngineMode[] = ['offline-hymt15', 'offline-hunyuan-mt', 'offline-hybrid']
+export const LLM_ENGINE_MODES: EngineMode[] = ['offline-hymt15', 'offline-hunyuan-mt', 'offline-hybrid', 'offline-lfm2']
 
 /** Display name for each engine mode */
 export function getEngineDisplayName(mode: EngineMode): string {
@@ -113,6 +113,7 @@ export function getEngineDisplayName(mode: EngineMode): string {
     case 'offline-opus': return 'OPUS-MT (Lightweight)'
     case 'offline-hymt15': return 'HY-MT 1.5 (Recommended)'
     case 'offline-hunyuan-mt': return 'Hunyuan-MT 7B (High Quality)'
+    case 'offline-lfm2': return 'LFM2 (Ultra-fast)'
     case 'offline-hybrid': return 'Hybrid (OPUS-MT + TranslateGemma)'
     case 'rotation': return 'API Auto Rotation'
     case 'online': return 'Google Translation'
@@ -178,6 +179,8 @@ export function buildEngineConfig(
       return { ...base, translatorEngineId: 'deepl-translate', deeplApiKey: apiKeys.deeplApiKey }
     case 'online-gemini':
       return { ...base, translatorEngineId: 'gemini-translate', geminiApiKey: apiKeys.geminiApiKey }
+    case 'offline-lfm2':
+      return { ...base, translatorEngineId: 'lfm2' }
     case 'offline-hymt15':
       return { ...base, translatorEngineId: 'hunyuan-mt-15' }
     case 'offline-hunyuan-mt':


### PR DESCRIPTION
## Description
Add Liquid AI's LFM2-350M-ENJP-MT as an ultra-fast offline translation engine.

- 350M parameters, ~230MB quantized — minimal memory footprint
- Quality competitive with GPT-4o on JP-EN benchmarks
- 2x faster decode than Qwen3 on CPU
- GGUF format, runs via existing node-llama-cpp/UtilityProcess infrastructure
- Follows the same LlamaWorkerTranslator pattern as HY-MT1.5

Closes #507