### PR TITLE
509 Add multi-speaker color coding and draggable subtitle position

### DIFF
--- a/src/main/ipc/display-ipc.ts
+++ b/src/main/ipc/display-ipc.ts
@@ -1,5 +1,6 @@
 import { screen, ipcMain } from 'electron'
 import type { AppContext } from '../app-context'
+import { store } from '../store'
 import { getSubtitleHeight } from '../window-manager'
 import { createLogger } from '../logger'
 
@@ -31,6 +32,54 @@ export function registerDisplayIpc(ctx: AppContext): void {
         height: h
       })
     }
+  })
+
+  // Toggle subtitle drag mode (#509): disable click-through so user can drag
+  ipcMain.handle('toggle-subtitle-drag-mode', (_event, enabled: boolean) => {
+    if (!ctx.subtitleWindow) return
+    if (enabled) {
+      ctx.subtitleWindow.setIgnoreMouseEvents(false)
+    } else {
+      ctx.subtitleWindow.setIgnoreMouseEvents(true, { forward: true })
+    }
+    ctx.subtitleWindow.webContents.send('drag-mode-changed', enabled)
+  })
+
+  // Move subtitle window by pixel delta (#509)
+  ipcMain.on('move-subtitle-by-delta', (_event, dx: number, dy: number) => {
+    if (!ctx.subtitleWindow) return
+    const [x, y] = ctx.subtitleWindow.getPosition()
+    ctx.subtitleWindow.setPosition(x + dx, y + dy)
+  })
+
+  // Save current subtitle window position to electron-store keyed by display ID (#509)
+  ipcMain.handle('save-subtitle-position', () => {
+    if (!ctx.subtitleWindow) return
+    const bounds = ctx.subtitleWindow.getBounds()
+    const display = screen.getDisplayMatching(bounds)
+    const positions = (store.get('subtitlePositions' as never) as Record<string, { x: number; y: number }> | undefined) || {}
+    positions[String(display.id)] = { x: bounds.x, y: bounds.y }
+    store.set('subtitlePositions' as never, positions as never)
+    log.info(`Saved subtitle position for display ${display.id}: (${bounds.x}, ${bounds.y})`)
+  })
+
+  // Reset subtitle position to default for the current display (#509)
+  ipcMain.handle('reset-subtitle-position', () => {
+    if (!ctx.subtitleWindow) return
+    const bounds = ctx.subtitleWindow.getBounds()
+    const display = screen.getDisplayMatching(bounds)
+    const h = getSubtitleHeight(display)
+    ctx.subtitleWindow.setBounds({
+      x: display.bounds.x,
+      y: display.bounds.y + display.bounds.height - h,
+      width: display.bounds.width,
+      height: h
+    })
+    // Remove saved position for this display
+    const positions = (store.get('subtitlePositions' as never) as Record<string, { x: number; y: number }> | undefined) || {}
+    delete positions[String(display.id)]
+    store.set('subtitlePositions' as never, positions as never)
+    log.info(`Reset subtitle position for display ${display.id}`)
   })
 
   // Forward translation result to subtitle window (from renderer)

--- a/src/main/window-manager.ts
+++ b/src/main/window-manager.ts
@@ -48,9 +48,16 @@ export function createSubtitleWindow(ctx: AppContext): void {
   const targetDisplay = savedDisplay || externalDisplay || displays[0]
 
   const subtitleHeight = getSubtitleHeight(targetDisplay)
+
+  // Restore saved position for this display if available (#509)
+  const savedPositions = (store.get('subtitlePositions' as never) as Record<string, { x: number; y: number }> | undefined) || {}
+  const savedPos = savedPositions[String(targetDisplay.id)]
+  const initialX = savedPos?.x ?? targetDisplay.bounds.x
+  const initialY = savedPos?.y ?? (targetDisplay.bounds.y + targetDisplay.bounds.height - subtitleHeight)
+
   ctx.subtitleWindow = new BrowserWindow({
-    x: targetDisplay.bounds.x,
-    y: targetDisplay.bounds.y + targetDisplay.bounds.height - subtitleHeight,
+    x: initialX,
+    y: initialY,
     width: targetDisplay.bounds.width,
     height: subtitleHeight,
     transparent: true,

--- a/src/pipeline/SpeakerTracker.ts
+++ b/src/pipeline/SpeakerTracker.ts
@@ -6,8 +6,24 @@
  */
 
 const SPEAKER_CHANGE_GAP_MS = 2000
-const SPEAKER_COLORS = ['#60a5fa', '#4ade80', '#f472b6', '#facc15', '#a78bfa', '#fb923c']
-const SPEAKER_NAMES = ['A', 'B', 'C', 'D', 'E', 'F']
+
+/** Default 8-color palette for speaker identification */
+export const SPEAKER_COLORS = [
+  '#60a5fa', '#4ade80', '#f472b6', '#facc15',
+  '#a78bfa', '#fb923c', '#2dd4bf', '#f87171'
+]
+export const SPEAKER_NAMES = ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H']
+
+/**
+ * Map a speakerId string (e.g. "Speaker A") to its palette color.
+ * Returns undefined if the speakerId does not match the expected format.
+ */
+export function getSpeakerColor(speakerId: string): string | undefined {
+  const match = speakerId.match(/^Speaker ([A-H])$/)
+  if (!match) return undefined
+  const idx = match[1]!.charCodeAt(0) - 'A'.charCodeAt(0)
+  return SPEAKER_COLORS[idx]
+}
 
 export class SpeakerTracker {
   private currentSpeaker = 0

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -115,6 +115,19 @@ contextBridge.exposeInMainWorld('api', {
   enableLoopbackAudio: () => ipcRenderer.invoke('enable-loopback-audio'),
   disableLoopbackAudio: () => ipcRenderer.invoke('disable-loopback-audio'),
 
+  // Subtitle drag mode (#509)
+  toggleSubtitleDragMode: (enabled: boolean) =>
+    ipcRenderer.invoke('toggle-subtitle-drag-mode', enabled),
+  moveSubtitleByDelta: (dx: number, dy: number) =>
+    ipcRenderer.send('move-subtitle-by-delta', dx, dy),
+  saveSubtitlePosition: () => ipcRenderer.invoke('save-subtitle-position'),
+  resetSubtitlePosition: () => ipcRenderer.invoke('reset-subtitle-position'),
+  onDragModeChanged: (callback: (enabled: boolean) => void) => {
+    const handler = (_event: Electron.IpcRendererEvent, enabled: boolean): void => callback(enabled)
+    ipcRenderer.on('drag-mode-changed', handler)
+    return () => ipcRenderer.off('drag-mode-changed', handler)
+  },
+
   // Auto-update (#314)
   updateCheck: () => ipcRenderer.invoke('update-check'),
   updateDownload: () => ipcRenderer.invoke('update-download'),

--- a/src/renderer/components/SubtitleOverlay.tsx
+++ b/src/renderer/components/SubtitleOverlay.tsx
@@ -1,4 +1,18 @@
-import React, { useEffect, useRef, useState } from 'react'
+import React, { useCallback, useEffect, useRef, useState } from 'react'
+
+/** Default 8-color palette for speaker identification — must match SpeakerTracker.ts */
+const SPEAKER_COLORS = [
+  '#60a5fa', '#4ade80', '#f472b6', '#facc15',
+  '#a78bfa', '#fb923c', '#2dd4bf', '#f87171'
+]
+
+/** Map a speakerId string (e.g. "Speaker A") to its palette color */
+function getSpeakerColor(speakerId: string): string | undefined {
+  const match = speakerId.match(/^Speaker ([A-H])$/)
+  if (!match) return undefined
+  const idx = match[1]!.charCodeAt(0) - 'A'.charCodeAt(0)
+  return SPEAKER_COLORS[idx]
+}
 
 interface SubtitleLine {
   id: number
@@ -52,8 +66,44 @@ function getConfidenceStyle(
 function SubtitleOverlay(): React.JSX.Element {
   const [lines, setLines] = useState<SubtitleLine[]>([])
   const [config, setConfig] = useState<SubtitleConfig>(DEFAULT_CONFIG)
+  const [isDragMode, setIsDragMode] = useState(false)
   const fadeTimerRef = useRef<ReturnType<typeof setInterval> | null>(null)
   const nextLineIdRef = useRef(1)
+  const isDraggingRef = useRef(false)
+  const dragStartRef = useRef({ screenX: 0, screenY: 0 })
+
+  // Drag handlers — move the entire subtitle window by delta
+  const handleDragMouseDown = useCallback((e: React.MouseEvent) => {
+    isDraggingRef.current = true
+    dragStartRef.current = { screenX: e.screenX, screenY: e.screenY }
+    e.preventDefault()
+  }, [])
+
+  useEffect(() => {
+    if (!isDragMode) return
+
+    const handleMouseMove = (e: MouseEvent): void => {
+      if (!isDraggingRef.current) return
+      const dx = e.screenX - dragStartRef.current.screenX
+      const dy = e.screenY - dragStartRef.current.screenY
+      dragStartRef.current = { screenX: e.screenX, screenY: e.screenY }
+      window.api.moveSubtitleByDelta?.(dx, dy)
+    }
+
+    const handleMouseUp = (): void => {
+      if (isDraggingRef.current) {
+        isDraggingRef.current = false
+        window.api.saveSubtitlePosition?.()
+      }
+    }
+
+    window.addEventListener('mousemove', handleMouseMove)
+    window.addEventListener('mouseup', handleMouseUp)
+    return () => {
+      window.removeEventListener('mousemove', handleMouseMove)
+      window.removeEventListener('mouseup', handleMouseUp)
+    }
+  }, [isDragMode])
 
   // Load initial settings and listen for changes
   useEffect(() => {
@@ -69,7 +119,16 @@ function SubtitleOverlay(): React.JSX.Element {
     const unsubscribe = window.api.onSubtitleSettingsChanged((settings) => {
       setConfig((prev) => ({ ...prev, ...settings as Partial<SubtitleConfig> }))
     })
-    return () => unsubscribe?.()
+
+    // Listen for drag mode toggle from main process
+    const unsubDrag = window.api.onDragModeChanged?.((enabled: boolean) => {
+      setIsDragMode(enabled)
+    })
+
+    return () => {
+      unsubscribe?.()
+      unsubDrag?.()
+    }
   }, [])
 
   useEffect(() => {
@@ -164,6 +223,36 @@ function SubtitleOverlay(): React.JSX.Element {
         userSelect: 'none'
       }}
     >
+      {/* Drag handle overlay — visible only in drag mode */}
+      {isDragMode && (
+        <div
+          onMouseDown={handleDragMouseDown}
+          style={{
+            position: 'fixed',
+            inset: 0,
+            cursor: 'move',
+            zIndex: 9999,
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            background: 'rgba(59, 130, 246, 0.08)',
+            border: '2px dashed rgba(96, 165, 250, 0.5)',
+            borderRadius: '0.625rem'
+          }}
+        >
+          <span style={{
+            color: '#60a5fa',
+            fontSize: '14px',
+            fontWeight: 600,
+            background: 'rgba(0,0,0,0.6)',
+            padding: '6px 16px',
+            borderRadius: '6px',
+            pointerEvents: 'none'
+          }}>
+            Drag to reposition
+          </span>
+        </div>
+      )}
       {lines.map((line) => {
         const confStyle = getConfidenceStyle(line.confidence, config.showConfidenceIndicator)
         return (
@@ -185,9 +274,8 @@ function SubtitleOverlay(): React.JSX.Element {
                   ? '#94a3b8'
                   : line.isDraft
                     ? '#f59e0b'
-                    : line.sourceLanguage === 'ja'
-                      ? '#4ade80'
-                      : '#60a5fa'
+                    : (line.speakerId && getSpeakerColor(line.speakerId))
+                      || (line.sourceLanguage === 'ja' ? '#4ade80' : '#60a5fa')
               }`
             }}
           >
@@ -203,7 +291,18 @@ function SubtitleOverlay(): React.JSX.Element {
               }}
             >
               {line.speakerId && (
-                <span style={{ fontSize: '0.7em', opacity: 0.7, marginRight: '0.5rem', maxWidth: '7.5rem', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', display: 'inline-block', verticalAlign: 'middle' }}>
+                <span style={{
+                  fontSize: '0.7em',
+                  opacity: 0.85,
+                  marginRight: '0.5rem',
+                  maxWidth: '7.5rem',
+                  overflow: 'hidden',
+                  textOverflow: 'ellipsis',
+                  whiteSpace: 'nowrap',
+                  display: 'inline-block',
+                  verticalAlign: 'middle',
+                  color: getSpeakerColor(line.speakerId) || 'inherit'
+                }}>
                   [{line.speakerId}]
                 </span>
               )}

--- a/src/renderer/components/settings/SubtitleSettings.tsx
+++ b/src/renderer/components/settings/SubtitleSettings.tsx
@@ -1,7 +1,14 @@
-import React from 'react'
+import React, { useCallback, useState } from 'react'
 import { Section } from './Section'
-import { colorInputStyle, selectStyle, sliderLabelStyle } from './shared'
+import { buttonStyle, colorInputStyle, selectStyle, sliderLabelStyle } from './shared'
 import type { DisplayInfo, SubtitlePositionType } from './shared'
+
+/** Speaker color palette — must match SpeakerTracker.ts */
+const SPEAKER_COLORS = [
+  '#60a5fa', '#4ade80', '#f472b6', '#facc15',
+  '#a78bfa', '#fb923c', '#2dd4bf', '#f87171'
+]
+const SPEAKER_NAMES = ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H']
 
 interface SubtitleSettingsProps {
   fontSize: number
@@ -38,6 +45,23 @@ export function SubtitleSettings({
   selectedDisplay,
   onDisplayChange
 }: SubtitleSettingsProps): React.JSX.Element {
+  const [isDragMode, setIsDragMode] = useState(false)
+
+  const handleToggleDragMode = useCallback(() => {
+    const next = !isDragMode
+    setIsDragMode(next)
+    window.api.toggleSubtitleDragMode?.(next)
+  }, [isDragMode])
+
+  const handleResetPosition = useCallback(() => {
+    window.api.resetSubtitlePosition?.()
+    // Also exit drag mode if active
+    if (isDragMode) {
+      setIsDragMode(false)
+      window.api.toggleSubtitleDragMode?.(false)
+    }
+  }, [isDragMode])
+
   return (
     <>
       <Section label="Subtitle Appearance">
@@ -117,19 +141,93 @@ export function SubtitleSettings({
         </div>
       </Section>
 
+      {/* Speaker color palette preview (#509) */}
+      <Section label="Speaker Colors">
+        <div style={{ display: 'flex', flexDirection: 'column', gap: '6px' }}>
+          <div style={sliderLabelStyle}>
+            Each speaker is automatically assigned a color
+          </div>
+          <div style={{ display: 'flex', gap: '8px', flexWrap: 'wrap' }}>
+            {SPEAKER_COLORS.map((color, i) => (
+              <div
+                key={color}
+                style={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  gap: '4px'
+                }}
+              >
+                <div
+                  style={{
+                    width: '16px',
+                    height: '16px',
+                    borderRadius: '4px',
+                    background: color,
+                    border: '1px solid rgba(255,255,255,0.15)'
+                  }}
+                />
+                <span style={{ fontSize: '11px', color: '#94a3b8' }}>
+                  {SPEAKER_NAMES[i]}
+                </span>
+              </div>
+            ))}
+          </div>
+        </div>
+      </Section>
+
       <Section label="Subtitle Display">
-        <select
-          value={selectedDisplay}
-          onChange={(e) => onDisplayChange(Number(e.target.value))}
-          style={selectStyle}
-          aria-label="Subtitle display"
-        >
-          {displays.map((d) => (
-            <option key={d.id} value={d.id}>
-              {d.label}
-            </option>
-          ))}
-        </select>
+        <div style={{ display: 'flex', flexDirection: 'column', gap: '10px' }}>
+          <select
+            value={selectedDisplay}
+            onChange={(e) => onDisplayChange(Number(e.target.value))}
+            style={selectStyle}
+            aria-label="Subtitle display"
+          >
+            {displays.map((d) => (
+              <option key={d.id} value={d.id}>
+                {d.label}
+              </option>
+            ))}
+          </select>
+
+          {/* Drag mode toggle and reset position (#509) */}
+          <div style={{ display: 'flex', gap: '8px' }}>
+            <button
+              onClick={handleToggleDragMode}
+              style={{
+                ...buttonStyle,
+                flex: 1,
+                fontSize: '13px',
+                padding: '8px 12px',
+                marginTop: 0,
+                background: isDragMode ? '#dc2626' : '#334155',
+                fontWeight: 600
+              }}
+            >
+              {isDragMode ? 'Done Repositioning' : 'Reposition Subtitles'}
+            </button>
+            <button
+              onClick={handleResetPosition}
+              style={{
+                ...buttonStyle,
+                flex: 0,
+                whiteSpace: 'nowrap',
+                fontSize: '13px',
+                padding: '8px 12px',
+                marginTop: 0,
+                background: '#334155',
+                fontWeight: 500
+              }}
+            >
+              Reset
+            </button>
+          </div>
+          {isDragMode && (
+            <div style={{ fontSize: '11px', color: '#f59e0b' }}>
+              Drag the subtitle overlay to your preferred position, then click "Done Repositioning"
+            </div>
+          )}
+        </div>
       </Section>
     </>
   )


### PR DESCRIPTION
## Summary
- Expand speaker color palette from 6 to 8 colors and use per-speaker colors for subtitle border-left and speaker labels (previously language-based only)
- Add draggable subtitle overlay: "Reposition Subtitles" button in settings toggles click-through off, shows drag handle overlay, persists position per display
- Add speaker color palette preview and "Reset Position" button in SubtitleSettings

## Changes
- `SpeakerTracker.ts`: Expand to 8 colors/names (A-H), export `getSpeakerColor()` helper
- `SubtitleOverlay.tsx`: Map `speakerId` to speaker color for border and label; add drag mode with mouse delta IPC
- `SubtitleSettings.tsx`: Add speaker color palette preview, drag mode toggle, and reset position button
- `display-ipc.ts`: Add IPC handlers for drag mode toggle, delta movement, position save/reset
- `window-manager.ts`: Restore saved subtitle position per display on launch
- `preload/index.ts`: Expose new IPC channels for drag mode, delta movement, position persistence

## Test plan
- [ ] Verify speaker labels and border colors match the 8-color palette when multiple speakers are detected
- [ ] Click "Reposition Subtitles" in settings, drag the subtitle overlay, verify it moves
- [ ] Click "Done Repositioning" and verify click-through is re-enabled
- [ ] Restart the app and verify saved position is restored
- [ ] Click "Reset" and verify subtitle returns to default bottom position
- [ ] Verify speaker color palette preview shows all 8 colors in SubtitleSettings

Closes #509