### PR TITLE
Add confidence-based subtitle styling

### DIFF
--- a/src/engines/types.ts
+++ b/src/engines/types.ts
@@ -61,6 +61,8 @@ export interface TranslationResult {
   speakerId?: string
   /** Translation stage: 'draft' (OPUS-MT), 'refined' (LLM), or 'ger-corrected' (GER post-correction) */
   translationStage?: 'draft' | 'refined' | 'ger-corrected'
+  /** STT confidence score (0.0–1.0), forwarded from STTResult for UI styling */
+  confidence?: number
 }
 
 /**

--- a/src/main/store.ts
+++ b/src/main/store.ts
@@ -71,6 +71,8 @@ export interface AppSettings {
   noiseSuppressionEnabled: boolean
   /** Streaming chunk interval in ms (default 1000, range 500-3000) */
   streamingIntervalMs: number
+  /** Show confidence-based styling on subtitle text (opacity/italic for low-confidence) */
+  showConfidenceIndicator: boolean
 }
 
 export const store = new Store<AppSettings>({
@@ -108,6 +110,7 @@ export const store = new Store<AppSettings>({
     targetLanguage: 'en',
     wsAudioPort: DEFAULT_WS_PORT,
     noiseSuppressionEnabled: false,
-    streamingIntervalMs: 1000
+    streamingIntervalMs: 1000,
+    showConfidenceIndicator: true
   }
 })

--- a/src/pipeline/StreamingProcessor.ts
+++ b/src/pipeline/StreamingProcessor.ts
@@ -209,7 +209,8 @@ export class StreamingProcessor {
         targetLanguage: targetLang,
         timestamp: Date.now(),
         isInterim: false,
-        speakerId
+        speakerId,
+        confidence: sttResult.confidence
       }
 
       this.deps.emitter.emit('result', result)

--- a/src/pipeline/TranslationPipeline.ts
+++ b/src/pipeline/TranslationPipeline.ts
@@ -374,7 +374,8 @@ export class TranslationPipeline extends EventEmitter {
         sourceLanguage: sttResult.language,
         targetLanguage: targetLang,
         timestamp: Date.now(),
-        speakerId
+        speakerId,
+        confidence: sttResult.confidence
       }
     } catch (translatorErr) {
       log.error('Translator error:', translatorErr)

--- a/src/renderer/components/SettingsPanel.tsx
+++ b/src/renderer/components/SettingsPanel.tsx
@@ -117,6 +117,12 @@ function SettingsPanel(): React.JSX.Element {
             onBgOpacityChange={(v) => { s.setSubtitleBgOpacity(v); s.pushSubtitleSettings({ backgroundOpacity: v }) }}
             position={s.subtitlePosition}
             onPositionChange={(v) => { s.setSubtitlePosition(v); s.pushSubtitleSettings({ position: v }) }}
+            showConfidenceIndicator={s.showConfidenceIndicator}
+            onShowConfidenceIndicatorChange={(v) => {
+              s.setShowConfidenceIndicator(v)
+              s.pushSubtitleSettings({ showConfidenceIndicator: v })
+              window.api.saveSettings({ showConfidenceIndicator: v })
+            }}
             displays={s.displays}
             selectedDisplay={s.selectedDisplay}
             onDisplayChange={s.handleDisplayChange}

--- a/src/renderer/components/SubtitleOverlay.tsx
+++ b/src/renderer/components/SubtitleOverlay.tsx
@@ -11,6 +11,8 @@ interface SubtitleLine {
   speakerId?: string
   /** Whether this line is a draft from hybrid translation, pending refinement */
   isDraft?: boolean
+  /** STT confidence score (0.0–1.0) for confidence-based styling */
+  confidence?: number
 }
 
 interface SubtitleConfig {
@@ -19,6 +21,7 @@ interface SubtitleConfig {
   translatedTextColor: string
   backgroundOpacity: number
   position: 'top' | 'bottom'
+  showConfidenceIndicator: boolean
 }
 
 const DEFAULT_CONFIG: SubtitleConfig = {
@@ -26,13 +29,25 @@ const DEFAULT_CONFIG: SubtitleConfig = {
   sourceTextColor: '#ffffff',
   translatedTextColor: '#7dd3fc',
   backgroundOpacity: 78,
-  position: 'bottom'
+  position: 'bottom',
+  showConfidenceIndicator: true
 }
 
 const MAX_LINES = 3
 const FADE_DURATION_MS = 8000
 const INTERIM_LINE_ID = -1
 const DRAFT_LINE_ID = -2
+
+/** Compute opacity and fontStyle overrides based on STT confidence level */
+function getConfidenceStyle(
+  confidence: number | undefined,
+  enabled: boolean
+): { opacity: number; fontStyle: 'normal' | 'italic' } {
+  if (!enabled || confidence === undefined) return { opacity: 1, fontStyle: 'normal' }
+  if (confidence >= 0.9) return { opacity: 1, fontStyle: 'normal' }
+  if (confidence >= 0.5) return { opacity: 0.8, fontStyle: 'normal' }
+  return { opacity: 0.5, fontStyle: 'italic' }
+}
 
 function SubtitleOverlay(): React.JSX.Element {
   const [lines, setLines] = useState<SubtitleLine[]>([])
@@ -44,12 +59,15 @@ function SubtitleOverlay(): React.JSX.Element {
   useEffect(() => {
     window.api.getSettings().then((s) => {
       if (s.subtitleSettings) {
-        setConfig(s.subtitleSettings as SubtitleConfig)
+        setConfig((prev) => ({ ...prev, ...s.subtitleSettings as Partial<SubtitleConfig> }))
+      }
+      if (typeof s.showConfidenceIndicator === 'boolean') {
+        setConfig((prev) => ({ ...prev, showConfidenceIndicator: s.showConfidenceIndicator as boolean }))
       }
     })
 
     const unsubscribe = window.api.onSubtitleSettingsChanged((settings) => {
-      setConfig(settings as SubtitleConfig)
+      setConfig((prev) => ({ ...prev, ...settings as Partial<SubtitleConfig> }))
     })
     return () => unsubscribe?.()
   }, [])
@@ -146,67 +164,70 @@ function SubtitleOverlay(): React.JSX.Element {
         userSelect: 'none'
       }}
     >
-      {lines.map((line) => (
-        <div
-          key={line.id}
-          style={{
-            background: (line.isInterim || line.isDraft)
-              ? `rgba(0, 0, 0, ${Math.max(0, config.backgroundOpacity - 13) / 100})`
-              : `rgba(0, 0, 0, ${config.backgroundOpacity / 100})`,
-            borderRadius: '0.625rem',
-            padding: '0.625rem 1.25rem',
-            marginBottom: '0.375rem',
-            opacity: line.opacity,
-            transition: 'opacity 0.3s ease-out',
-            backdropFilter: 'blur(8px)',
-            WebkitBackdropFilter: 'blur(8px)',
-            borderLeft: `0.25rem solid ${
-              line.isInterim
-                ? '#94a3b8'
-                : line.isDraft
-                  ? '#f59e0b'
-                  : line.sourceLanguage === 'ja'
-                    ? '#4ade80'
-                    : '#60a5fa'
-            }`
-          }}
-        >
+      {lines.map((line) => {
+        const confStyle = getConfidenceStyle(line.confidence, config.showConfidenceIndicator)
+        return (
           <div
+            key={line.id}
             style={{
-              color: line.isInterim ? '#cbd5e1' : line.isDraft ? '#d4d4d8' : config.sourceTextColor,
-              fontSize: `${config.fontSize}px`,
-              fontWeight: 600,
-              lineHeight: 1.4,
-              textShadow: '0 1px 3px rgba(0,0,0,0.5)',
-              fontStyle: line.isInterim || line.isDraft ? 'italic' : 'normal',
-              opacity: line.isDraft ? 0.85 : 1
+              background: (line.isInterim || line.isDraft)
+                ? `rgba(0, 0, 0, ${Math.max(0, config.backgroundOpacity - 13) / 100})`
+                : `rgba(0, 0, 0, ${config.backgroundOpacity / 100})`,
+              borderRadius: '0.625rem',
+              padding: '0.625rem 1.25rem',
+              marginBottom: '0.375rem',
+              opacity: line.opacity,
+              transition: 'opacity 0.3s ease-out',
+              backdropFilter: 'blur(8px)',
+              WebkitBackdropFilter: 'blur(8px)',
+              borderLeft: `0.25rem solid ${
+                line.isInterim
+                  ? '#94a3b8'
+                  : line.isDraft
+                    ? '#f59e0b'
+                    : line.sourceLanguage === 'ja'
+                      ? '#4ade80'
+                      : '#60a5fa'
+              }`
             }}
           >
-            {line.speakerId && (
-              <span style={{ fontSize: '0.7em', opacity: 0.7, marginRight: '0.5rem', maxWidth: '7.5rem', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', display: 'inline-block', verticalAlign: 'middle' }}>
-                [{line.speakerId}]
-              </span>
-            )}
-            {line.sourceText}
-          </div>
-          {line.translatedText && (
             <div
               style={{
-                color: line.isInterim ? '#94a3b8' : line.isDraft ? '#b4b4bb' : config.translatedTextColor,
-                fontSize: `${translatedFontSize}px`,
+                color: line.isInterim ? '#cbd5e1' : line.isDraft ? '#d4d4d8' : config.sourceTextColor,
+                fontSize: `${config.fontSize}px`,
                 fontWeight: 600,
                 lineHeight: 1.4,
-                marginTop: '0.125rem',
                 textShadow: '0 1px 3px rgba(0,0,0,0.5)',
-                fontStyle: line.isInterim || line.isDraft ? 'italic' : 'normal',
-                opacity: line.isDraft ? 0.85 : 1
+                fontStyle: line.isInterim || line.isDraft ? 'italic' : confStyle.fontStyle,
+                opacity: line.isDraft ? 0.85 : confStyle.opacity
               }}
             >
-              {line.translatedText}
+              {line.speakerId && (
+                <span style={{ fontSize: '0.7em', opacity: 0.7, marginRight: '0.5rem', maxWidth: '7.5rem', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', display: 'inline-block', verticalAlign: 'middle' }}>
+                  [{line.speakerId}]
+                </span>
+              )}
+              {line.sourceText}
             </div>
-          )}
-        </div>
-      ))}
+            {line.translatedText && (
+              <div
+                style={{
+                  color: line.isInterim ? '#94a3b8' : line.isDraft ? '#b4b4bb' : config.translatedTextColor,
+                  fontSize: `${translatedFontSize}px`,
+                  fontWeight: 600,
+                  lineHeight: 1.4,
+                  marginTop: '0.125rem',
+                  textShadow: '0 1px 3px rgba(0,0,0,0.5)',
+                  fontStyle: line.isInterim || line.isDraft ? 'italic' : confStyle.fontStyle,
+                  opacity: line.isDraft ? 0.85 : confStyle.opacity
+                }}
+              >
+                {line.translatedText}
+              </div>
+            )}
+          </div>
+        )
+      })}
     </div>
   )
 }

--- a/src/renderer/components/settings/SubtitleSettings.tsx
+++ b/src/renderer/components/settings/SubtitleSettings.tsx
@@ -14,6 +14,8 @@ interface SubtitleSettingsProps {
   onBgOpacityChange: (v: number) => void
   position: SubtitlePositionType
   onPositionChange: (v: SubtitlePositionType) => void
+  showConfidenceIndicator: boolean
+  onShowConfidenceIndicatorChange: (v: boolean) => void
   displays: DisplayInfo[]
   selectedDisplay: number
   onDisplayChange: (displayId: number) => void
@@ -30,6 +32,8 @@ export function SubtitleSettings({
   onBgOpacityChange,
   position,
   onPositionChange,
+  showConfidenceIndicator,
+  onShowConfidenceIndicatorChange,
   displays,
   selectedDisplay,
   onDisplayChange
@@ -93,6 +97,23 @@ export function SubtitleSettings({
               <option value="top">Top</option>
             </select>
           </div>
+          <label style={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: '8px',
+            marginTop: '4px',
+            fontSize: '13px',
+            color: '#94a3b8',
+            cursor: 'pointer'
+          }}>
+            <input
+              type="checkbox"
+              checked={showConfidenceIndicator}
+              onChange={(e) => onShowConfidenceIndicatorChange(e.target.checked)}
+              aria-label="Show confidence indicator"
+            />
+            <span>Show confidence indicator</span>
+          </label>
         </div>
       </Section>
 

--- a/src/renderer/hooks/useSettingsState.ts
+++ b/src/renderer/hooks/useSettingsState.ts
@@ -75,6 +75,8 @@ export interface SettingsState {
   setSubtitleBgOpacity: (v: number) => void
   subtitlePosition: SubtitlePositionType
   setSubtitlePosition: (v: SubtitlePositionType) => void
+  showConfidenceIndicator: boolean
+  setShowConfidenceIndicator: (v: boolean) => void
 
   // SLM options
   slmKvCacheQuant: boolean
@@ -275,6 +277,7 @@ export function useSettingsState(): SettingsState {
     subtitleTranslatedColor: subtitle.subtitleTranslatedColor, setSubtitleTranslatedColor: subtitle.setSubtitleTranslatedColor,
     subtitleBgOpacity: subtitle.subtitleBgOpacity, setSubtitleBgOpacity: subtitle.setSubtitleBgOpacity,
     subtitlePosition: subtitle.subtitlePosition, setSubtitlePosition: subtitle.setSubtitlePosition,
+    showConfidenceIndicator: subtitle.showConfidenceIndicator, setShowConfidenceIndicator: subtitle.setShowConfidenceIndicator,
     pushSubtitleSettings: subtitle.pushSubtitleSettings,
 
     // Language

--- a/src/renderer/hooks/useSubtitleSettings.ts
+++ b/src/renderer/hooks/useSubtitleSettings.ts
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react'
-import { num, rec, str } from './settingsCastUtils'
+import { bool, num, rec, str } from './settingsCastUtils'
 import type { SubtitlePositionType } from '../components/settings/shared'
 
 export interface SubtitleSettingsState {
@@ -13,6 +13,8 @@ export interface SubtitleSettingsState {
   setSubtitleBgOpacity: (v: number) => void
   subtitlePosition: SubtitlePositionType
   setSubtitlePosition: (v: SubtitlePositionType) => void
+  showConfidenceIndicator: boolean
+  setShowConfidenceIndicator: (v: boolean) => void
   pushSubtitleSettings: (overrides?: Record<string, unknown>) => void
 }
 
@@ -22,6 +24,7 @@ export function useSubtitleSettings(): SubtitleSettingsState {
   const [subtitleTranslatedColor, setSubtitleTranslatedColor] = useState('#7dd3fc')
   const [subtitleBgOpacity, setSubtitleBgOpacity] = useState(78)
   const [subtitlePosition, setSubtitlePosition] = useState<SubtitlePositionType>('bottom')
+  const [showConfidenceIndicator, setShowConfidenceIndicator] = useState(true)
 
   // Load subtitle settings on mount
   useEffect(() => {
@@ -33,6 +36,9 @@ export function useSubtitleSettings(): SubtitleSettingsState {
         if (sub.translatedTextColor) setSubtitleTranslatedColor(str(sub.translatedTextColor, '#7dd3fc'))
         if (sub.backgroundOpacity !== undefined) setSubtitleBgOpacity(num(sub.backgroundOpacity, 78))
         if (sub.position) setSubtitlePosition(str(sub.position, 'bottom') as SubtitlePositionType)
+      }
+      if (s.showConfidenceIndicator !== undefined) {
+        setShowConfidenceIndicator(bool(s.showConfidenceIndicator, true))
       }
     })
   }, [])
@@ -55,6 +61,7 @@ export function useSubtitleSettings(): SubtitleSettingsState {
     subtitleTranslatedColor, setSubtitleTranslatedColor,
     subtitleBgOpacity, setSubtitleBgOpacity,
     subtitlePosition, setSubtitlePosition,
+    showConfidenceIndicator, setShowConfidenceIndicator,
     pushSubtitleSettings
   }
 }


### PR DESCRIPTION
## Description
Style subtitle text based on STT confidence scores to help users distinguish reliable from uncertain transcriptions.

- High confidence (≥0.9): normal display
- Medium confidence (0.5-0.9): slightly dimmed (opacity 0.8)
- Low confidence (<0.5): dimmed (opacity 0.5) + italic

Toggleable via "Show confidence indicator" setting (enabled by default).

Closes #504