### PR TITLE
512 Add PLaMo-2-Translate 10B as quality translation mode

### DIFF
--- a/src/engines/model-downloader.ts
+++ b/src/engines/model-downloader.ts
@@ -180,6 +180,39 @@ export function getLFM2Variants(): Record<string, GGUFVariant> {
   return LFM2_VARIANTS
 }
 
+/** PLaMo-2-Translate 10B GGUF variants (mmnga quantizations) */
+export const PLAMO_VARIANTS: Record<string, GGUFVariant> = {
+  'Q4_K_S': {
+    filename: 'plamo-2-translate-Q4_K_S.gguf',
+    url: 'https://huggingface.co/mmnga/plamo-2-translate-gguf/resolve/main/plamo-2-translate-Q4_K_S.gguf',
+    sizeMB: 5510,
+    label: 'Q4_K_S (Recommended, ~5.5GB)'
+  },
+  'Q3_K_M': {
+    filename: 'plamo-2-translate-Q3_K_M.gguf',
+    url: 'https://huggingface.co/mmnga/plamo-2-translate-gguf/resolve/main/plamo-2-translate-Q3_K_M.gguf',
+    sizeMB: 4640,
+    label: 'Q3_K_M (Smallest, ~4.6GB)'
+  },
+  'Q6_K': {
+    filename: 'plamo-2-translate-Q6_K.gguf',
+    url: 'https://huggingface.co/mmnga/plamo-2-translate-gguf/resolve/main/plamo-2-translate-Q6_K.gguf',
+    sizeMB: 7820,
+    label: 'Q6_K (Balanced, ~7.8GB)'
+  },
+  'Q8_0': {
+    filename: 'plamo-2-translate-Q8_0.gguf',
+    url: 'https://huggingface.co/mmnga/plamo-2-translate-gguf/resolve/main/plamo-2-translate-Q8_0.gguf',
+    sizeMB: 10100,
+    label: 'Q8_0 (Best quality, ~10.1GB)'
+  }
+}
+
+/** Get PLaMo-2-Translate GGUF variants */
+export function getPLaMoVariants(): Record<string, GGUFVariant> {
+  return PLAMO_VARIANTS
+}
+
 export const GGUF_VARIANTS_4B: Record<string, GGUFVariant> = {
   'Q4_K_M': {
     filename: 'translategemma-4b-it.Q4_K_M.gguf',

--- a/src/engines/translator/PLaMoTranslator.ts
+++ b/src/engines/translator/PLaMoTranslator.ts
@@ -1,0 +1,32 @@
+import { getPLaMoVariants } from '../model-downloader'
+import { LlamaWorkerTranslator } from './LlamaWorkerTranslator'
+import type { GGUFVariantConfig } from './LlamaWorkerTranslator'
+
+/**
+ * PLaMo-2-Translate 10B translator via node-llama-cpp UtilityProcess.
+ * Uses the shared worker pool instead of spawning its own process.
+ * 10B parameter PFN model (~5.5GB Q4_K_S) for high-quality JA↔EN translation.
+ * Adopted by Japan Government AI Project "Gennai".
+ * License: PLaMo Community License.
+ */
+export class PLaMoTranslator extends LlamaWorkerTranslator {
+  readonly id = 'plamo'
+  readonly name = 'PLaMo-2 10B (Quality)'
+
+  constructor(options?: { onProgress?: (message: string) => void; variant?: string; kvCacheQuant?: boolean }) {
+    // PLaMo GGUF doesn't have Q4_K_M — default to Q4_K_S
+    super({ ...options, variant: options?.variant ?? 'Q4_K_S' })
+  }
+
+  protected getVariants(): Record<string, GGUFVariantConfig> {
+    return getPLaMoVariants()
+  }
+
+  protected getModelSizeLabel(): string {
+    return 'PLaMo-2-Translate 10B'
+  }
+
+  protected getExtraInitOptions() {
+    return { modelType: 'plamo' as const }
+  }
+}

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -11,6 +11,7 @@ import { SLMTranslator } from '../engines/translator/SLMTranslator'
 import { HunyuanMTTranslator } from '../engines/translator/HunyuanMTTranslator'
 import { HunyuanMT15Translator } from '../engines/translator/HunyuanMT15Translator'
 import { LFM2Translator } from '../engines/translator/LFM2Translator'
+import { PLaMoTranslator } from '../engines/translator/PLaMoTranslator'
 import { ANETranslator } from '../engines/translator/ANETranslator'
 import { HybridTranslator } from '../engines/translator/HybridTranslator'
 import { discoverPlugins, loadPluginEngine } from '../engines/plugin-loader'
@@ -87,6 +88,11 @@ async function initPipeline(): Promise<void> {
   }))
   // LFM2-350M ultra-fast JA↔EN translator — 350M params, ~230MB
   ctx.pipeline.registerTranslator('lfm2', () => new LFM2Translator({
+    onProgress: (msg) => ctx.mainWindow?.webContents.send('status-update', msg),
+    kvCacheQuant: store.get('slmKvCacheQuant')
+  }))
+  // PLaMo-2-Translate 10B quality translator — Japan Gov "Gennai" adopted, ~5.5GB
+  ctx.pipeline.registerTranslator('plamo', () => new PLaMoTranslator({
     onProgress: (msg) => ctx.mainWindow?.webContents.send('status-update', msg),
     kvCacheQuant: store.get('slmKvCacheQuant')
   }))

--- a/src/main/slm-worker.ts
+++ b/src/main/slm-worker.ts
@@ -1,10 +1,10 @@
 /**
  * UtilityProcess worker for SLM inference via node-llama-cpp.
- * Supports TranslateGemma and Hunyuan-MT models.
+ * Supports TranslateGemma, Hunyuan-MT, LFM2, and PLaMo-2 models.
  * Runs in a separate process to avoid blocking the main process.
  *
  * IPC protocol:
- *   Main → Worker: { type: 'init', modelPath: string, kvCacheQuant?: boolean, modelType?: 'translategemma' | 'hunyuan-mt', draftModelPath?: string }
+ *   Main → Worker: { type: 'init', modelPath: string, kvCacheQuant?: boolean, modelType?: ModelType, draftModelPath?: string }
  *   Main → Worker: { type: 'translate', id: string, text: string, from: string, to: string }
  *   Main → Worker: { type: 'translate-incremental', id: string, text: string, previousOutput: string, from: string, to: string }
  *   Main → Worker: { type: 'summarize', id: string, transcript: string }
@@ -21,7 +21,7 @@ import { createLogger } from './logger'
 
 const log = createLogger('slm-worker')
 
-type ModelType = 'translategemma' | 'hunyuan-mt' | 'hunyuan-mt-15' | 'lfm2'
+type ModelType = 'translategemma' | 'hunyuan-mt' | 'hunyuan-mt-15' | 'lfm2' | 'plamo'
 
 /** Messages sent from main process to this worker */
 type WorkerInboundMessage =
@@ -161,6 +161,13 @@ function buildTranslationPrompt(
   const toLang = LANG_NAMES_EN[to] ?? to
   const contextSection = buildContextPrompt(translateContext)
 
+  if (activeModelType === 'plamo') {
+    // PLaMo-2-Translate uses structured tags for translation.
+    // The prompt is passed directly as user content; node-llama-cpp
+    // applies the chat template which includes the <|plamo:op|> tags.
+    return `<|plamo:op|>dataset\ntranslation\n<|plamo:op|>input lang=${fromLang}\n${contextSection}${text}\n<|plamo:op|>output lang=${toLang}\n`
+  }
+
   if (activeModelType === 'lfm2') {
     // LFM2 uses a simple system prompt via chat template;
     // the system message is set by node-llama-cpp's chat session,
@@ -200,6 +207,10 @@ function getLFM2SystemPrompt(to: string): string {
 
 /** Get inference parameters based on model type */
 function getInferenceParams(): { temperature: number; maxTokens: number; topK?: number; topP?: number; minP?: number; repeatPenalty?: { penalty: number } } {
+  if (activeModelType === 'plamo') {
+    // PLaMo-2-Translate recommends greedy decoding (temperature=0) for translation
+    return { temperature: 0, maxTokens: 1024 }
+  }
   if (activeModelType === 'lfm2') {
     return { temperature: 0.5, maxTokens: 512, topP: 1.0, minP: 0.1, repeatPenalty: { penalty: 1.05 } }
   }

--- a/src/renderer/components/settings/TranslatorSettings.tsx
+++ b/src/renderer/components/settings/TranslatorSettings.tsx
@@ -117,6 +117,19 @@ export function TranslatorSettings({
           <input
             type="radio"
             name="engine"
+            checked={engineMode === 'offline-plamo'}
+            onChange={() => onEngineModeChange('offline-plamo')}
+            disabled={disabled}
+          />
+          <div>
+            <div style={{ fontWeight: 500 }}>PLaMo-2 10B (Quality, JA↔EN)</div>
+            <div style={{ fontSize: '12px', color: '#94a3b8' }}>Japan Gov "Gennai" adopted, style-aware, ~5.5GB</div>
+          </div>
+        </label>
+        <label style={radioLabelStyle}>
+          <input
+            type="radio"
+            name="engine"
             checked={engineMode === 'offline-hunyuan-mt'}
             onChange={() => onEngineModeChange('offline-hunyuan-mt')}
             disabled={disabled}

--- a/src/renderer/components/settings/shared.ts
+++ b/src/renderer/components/settings/shared.ts
@@ -25,7 +25,7 @@ export const LANGUAGE_LABELS: Record<Language, string> = {
 
 export const ALL_LANGUAGES = Object.keys(LANGUAGE_LABELS) as Language[]
 
-export type EngineMode = 'auto' | 'rotation' | 'online' | 'online-deepl' | 'online-gemini' | 'offline-opus' | 'offline-hymt15' | 'offline-hunyuan-mt' | 'offline-hybrid' | 'offline-lfm2'
+export type EngineMode = 'auto' | 'rotation' | 'online' | 'online-deepl' | 'online-gemini' | 'offline-opus' | 'offline-hymt15' | 'offline-hunyuan-mt' | 'offline-hybrid' | 'offline-lfm2' | 'offline-plamo'
 
 export type SttEngineType = 'whisper-local' | 'mlx-whisper'
 export type WhisperVariantType = 'kotoba-v2.0' | 'large-v3-turbo' | 'distil-large-v3' | 'base' | 'small'
@@ -105,7 +105,7 @@ export const colorInputStyle: React.CSSProperties = {
 export const API_ENGINE_MODES: EngineMode[] = ['rotation', 'online', 'online-deepl', 'online-gemini']
 
 /** LLM-based engine modes that support KV cache / SimulMT options */
-export const LLM_ENGINE_MODES: EngineMode[] = ['offline-hymt15', 'offline-hunyuan-mt', 'offline-hybrid', 'offline-lfm2']
+export const LLM_ENGINE_MODES: EngineMode[] = ['offline-hymt15', 'offline-hunyuan-mt', 'offline-hybrid', 'offline-lfm2', 'offline-plamo']
 
 /** Display name for each engine mode */
 export function getEngineDisplayName(mode: EngineMode): string {
@@ -114,6 +114,7 @@ export function getEngineDisplayName(mode: EngineMode): string {
     case 'offline-hymt15': return 'HY-MT 1.5 (Recommended)'
     case 'offline-hunyuan-mt': return 'Hunyuan-MT 7B (High Quality)'
     case 'offline-lfm2': return 'LFM2 (Ultra-fast)'
+    case 'offline-plamo': return 'PLaMo-2 10B (Quality)'
     case 'offline-hybrid': return 'Hybrid (OPUS-MT + TranslateGemma)'
     case 'rotation': return 'API Auto Rotation'
     case 'online': return 'Google Translation'
@@ -181,6 +182,8 @@ export function buildEngineConfig(
       return { ...base, translatorEngineId: 'gemini-translate', geminiApiKey: apiKeys.geminiApiKey }
     case 'offline-lfm2':
       return { ...base, translatorEngineId: 'lfm2' }
+    case 'offline-plamo':
+      return { ...base, translatorEngineId: 'plamo' }
     case 'offline-hymt15':
       return { ...base, translatorEngineId: 'hunyuan-mt-15' }
     case 'offline-hunyuan-mt':


### PR DESCRIPTION
## Description

Add PLaMo-2-Translate 10B GGUF as a primary quality translation engine for JA↔EN.

- Add `PLAMO_VARIANTS` to model-downloader registry (Q4_K_S recommended ~5.5GB, Q3_K_M, Q6_K, Q8_0)
- Create `PLaMoTranslator` extending `LlamaWorkerTranslator` with Q4_K_S default (no Q4_K_M available in GGUF)
- Add `plamo` model type to slm-worker with official prompt format (`<|plamo:op|>` structured tags) and greedy decoding (temperature=0)
- Register in `initPipeline()` and add to TranslatorSettings UI as primary offline engine
- PLaMo-2-Translate: 10B param PFN model, adopted by Japan Government AI Project "Gennai", style-aware translation

Closes #512