### PR TITLE
501 Add system audio capture via electron-audio-loopback

### DIFF
--- a/electron.vite.config.ts
+++ b/electron.vite.config.ts
@@ -41,7 +41,7 @@ export default defineConfig({
         }
       },
       rollupOptions: {
-        external: ['node-llama-cpp']
+        external: ['node-llama-cpp', 'electron-audio-loopback']
       }
     }
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@kutalia/whisper-node-addon": "^1.1.0",
         "@ricky0123/vad-web": "^0.0.30",
         "deepfilternet3-noise-filter": "^1.2.1",
+        "electron-audio-loopback": "^1.0.6",
         "electron-store": "^10.0.0",
         "electron-updater": "^6.3.0",
         "node-llama-cpp": "^3.0.0",
@@ -5898,6 +5899,15 @@
       },
       "engines": {
         "node": ">= 12.20.55"
+      }
+    },
+    "node_modules/electron-audio-loopback": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/electron-audio-loopback/-/electron-audio-loopback-1.0.6.tgz",
+      "integrity": "sha512-QW0ogDqMpWHDAQHmQyssJ+Yh4qR3kWCP3Q4H9WuIXKwVlgkqOYGyt0v/JzbK3tBNTwfqbuHZy86kwCCajxqAdg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "electron": ">=31.0.1"
       }
     },
     "node_modules/electron-builder": {

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "@kutalia/whisper-node-addon": "^1.1.0",
     "@ricky0123/vad-web": "^0.0.30",
     "deepfilternet3-noise-filter": "^1.2.1",
+    "electron-audio-loopback": "^1.0.6",
     "electron-store": "^10.0.0",
     "electron-updater": "^6.3.0",
     "node-llama-cpp": "^3.0.0",

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1,4 +1,5 @@
 import { app } from 'electron'
+import { initMain as initAudioLoopback } from 'electron-audio-loopback'
 import { TranslationPipeline } from '../pipeline/TranslationPipeline'
 import { WhisperLocalEngine } from '../engines/stt/WhisperLocalEngine'
 import { MlxWhisperEngine } from '../engines/stt/MlxWhisperEngine'
@@ -166,6 +167,10 @@ async function initPipeline(): Promise<void> {
 registerAudioHandlers(ctx)
 registerIpcHandlers(ctx)
 registerUpdateHandlers(ctx)
+
+// --- Initialize electron-audio-loopback before app is ready ---
+// Must be called before app.whenReady() per package documentation
+initAudioLoopback()
 
 // --- App Lifecycle ---
 

--- a/src/main/store.ts
+++ b/src/main/store.ts
@@ -73,6 +73,8 @@ export interface AppSettings {
   streamingIntervalMs: number
   /** Show confidence-based styling on subtitle text (opacity/italic for low-confidence) */
   showConfidenceIndicator: boolean
+  /** Audio source: microphone only, system audio (loopback), or both mixed */
+  audioSource: 'microphone' | 'system' | 'both'
 }
 
 export const store = new Store<AppSettings>({
@@ -111,6 +113,7 @@ export const store = new Store<AppSettings>({
     wsAudioPort: DEFAULT_WS_PORT,
     noiseSuppressionEnabled: false,
     streamingIntervalMs: 1000,
-    showConfidenceIndicator: true
+    showConfidenceIndicator: true,
+    audioSource: 'microphone'
   }
 })

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -41,6 +41,9 @@ export interface ElectronAPI {
   wsAudioStop: () => Promise<void>
   wsAudioGetStatus: () => Promise<{ running: boolean; connected: boolean; port: number | null }>
   onWsAudioStatus: (callback: (status: { running: boolean; connected: boolean; port: number | null }) => void) => (() => void)
+  // System audio loopback (#501)
+  enableLoopbackAudio: () => Promise<void>
+  disableLoopbackAudio: () => Promise<void>
   // Auto-update (#314)
   updateCheck: () => Promise<{ success?: boolean; error?: string }>
   updateDownload: () => Promise<{ success?: boolean; error?: string }>

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -111,6 +111,10 @@ contextBridge.exposeInMainWorld('api', {
     return () => ipcRenderer.off('ws-audio-status', handler)
   },
 
+  // System audio loopback (#501)
+  enableLoopbackAudio: () => ipcRenderer.invoke('enable-loopback-audio'),
+  disableLoopbackAudio: () => ipcRenderer.invoke('disable-loopback-audio'),
+
   // Auto-update (#314)
   updateCheck: () => ipcRenderer.invoke('update-check'),
   updateDownload: () => ipcRenderer.invoke('update-download'),

--- a/src/renderer/components/SettingsPanel.tsx
+++ b/src/renderer/components/SettingsPanel.tsx
@@ -29,12 +29,13 @@ function SettingsPanel(): React.JSX.Element {
         />
       )}
 
-      {/* Microphone Selection — always visible */}
+      {/* Audio Input — always visible (#501: supports mic, system, or both) */}
       <AudioSettings
         audio={s.audio}
         disabled={disabled}
         noiseSuppressionEnabled={s.noiseSuppression.enabled}
         onNoiseSuppressionChange={s.noiseSuppression.setEnabled}
+        platform={s.platform}
       />
 
       {/* Current config summary — always visible */}

--- a/src/renderer/components/settings/AudioSettings.tsx
+++ b/src/renderer/components/settings/AudioSettings.tsx
@@ -1,7 +1,14 @@
 import React from 'react'
 import { Section } from './Section'
 import { selectStyle } from './shared'
-import type { UseAudioCaptureReturn } from '../../hooks/useAudioCapture'
+import type { UseAudioCaptureReturn, AudioSource } from '../../hooks/useAudioCapture'
+
+/** Audio source display labels */
+const AUDIO_SOURCE_OPTIONS: Array<{ value: AudioSource; label: string; description: string }> = [
+  { value: 'microphone', label: 'Microphone', description: 'Capture from microphone only' },
+  { value: 'system', label: 'System Audio', description: 'Capture system audio (Zoom, YouTube, etc.)' },
+  { value: 'both', label: 'Microphone + System', description: 'Mix microphone and system audio' }
+]
 
 interface AudioSettingsProps {
   audio: UseAudioCaptureReturn
@@ -9,30 +16,60 @@ interface AudioSettingsProps {
   /** #313: Noise suppression enabled state */
   noiseSuppressionEnabled: boolean
   onNoiseSuppressionChange: (enabled: boolean) => void
+  /** macOS requires Screen Recording permission for system audio (#501) */
+  platform: string
 }
 
-export function AudioSettings({ audio, disabled, noiseSuppressionEnabled, onNoiseSuppressionChange }: AudioSettingsProps): React.JSX.Element {
+export function AudioSettings({ audio, disabled, noiseSuppressionEnabled, onNoiseSuppressionChange, platform }: AudioSettingsProps): React.JSX.Element {
+  const showMicSelector = audio.audioSource !== 'system'
+
   return (
-    <Section label="Microphone">
+    <Section label="Audio Input">
+      {/* #501: Audio source selector */}
       <select
-        value={audio.selectedDevice}
-        onChange={(e) => audio.setSelectedDevice(e.target.value)}
-        style={selectStyle}
+        value={audio.audioSource}
+        onChange={(e) => audio.setAudioSource(e.target.value as AudioSource)}
+        style={{ ...selectStyle, marginBottom: '8px' }}
         disabled={disabled}
-        aria-label="Microphone device"
+        aria-label="Audio source"
       >
-        {audio.devices.length === 0 ? (
-          <option value="" disabled>
-            No audio devices found
+        {AUDIO_SOURCE_OPTIONS.map((opt) => (
+          <option key={opt.value} value={opt.value}>
+            {opt.label}
           </option>
-        ) : (
-          audio.devices.map((d) => (
-            <option key={d.deviceId} value={d.deviceId}>
-              {d.label}
-            </option>
-          ))
-        )}
+        ))}
       </select>
+      {/* Description for selected audio source */}
+      <div style={{ fontSize: '11px', color: '#64748b', marginBottom: '8px' }}>
+        {AUDIO_SOURCE_OPTIONS.find((o) => o.value === audio.audioSource)?.description}
+        {audio.audioSource !== 'microphone' && platform === 'darwin' && (
+          <span style={{ color: '#f59e0b' }}>
+            {' '}— Requires Screen Recording permission
+          </span>
+        )}
+      </div>
+      {/* Microphone device selector — hidden when system-only mode */}
+      {showMicSelector && (
+        <select
+          value={audio.selectedDevice}
+          onChange={(e) => audio.setSelectedDevice(e.target.value)}
+          style={selectStyle}
+          disabled={disabled}
+          aria-label="Microphone device"
+        >
+          {audio.devices.length === 0 ? (
+            <option value="" disabled>
+              No audio devices found
+            </option>
+          ) : (
+            audio.devices.map((d) => (
+              <option key={d.deviceId} value={d.deviceId}>
+                {d.label}
+              </option>
+            ))
+          )}
+        </select>
+      )}
       {/* Volume meter */}
       <div style={{ marginTop: '6px', height: '4px', background: '#1e293b', borderRadius: '2px' }}>
         <div
@@ -50,25 +87,27 @@ export function AudioSettings({ audio, disabled, noiseSuppressionEnabled, onNois
           }}
         />
       </div>
-      {/* #313: Noise suppression toggle */}
-      <label style={{
-        display: 'flex',
-        alignItems: 'center',
-        gap: '8px',
-        marginTop: '8px',
-        fontSize: '13px',
-        color: '#94a3b8',
-        cursor: disabled ? 'default' : 'pointer'
-      }}>
-        <input
-          type="checkbox"
-          checked={noiseSuppressionEnabled}
-          onChange={(e) => onNoiseSuppressionChange(e.target.checked)}
-          disabled={disabled}
-          aria-label="Enable noise suppression"
-        />
-        <span>Noise suppression (DeepFilterNet3)</span>
-      </label>
+      {/* #313: Noise suppression toggle — only relevant when microphone is active */}
+      {showMicSelector && (
+        <label style={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: '8px',
+          marginTop: '8px',
+          fontSize: '13px',
+          color: '#94a3b8',
+          cursor: disabled ? 'default' : 'pointer'
+        }}>
+          <input
+            type="checkbox"
+            checked={noiseSuppressionEnabled}
+            onChange={(e) => onNoiseSuppressionChange(e.target.checked)}
+            disabled={disabled}
+            aria-label="Enable noise suppression"
+          />
+          <span>Noise suppression (DeepFilterNet3)</span>
+        </label>
+      )}
       {audio.permissionError && (
         <div style={{ marginTop: '6px', fontSize: '12px', color: '#ef4444' }}>
           {audio.permissionError}

--- a/src/renderer/hooks/useAudioCapture.ts
+++ b/src/renderer/hooks/useAudioCapture.ts
@@ -6,10 +6,15 @@ export interface AudioDevice {
   label: string
 }
 
+/** Audio source mode: microphone only, system audio (loopback), or both mixed (#501) */
+export type AudioSource = 'microphone' | 'system' | 'both'
+
 export interface UseAudioCaptureReturn {
   devices: AudioDevice[]
   selectedDevice: string
   setSelectedDevice: (id: string) => void
+  audioSource: AudioSource
+  setAudioSource: (source: AudioSource) => void
   isCapturing: boolean
   volume: number // 0-1 for level meter
   permissionError: string | null // #48: mic permission error
@@ -81,6 +86,7 @@ export function useAudioCapture(noiseSuppression?: NoiseSuppressionProcessor, st
     : DEFAULT_STREAMING_INTERVAL_MS
   const [devices, setDevices] = useState<AudioDevice[]>([])
   const [selectedDevice, setSelectedDevice] = useState<string>('')
+  const [audioSource, setAudioSource] = useState<AudioSource>('microphone')
   const [isCapturing, setIsCapturing] = useState(false)
   const [volume, setVolume] = useState(0)
   const [permissionError, setPermissionError] = useState<string | null>(null) // #48
@@ -90,6 +96,10 @@ export function useAudioCapture(noiseSuppression?: NoiseSuppressionProcessor, st
   const chunkCallbackRef = useRef<((chunk: Float32Array) => void) | null>(null)
   const streamingCallbackRef = useRef<((buffer: Float32Array) => void) | null>(null)
   const speechEndCallbackRef = useRef<((finalBuffer: Float32Array) => void) | null>(null)
+
+  // #501: Track loopback and mixer resources for cleanup
+  const loopbackStreamRef = useRef<MediaStream | null>(null)
+  const audioContextRef = useRef<AudioContext | null>(null)
 
   // Rolling buffer state for streaming (#53: use circular buffer)
   const isSpeakingRef = useRef(false)
@@ -200,16 +210,66 @@ export function useAudioCapture(noiseSuppression?: NoiseSuppressionProcessor, st
     }
   }, [])
 
+  // #501: Acquire system audio loopback stream via electron-audio-loopback
+  const getLoopbackStream = useCallback(async (): Promise<MediaStream> => {
+    // Enable loopback audio in the main process (registers desktopCapturer handler)
+    await window.api.enableLoopbackAudio()
+    try {
+      // getDisplayMedia captures system audio; video track is required by the API
+      // but we discard it immediately to avoid wasting resources
+      const stream = await navigator.mediaDevices.getDisplayMedia({
+        video: true,
+        audio: true
+      })
+      // Remove video tracks — only audio is needed
+      for (const track of stream.getVideoTracks()) {
+        track.stop()
+        stream.removeTrack(track)
+      }
+      return stream
+    } finally {
+      // Disable loopback capture handler after stream is acquired
+      await window.api.disableLoopbackAudio()
+    }
+  }, [])
+
+  // #501: Mix two MediaStreams into one using Web Audio API
+  const mixStreams = useCallback((micStream: MediaStream, loopbackStream: MediaStream): MediaStream => {
+    const ctx = new AudioContext({ sampleRate: 16000 })
+    audioContextRef.current = ctx
+    const dest = ctx.createMediaStreamDestination()
+
+    const micSource = ctx.createMediaStreamSource(micStream)
+    const loopbackSource = ctx.createMediaStreamSource(loopbackStream)
+
+    micSource.connect(dest)
+    loopbackSource.connect(dest)
+
+    return dest.stream
+  }, [])
+
   const start = useCallback(async () => {
     if (isCapturing) return
 
     try {
       const deviceId = selectedDevice
+      const currentAudioSource = audioSource
       const vad = await MicVAD.new({
         getStream: async () => {
           // #313: Request 48 kHz when DeepFilterNet3 is active (it requires 48 kHz);
           // VAD resamples internally to 16 kHz regardless.
           const idealSampleRate = noiseSuppression ? 48000 : 16000
+
+          // #501: Get the appropriate stream based on audio source setting
+          if (currentAudioSource === 'system') {
+            // System audio only — no microphone
+            const loopback = await getLoopbackStream()
+            loopbackStreamRef.current = loopback
+            console.log('[audio-capture] Using system audio loopback')
+            return loopback
+          }
+
+          // Get microphone stream (used for 'microphone' and 'both' modes)
           const rawStream = await navigator.mediaDevices.getUserMedia({
             audio: {
               deviceId: deviceId ? { exact: deviceId } : undefined,
@@ -219,11 +279,22 @@ export function useAudioCapture(noiseSuppression?: NoiseSuppressionProcessor, st
               noiseSuppression: !noiseSuppression // disable browser NS when DeepFilterNet3 is active
             }
           })
+
           // #313: Apply DeepFilterNet3 noise suppression before VAD
-          if (noiseSuppression) {
-            return noiseSuppression.processStream(rawStream)
+          const micStream = noiseSuppression
+            ? await noiseSuppression.processStream(rawStream)
+            : rawStream
+
+          if (currentAudioSource === 'both') {
+            // #501: Mix microphone + system audio loopback
+            const loopback = await getLoopbackStream()
+            loopbackStreamRef.current = loopback
+            console.log('[audio-capture] Using mixed microphone + system audio')
+            return mixStreams(micStream, loopback)
           }
-          return rawStream
+
+          // Microphone only (default)
+          return micStream
         },
         // Override with more sensitive thresholds for real-time translation
         positiveSpeechThreshold: 0.25,
@@ -307,6 +378,15 @@ export function useAudioCapture(noiseSuppression?: NoiseSuppressionProcessor, st
         vadRef.current.destroy()
         vadRef.current = null
       }
+      // #501: Clean up loopback resources on failed start
+      if (loopbackStreamRef.current) {
+        loopbackStreamRef.current.getTracks().forEach((t) => t.stop())
+        loopbackStreamRef.current = null
+      }
+      if (audioContextRef.current) {
+        audioContextRef.current.close().catch(() => {})
+        audioContextRef.current = null
+      }
       isSpeakingRef.current = false
       rollingBufferRef.current = []
       rollingBufferIndexRef.current = 0
@@ -315,13 +395,22 @@ export function useAudioCapture(noiseSuppression?: NoiseSuppressionProcessor, st
       setIsCapturing(false)
       throw err
     }
-  }, [selectedDevice, isCapturing, startStreamingTimer, stopStreamingTimer])
+  }, [selectedDevice, audioSource, isCapturing, startStreamingTimer, stopStreamingTimer, getLoopbackStream, mixStreams])
 
   const stop = useCallback(() => {
     stopStreamingTimer()
     if (vadRef.current) {
       vadRef.current.destroy()
       vadRef.current = null
+    }
+    // #501: Release loopback stream and audio mixer resources
+    if (loopbackStreamRef.current) {
+      loopbackStreamRef.current.getTracks().forEach((t) => t.stop())
+      loopbackStreamRef.current = null
+    }
+    if (audioContextRef.current) {
+      audioContextRef.current.close().catch((err) => console.warn('[audio-capture] AudioContext close error:', err))
+      audioContextRef.current = null
     }
     // #313: Release DeepFilterNet3 resources
     noiseSuppression?.destroy().catch((err) => console.warn('[audio-capture] Noise suppression cleanup error:', err))
@@ -335,7 +424,7 @@ export function useAudioCapture(noiseSuppression?: NoiseSuppressionProcessor, st
     console.log('[audio-capture] VAD stopped')
   }, [stopStreamingTimer, noiseSuppression])
 
-  // #443: Safety net — clear streaming timer and VAD on unmount if stop() was not called
+  // #443: Safety net — clear streaming timer, VAD, and loopback on unmount if stop() was not called
   useEffect(() => {
     return () => {
       if (streamingTimerRef.current) {
@@ -345,6 +434,15 @@ export function useAudioCapture(noiseSuppression?: NoiseSuppressionProcessor, st
       if (vadRef.current) {
         vadRef.current.destroy()
         vadRef.current = null
+      }
+      // #501: Release loopback resources on unmount
+      if (loopbackStreamRef.current) {
+        loopbackStreamRef.current.getTracks().forEach((t) => t.stop())
+        loopbackStreamRef.current = null
+      }
+      if (audioContextRef.current) {
+        audioContextRef.current.close().catch(() => {})
+        audioContextRef.current = null
       }
     }
   }, [])
@@ -368,6 +466,8 @@ export function useAudioCapture(noiseSuppression?: NoiseSuppressionProcessor, st
     devices,
     selectedDevice,
     setSelectedDevice,
+    audioSource,
+    setAudioSource,
     isCapturing,
     volume,
     permissionError,

--- a/src/renderer/hooks/useSessionSettings.ts
+++ b/src/renderer/hooks/useSessionSettings.ts
@@ -88,6 +88,10 @@ export function useSessionSettings(): SessionSettingsState {
       if (s.noiseSuppressionEnabled !== undefined) noiseSuppression.setEnabled(bool(s.noiseSuppressionEnabled, false))
       if (s.selectedMicrophone) audio.setSelectedDevice(typeof s.selectedMicrophone === 'string' ? s.selectedMicrophone : '')
       if (typeof s.streamingIntervalMs === 'number') setStreamingIntervalMs(s.streamingIntervalMs)
+      // #501: Restore audio source preference
+      if (s.audioSource && ['microphone', 'system', 'both'].includes(s.audioSource as string)) {
+        audio.setAudioSource(s.audioSource as 'microphone' | 'system' | 'both')
+      }
     })
 
     // Check for crashed session

--- a/src/renderer/hooks/useSettingsState.ts
+++ b/src/renderer/hooks/useSettingsState.ts
@@ -164,7 +164,8 @@ export function useSettingsState(): SettingsState {
         simulMtWaitK: engine.simulMtWaitK,
         sourceLanguage: language.sourceLanguage,
         targetLanguage: language.targetLanguage,
-        noiseSuppressionEnabled: session.noiseSuppression.enabled
+        noiseSuppressionEnabled: session.noiseSuppression.enabled,
+        audioSource: session.audio.audioSource
       }), 10_000, 'saveSettings')
 
       const resolvedMode = resolveEngineMode(engine.engineMode, apiKeys, engine.gpuInfo)


### PR DESCRIPTION
## Description

Add system audio capture (loopback) so users can translate audio from any app (Zoom, Teams, YouTube) — not just microphone input.

### Changes
- Add `electron-audio-loopback` dependency for cross-platform system audio capture
- Add audio source selector in AudioSettings: **Microphone** / **System Audio** / **Both**
- Initialize `electron-audio-loopback` in main process before `app.whenReady()`
- Expose `enableLoopbackAudio` / `disableLoopbackAudio` IPC via preload
- Route loopback `MediaStream` through existing VAD + STT pipeline
- Mix microphone + system audio via Web Audio API `MediaStreamAudioDestinationNode` in "Both" mode
- Show macOS Screen Recording permission hint when system audio is selected
- Persist `audioSource` setting in electron-store
- Clean up loopback stream, AudioContext, and mixer resources on stop/error/unmount

### Architecture
- `getLoopbackStream()` — enables loopback via IPC, calls `getDisplayMedia`, strips video tracks, disables loopback
- `mixStreams()` — creates AudioContext with two `MediaStreamSource` nodes routed to a `MediaStreamAudioDestinationNode`
- Mic device selector is hidden when audio source is "System Audio" only
- Noise suppression toggle only shown when microphone is active

Closes #501