### PR TITLE
517 Add organization-wide glossary sharing

### DIFF
--- a/src/engines/translator/glossary-manager.test.ts
+++ b/src/engines/translator/glossary-manager.test.ts
@@ -1,0 +1,165 @@
+import { describe, it, expect } from 'vitest'
+import {
+  parseJsonGlossary,
+  parseCsvGlossary,
+  exportJsonGlossary,
+  exportCsvGlossary,
+  mergeGlossaries,
+  detectGlossaryFormat,
+  parseGlossary
+} from './glossary-manager'
+
+describe('parseJsonGlossary', () => {
+  it('parses valid JSON array', () => {
+    const input = JSON.stringify([
+      { source: 'AI', target: 'Artificial Intelligence' },
+      { source: 'ML', target: 'Machine Learning' }
+    ])
+    const result = parseJsonGlossary(input)
+    expect(result).toEqual([
+      { source: 'AI', target: 'Artificial Intelligence' },
+      { source: 'ML', target: 'Machine Learning' }
+    ])
+  })
+
+  it('skips entries with missing fields', () => {
+    const input = JSON.stringify([
+      { source: 'AI', target: 'Artificial Intelligence' },
+      { source: 'ML' },
+      { target: 'Something' },
+      { source: '', target: 'Empty' }
+    ])
+    const result = parseJsonGlossary(input)
+    expect(result).toEqual([{ source: 'AI', target: 'Artificial Intelligence' }])
+  })
+
+  it('trims whitespace from terms', () => {
+    const input = JSON.stringify([{ source: '  AI  ', target: '  人工知能  ' }])
+    const result = parseJsonGlossary(input)
+    expect(result).toEqual([{ source: 'AI', target: '人工知能' }])
+  })
+
+  it('throws on non-array JSON', () => {
+    expect(() => parseJsonGlossary('{"source": "AI"}')).toThrow('must be an array')
+  })
+})
+
+describe('parseCsvGlossary', () => {
+  it('parses CSV with header', () => {
+    const csv = 'source,target\nAI,Artificial Intelligence\nML,Machine Learning'
+    const result = parseCsvGlossary(csv)
+    expect(result).toEqual([
+      { source: 'AI', target: 'Artificial Intelligence' },
+      { source: 'ML', target: 'Machine Learning' }
+    ])
+  })
+
+  it('handles quoted fields with commas', () => {
+    const csv = 'source,target\n"hello, world","こんにちは、世界"'
+    const result = parseCsvGlossary(csv)
+    expect(result).toEqual([{ source: 'hello, world', target: 'こんにちは、世界' }])
+  })
+
+  it('handles escaped quotes', () => {
+    const csv = 'source,target\n"say ""hello""","挨拶"'
+    const result = parseCsvGlossary(csv)
+    expect(result).toEqual([{ source: 'say "hello"', target: '挨拶' }])
+  })
+
+  it('returns empty for header-only CSV', () => {
+    const result = parseCsvGlossary('source,target')
+    expect(result).toEqual([])
+  })
+
+  it('skips blank rows', () => {
+    const csv = 'source,target\nAI,人工知能\n\nML,機械学習'
+    const result = parseCsvGlossary(csv)
+    expect(result).toEqual([
+      { source: 'AI', target: '人工知能' },
+      { source: 'ML', target: '機械学習' }
+    ])
+  })
+
+  it('handles Windows-style line endings', () => {
+    const csv = 'source,target\r\nAI,人工知能\r\nML,機械学習'
+    const result = parseCsvGlossary(csv)
+    expect(result).toHaveLength(2)
+  })
+})
+
+describe('exportJsonGlossary', () => {
+  it('exports valid JSON', () => {
+    const entries = [{ source: 'AI', target: '人工知能' }]
+    const json = exportJsonGlossary(entries)
+    expect(JSON.parse(json)).toEqual([{ source: 'AI', target: '人工知能' }])
+  })
+})
+
+describe('exportCsvGlossary', () => {
+  it('exports CSV with header', () => {
+    const entries = [
+      { source: 'AI', target: '人工知能' },
+      { source: 'ML', target: '機械学習' }
+    ]
+    const csv = exportCsvGlossary(entries)
+    expect(csv).toBe('source,target\nAI,人工知能\nML,機械学習')
+  })
+
+  it('escapes fields with commas', () => {
+    const entries = [{ source: 'hello, world', target: 'greeting' }]
+    const csv = exportCsvGlossary(entries)
+    expect(csv).toBe('source,target\n"hello, world",greeting')
+  })
+})
+
+describe('mergeGlossaries', () => {
+  it('merges without conflicts', () => {
+    const personal = [{ source: 'AI', target: 'Artificial Intelligence' }]
+    const org = [{ source: 'ML', target: 'Machine Learning' }]
+    const merged = mergeGlossaries(personal, org)
+    expect(merged).toHaveLength(2)
+    expect(merged).toContainEqual({ source: 'AI', target: 'Artificial Intelligence' })
+    expect(merged).toContainEqual({ source: 'ML', target: 'Machine Learning' })
+  })
+
+  it('org overrides personal on conflict', () => {
+    const personal = [{ source: 'AI', target: 'My AI Definition' }]
+    const org = [{ source: 'AI', target: 'Org AI Definition' }]
+    const merged = mergeGlossaries(personal, org)
+    expect(merged).toHaveLength(1)
+    expect(merged[0].target).toBe('Org AI Definition')
+  })
+
+  it('handles empty arrays', () => {
+    expect(mergeGlossaries([], [])).toEqual([])
+    expect(mergeGlossaries([{ source: 'A', target: 'B' }], [])).toEqual([{ source: 'A', target: 'B' }])
+    expect(mergeGlossaries([], [{ source: 'A', target: 'B' }])).toEqual([{ source: 'A', target: 'B' }])
+  })
+})
+
+describe('detectGlossaryFormat', () => {
+  it('detects JSON', () => {
+    expect(detectGlossaryFormat('glossary.json')).toBe('json')
+    expect(detectGlossaryFormat('my-terms.JSON')).toBe('json')
+  })
+
+  it('detects CSV', () => {
+    expect(detectGlossaryFormat('glossary.csv')).toBe('csv')
+    expect(detectGlossaryFormat('terms.CSV')).toBe('csv')
+  })
+
+  it('returns null for unknown', () => {
+    expect(detectGlossaryFormat('glossary.txt')).toBeNull()
+    expect(detectGlossaryFormat('glossary')).toBeNull()
+  })
+})
+
+describe('parseGlossary', () => {
+  it('delegates to correct parser', () => {
+    const json = JSON.stringify([{ source: 'A', target: 'B' }])
+    expect(parseGlossary(json, 'json')).toEqual([{ source: 'A', target: 'B' }])
+
+    const csv = 'source,target\nA,B'
+    expect(parseGlossary(csv, 'csv')).toEqual([{ source: 'A', target: 'B' }])
+  })
+})

--- a/src/engines/translator/glossary-manager.ts
+++ b/src/engines/translator/glossary-manager.ts
@@ -1,0 +1,164 @@
+import type { GlossaryEntry } from '../types'
+
+/**
+ * Parse a JSON glossary file.
+ * Expected format: array of { source, target, context? }
+ */
+export function parseJsonGlossary(content: string): GlossaryEntry[] {
+  const data = JSON.parse(content)
+  if (!Array.isArray(data)) {
+    throw new Error('JSON glossary must be an array')
+  }
+  return data
+    .filter(
+      (entry: unknown) =>
+        typeof entry === 'object' &&
+        entry !== null &&
+        typeof (entry as Record<string, unknown>).source === 'string' &&
+        typeof (entry as Record<string, unknown>).target === 'string'
+    )
+    .map((entry: Record<string, unknown>) => ({
+      source: String(entry.source).trim(),
+      target: String(entry.target).trim()
+    }))
+    .filter((entry) => entry.source.length > 0 && entry.target.length > 0)
+}
+
+/**
+ * Parse a CSV glossary file.
+ * Expected format: source,target,context (header row required)
+ * Handles quoted fields with commas inside.
+ */
+export function parseCsvGlossary(content: string): GlossaryEntry[] {
+  const lines = content.split(/\r?\n/).filter((line) => line.trim().length > 0)
+  if (lines.length < 2) return [] // Need header + at least one data row
+
+  // Skip header row
+  const entries: GlossaryEntry[] = []
+  for (let i = 1; i < lines.length; i++) {
+    const fields = parseCsvLine(lines[i])
+    if (fields.length >= 2) {
+      const source = fields[0].trim()
+      const target = fields[1].trim()
+      if (source.length > 0 && target.length > 0) {
+        entries.push({ source, target })
+      }
+    }
+  }
+  return entries
+}
+
+/**
+ * Parse a single CSV line, handling quoted fields.
+ */
+function parseCsvLine(line: string): string[] {
+  const fields: string[] = []
+  let current = ''
+  let inQuotes = false
+
+  for (let i = 0; i < line.length; i++) {
+    const char = line[i]
+    if (inQuotes) {
+      if (char === '"') {
+        if (i + 1 < line.length && line[i + 1] === '"') {
+          // Escaped quote
+          current += '"'
+          i++
+        } else {
+          inQuotes = false
+        }
+      } else {
+        current += char
+      }
+    } else {
+      if (char === '"') {
+        inQuotes = true
+      } else if (char === ',') {
+        fields.push(current)
+        current = ''
+      } else {
+        current += char
+      }
+    }
+  }
+  fields.push(current)
+  return fields
+}
+
+/**
+ * Export glossary entries to JSON format.
+ */
+export function exportJsonGlossary(entries: GlossaryEntry[]): string {
+  return JSON.stringify(
+    entries.map((e) => ({ source: e.source, target: e.target })),
+    null,
+    2
+  )
+}
+
+/**
+ * Export glossary entries to CSV format with header row.
+ */
+export function exportCsvGlossary(entries: GlossaryEntry[]): string {
+  const header = 'source,target'
+  const rows = entries.map((e) => `${escapeCsvField(e.source)},${escapeCsvField(e.target)}`)
+  return [header, ...rows].join('\n')
+}
+
+/**
+ * Escape a CSV field value — wrap in quotes if it contains commas, quotes, or newlines.
+ */
+function escapeCsvField(value: string): string {
+  if (value.includes(',') || value.includes('"') || value.includes('\n')) {
+    return `"${value.replace(/"/g, '""')}"`
+  }
+  return value
+}
+
+/**
+ * Merge personal and organization glossaries.
+ * Organization terms take precedence when source terms conflict.
+ * Deduplicates entries by source term (case-sensitive).
+ */
+export function mergeGlossaries(
+  personal: GlossaryEntry[],
+  organization: GlossaryEntry[]
+): GlossaryEntry[] {
+  const merged = new Map<string, GlossaryEntry>()
+
+  // Add personal terms first
+  for (const entry of personal) {
+    merged.set(entry.source, entry)
+  }
+
+  // Organization terms override personal
+  for (const entry of organization) {
+    merged.set(entry.source, entry)
+  }
+
+  return Array.from(merged.values())
+}
+
+/**
+ * Detect glossary file format from filename extension.
+ */
+export function detectGlossaryFormat(filename: string): 'json' | 'csv' | null {
+  const lower = filename.toLowerCase()
+  if (lower.endsWith('.json')) return 'json'
+  if (lower.endsWith('.csv')) return 'csv'
+  return null
+}
+
+/**
+ * Parse glossary from file content, auto-detecting format.
+ */
+export function parseGlossary(content: string, format: 'json' | 'csv'): GlossaryEntry[] {
+  switch (format) {
+    case 'json':
+      return parseJsonGlossary(content)
+    case 'csv':
+      return parseCsvGlossary(content)
+    default:
+      throw new Error(`Unsupported glossary format: ${format}`)
+  }
+}

--- a/src/main/ipc/pipeline-ipc.ts
+++ b/src/main/ipc/pipeline-ipc.ts
@@ -116,9 +116,11 @@ export function registerPipelineIpc(ctx: AppContext): void {
         throw err
       }
 
-      // Load glossary terms from store
-      const glossaryTerms = store.get('glossaryTerms') || []
-      ctx.pipeline!.setGlossary(glossaryTerms)
+      // Load merged glossary (personal + org) from store (#517)
+      const personal = store.get('glossaryTerms') || []
+      const org = store.get('orgGlossaryTerms') || []
+      const { mergeGlossaries } = await import('../../engines/translator/glossary-manager')
+      ctx.pipeline!.setGlossary(mergeGlossaries(personal, org))
 
       // Configure language settings (#263)
       ctx.pipeline!.setLanguageConfig(store.get('sourceLanguage'), store.get('targetLanguage'))

--- a/src/main/ipc/settings-ipc.ts
+++ b/src/main/ipc/settings-ipc.ts
@@ -1,9 +1,17 @@
-import { ipcMain } from 'electron'
+import { ipcMain, dialog } from 'electron'
+import { readFile, writeFile } from 'fs/promises'
 import { store } from '../store'
 import type { AppSettings, SubtitleSettings } from '../store'
 import { validateSubtitleSettings } from '../ipc-validators'
 import type { AppContext } from '../app-context'
 import { createLogger } from '../logger'
+import {
+  parseGlossary,
+  detectGlossaryFormat,
+  exportJsonGlossary,
+  exportCsvGlossary,
+  mergeGlossaries
+} from '../../engines/translator/glossary-manager'
 
 const _log = createLogger('ipc:settings')
 
@@ -25,6 +33,7 @@ export function registerSettingsIpc(ctx: AppContext): void {
       slmModelSize: store.get('slmModelSize'),
       slmSpeculativeDecoding: store.get('slmSpeculativeDecoding'),
       glossaryTerms: store.get('glossaryTerms') || [],
+      orgGlossaryTerms: store.get('orgGlossaryTerms') || [],
       simulMtEnabled: store.get('simulMtEnabled'),
       simulMtWaitK: store.get('simulMtWaitK'),
       whisperVariant: store.get('whisperVariant'),
@@ -57,13 +66,126 @@ export function registerSettingsIpc(ctx: AppContext): void {
     }
   })
 
+  /** Sync the merged glossary (personal + org) to the running pipeline */
+  function syncMergedGlossary(): void {
+    if (!ctx.pipeline) return
+    const personal = store.get('glossaryTerms') || []
+    const org = store.get('orgGlossaryTerms') || []
+    ctx.pipeline.setGlossary(mergeGlossaries(personal, org))
+  }
+
   // Glossary terms persistence (#240)
   ipcMain.handle('save-glossary', (_event, terms: Array<{ source: string; target: string }>) => {
     store.set('glossaryTerms', terms)
-    // Update running pipeline glossary in real-time
-    if (ctx.pipeline) {
-      ctx.pipeline.setGlossary(terms)
+    syncMergedGlossary()
+  })
+
+  // Organization glossary persistence (#517)
+  ipcMain.handle('save-org-glossary', (_event, terms: Array<{ source: string; target: string }>) => {
+    store.set('orgGlossaryTerms', terms)
+    syncMergedGlossary()
+  })
+
+  // Import glossary from file via native dialog (#517)
+  ipcMain.handle('import-glossary', async (_event, target: 'personal' | 'org') => {
+    const win = ctx.mainWindow
+    if (!win) return { error: 'No main window' }
+
+    const result = await dialog.showOpenDialog(win, {
+      title: 'Import Glossary',
+      filters: [
+        { name: 'Glossary Files', extensions: ['json', 'csv'] },
+        { name: 'JSON', extensions: ['json'] },
+        { name: 'CSV', extensions: ['csv'] }
+      ],
+      properties: ['openFile']
+    })
+
+    if (result.canceled || result.filePaths.length === 0) {
+      return { canceled: true }
     }
+
+    const filePath = result.filePaths[0]
+    try {
+      const format = detectGlossaryFormat(filePath)
+      if (!format) {
+        return { error: 'Unsupported file format. Use .json or .csv files.' }
+      }
+
+      const content = await readFile(filePath, 'utf-8')
+      const entries = parseGlossary(content, format)
+
+      if (entries.length === 0) {
+        return { error: 'No valid glossary entries found in file.' }
+      }
+
+      const storeKey = target === 'org' ? 'orgGlossaryTerms' : 'glossaryTerms'
+      store.set(storeKey, entries)
+      syncMergedGlossary()
+
+      _log.info(`Imported ${entries.length} ${target} glossary entries from ${filePath}`)
+      return { entries, count: entries.length }
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err)
+      _log.error(`Glossary import failed: ${message}`)
+      return { error: `Import failed: ${message}` }
+    }
+  })
+
+  // Export glossary to file via native dialog (#517)
+  ipcMain.handle('export-glossary', async (_event, target: 'personal' | 'org', format: 'json' | 'csv') => {
+    const win = ctx.mainWindow
+    if (!win) return { error: 'No main window' }
+
+    const storeKey = target === 'org' ? 'orgGlossaryTerms' : 'glossaryTerms'
+    const terms = store.get(storeKey) || []
+
+    if (terms.length === 0) {
+      return { error: 'No glossary terms to export.' }
+    }
+
+    const ext = format === 'json' ? 'json' : 'csv'
+    const result = await dialog.showSaveDialog(win, {
+      title: 'Export Glossary',
+      defaultPath: `glossary-${target}.${ext}`,
+      filters: [
+        { name: format === 'json' ? 'JSON' : 'CSV', extensions: [ext] }
+      ]
+    })
+
+    if (result.canceled || !result.filePath) {
+      return { canceled: true }
+    }
+
+    try {
+      const content = format === 'json'
+        ? exportJsonGlossary(terms)
+        : exportCsvGlossary(terms)
+      await writeFile(result.filePath, content, 'utf-8')
+      _log.info(`Exported ${terms.length} ${target} glossary entries to ${result.filePath}`)
+      return { success: true, path: result.filePath, count: terms.length }
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err)
+      _log.error(`Glossary export failed: ${message}`)
+      return { error: `Export failed: ${message}` }
+    }
+  })
+
+  // Get merged glossary preview (#517)
+  ipcMain.handle('get-merged-glossary', () => {
+    const personal = store.get('glossaryTerms') || []
+    const org = store.get('orgGlossaryTerms') || []
+    const merged = mergeGlossaries(personal, org)
+    // Find conflicts: entries where same source exists in both with different targets
+    const personalMap = new Map(personal.map((e) => [e.source, e.target]))
+    const conflicts = org
+      .filter((e) => personalMap.has(e.source) && personalMap.get(e.source) !== e.target)
+      .map((e) => ({
+        source: e.source,
+        personalTarget: personalMap.get(e.source)!,
+        orgTarget: e.target
+      }))
+    return { merged, conflicts, personalCount: personal.length, orgCount: org.length }
   })
 
   // #54: crash recovery — check if previous session ended uncleanly

--- a/src/main/store.ts
+++ b/src/main/store.ts
@@ -49,6 +49,8 @@ export interface AppSettings {
   slmModelSize: '4b' | '12b'
   /** User-defined glossary for fixed translation of specific terms */
   glossaryTerms: GlossaryEntry[]
+  /** Organization-wide glossary imported from JSON/CSV (#517) */
+  orgGlossaryTerms: GlossaryEntry[]
   /** Enable speculative decoding: 4B draft model + 12B verifier for 2-3x throughput */
   slmSpeculativeDecoding: boolean
   /** Enable simultaneous translation (SimulMT) with Wait-k policy for lower latency */
@@ -113,6 +115,7 @@ export const store = new Store<AppSettings>({
     slmKvCacheQuant: true,
     slmModelSize: '4b',
     glossaryTerms: [],
+    orgGlossaryTerms: [],
     slmSpeculativeDecoding: false,
     simulMtEnabled: false,
     simulMtWaitK: 3,

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -36,6 +36,26 @@ export interface ElectronAPI {
   getWhisperVariants: () => Promise<Array<{ key: string; label: string; description: string; filename: string; sizeMB: number; downloaded: boolean }>>
   getPlatform: () => Promise<string>
   saveGlossary: (terms: Array<{ source: string; target: string }>) => Promise<void>
+  saveOrgGlossary: (terms: Array<{ source: string; target: string }>) => Promise<void>
+  importGlossary: (target: 'personal' | 'org') => Promise<{
+    entries?: Array<{ source: string; target: string }>
+    count?: number
+    canceled?: boolean
+    error?: string
+  }>
+  exportGlossary: (target: 'personal' | 'org', format: 'json' | 'csv') => Promise<{
+    success?: boolean
+    path?: string
+    count?: number
+    canceled?: boolean
+    error?: string
+  }>
+  getMergedGlossary: () => Promise<{
+    merged: Array<{ source: string; target: string }>
+    conflicts: Array<{ source: string; personalTarget: string; orgTarget: string }>
+    personalCount: number
+    orgCount: number
+  }>
   isDraftModelAvailable: (engine?: string) => Promise<boolean>
   wsAudioStart: (port?: number) => Promise<void>
   wsAudioStop: () => Promise<void>

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -81,9 +81,16 @@ contextBridge.exposeInMainWorld('api', {
     return () => ipcRenderer.off('subtitle-settings-changed', handler)
   },
 
-  // Glossary management (#240)
+  // Glossary management (#240, #517)
   saveGlossary: (terms: Array<{ source: string; target: string }>) =>
     ipcRenderer.invoke('save-glossary', terms),
+  saveOrgGlossary: (terms: Array<{ source: string; target: string }>) =>
+    ipcRenderer.invoke('save-org-glossary', terms),
+  importGlossary: (target: 'personal' | 'org') =>
+    ipcRenderer.invoke('import-glossary', target),
+  exportGlossary: (target: 'personal' | 'org', format: 'json' | 'csv') =>
+    ipcRenderer.invoke('export-glossary', target, format),
+  getMergedGlossary: () => ipcRenderer.invoke('get-merged-glossary'),
 
   // #238: Check if draft model is available for speculative decoding
   isDraftModelAvailable: (engine?: string) => ipcRenderer.invoke('is-draft-model-available', engine),

--- a/src/renderer/components/SettingsPanel.tsx
+++ b/src/renderer/components/SettingsPanel.tsx
@@ -134,6 +134,8 @@ function SettingsPanel(): React.JSX.Element {
             onShowApiOptionsChange={s.setShowApiOptions}
             glossaryTerms={s.glossaryTerms}
             onGlossaryTermsChange={s.setGlossaryTerms}
+            orgGlossaryTerms={s.orgGlossaryTerms}
+            onOrgGlossaryTermsChange={s.setOrgGlossaryTerms}
           />
 
           <SubtitleSettings

--- a/src/renderer/components/settings/TranslatorSettings.tsx
+++ b/src/renderer/components/settings/TranslatorSettings.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import React, { useEffect, useState } from 'react'
 import { Section } from './Section'
 import { API_ENGINE_MODES, LLM_ENGINE_MODES, inputStyle, radioLabelStyle } from './shared'
 import type { EngineMode } from './shared'
@@ -34,6 +34,22 @@ interface TranslatorSettingsProps {
   // Glossary
   glossaryTerms: Array<{ source: string; target: string }>
   onGlossaryTermsChange: (terms: Array<{ source: string; target: string }>) => void
+  // Organization glossary (#517)
+  orgGlossaryTerms: Array<{ source: string; target: string }>
+  onOrgGlossaryTermsChange: (terms: Array<{ source: string; target: string }>) => void
+}
+
+/** Small action button style shared across glossary sections */
+const glossaryButtonStyle: React.CSSProperties = {
+  padding: '6px 10px',
+  fontSize: '11px',
+  fontWeight: 600,
+  background: '#334155',
+  color: '#e2e8f0',
+  border: 'none',
+  borderRadius: '4px',
+  cursor: 'pointer',
+  whiteSpace: 'nowrap'
 }
 
 export function TranslatorSettings({
@@ -60,10 +76,74 @@ export function TranslatorSettings({
   showApiOptions,
   onShowApiOptionsChange,
   glossaryTerms,
-  onGlossaryTermsChange
+  onGlossaryTermsChange,
+  orgGlossaryTerms,
+  onOrgGlossaryTermsChange
 }: TranslatorSettingsProps): React.JSX.Element {
   const [newGlossarySource, setNewGlossarySource] = useState('')
   const [newGlossaryTarget, setNewGlossaryTarget] = useState('')
+  const [glossaryStatus, setGlossaryStatus] = useState('')
+  const [showOrgGlossary, setShowOrgGlossary] = useState(orgGlossaryTerms.length > 0)
+  const [conflicts, setConflicts] = useState<Array<{ source: string; personalTarget: string; orgTarget: string }>>([])
+
+  // Load conflict preview when glossaries change
+  useEffect(() => {
+    if (orgGlossaryTerms.length > 0 && glossaryTerms.length > 0) {
+      window.api.getMergedGlossary().then((result) => {
+        setConflicts(result.conflicts)
+      }).catch(() => { /* ignore */ })
+    } else {
+      setConflicts([])
+    }
+  }, [glossaryTerms, orgGlossaryTerms])
+
+  // Expand org section if org terms are loaded
+  useEffect(() => {
+    if (orgGlossaryTerms.length > 0) setShowOrgGlossary(true)
+  }, [orgGlossaryTerms.length])
+
+  const handleImport = async (target: 'personal' | 'org'): Promise<void> => {
+    setGlossaryStatus('Importing...')
+    try {
+      const result = await window.api.importGlossary(target)
+      if (result.canceled) {
+        setGlossaryStatus('')
+        return
+      }
+      if (result.error) {
+        setGlossaryStatus(result.error)
+        return
+      }
+      if (result.entries) {
+        if (target === 'org') {
+          onOrgGlossaryTermsChange(result.entries)
+        } else {
+          onGlossaryTermsChange(result.entries)
+        }
+        setGlossaryStatus(`Imported ${result.count} terms`)
+      }
+    } catch (err) {
+      setGlossaryStatus(`Import failed: ${err}`)
+    }
+  }
+
+  const handleExport = async (target: 'personal' | 'org', format: 'json' | 'csv'): Promise<void> => {
+    setGlossaryStatus('Exporting...')
+    try {
+      const result = await window.api.exportGlossary(target, format)
+      if (result.canceled) {
+        setGlossaryStatus('')
+        return
+      }
+      if (result.error) {
+        setGlossaryStatus(result.error)
+        return
+      }
+      setGlossaryStatus(`Exported ${result.count} terms`)
+    } catch (err) {
+      setGlossaryStatus(`Export failed: ${err}`)
+    }
+  }
 
   const showLlmOptions = LLM_ENGINE_MODES.includes(engineMode)
   const isApiEngine = API_ENGINE_MODES.includes(engineMode)
@@ -336,10 +416,28 @@ export function TranslatorSettings({
         </div>
       </Section>
 
-      {/* Glossary */}
-      <Section label="Translation Glossary">
+      {/* Personal Glossary */}
+      <Section label="Personal Glossary">
         <div style={{ fontSize: '12px', color: '#94a3b8', marginBottom: '8px' }}>
           Define fixed translations for specific terms (e.g. proper nouns).
+        </div>
+        <div style={{ display: 'flex', gap: '6px', marginBottom: '8px', flexWrap: 'wrap' }}>
+          <button onClick={() => handleImport('personal')} disabled={disabled} style={glossaryButtonStyle}>
+            Import JSON/CSV
+          </button>
+          {glossaryTerms.length > 0 && (
+            <>
+              <button onClick={() => handleExport('personal', 'json')} disabled={disabled} style={glossaryButtonStyle}>
+                Export JSON
+              </button>
+              <button onClick={() => handleExport('personal', 'csv')} disabled={disabled} style={glossaryButtonStyle}>
+                Export CSV
+              </button>
+            </>
+          )}
+          <span style={{ fontSize: '11px', color: '#64748b', alignSelf: 'center' }}>
+            {glossaryTerms.length} terms
+          </span>
         </div>
         {glossaryTerms.length === 0 ? (
           <div
@@ -354,7 +452,7 @@ export function TranslatorSettings({
             No glossary terms added yet
           </div>
         ) : (
-          <div style={{ marginBottom: '8px' }}>
+          <div style={{ marginBottom: '8px', maxHeight: '200px', overflowY: 'auto' }}>
             {glossaryTerms.map((term, idx) => (
               <div
                 key={idx}
@@ -460,6 +558,123 @@ export function TranslatorSettings({
             Add
           </button>
         </div>
+      </Section>
+
+      {/* Organization Glossary (#517) */}
+      <Section label="Organization Glossary">
+        <button
+          onClick={() => setShowOrgGlossary(!showOrgGlossary)}
+          style={{
+            background: 'transparent',
+            border: 'none',
+            color: '#cbd5e1',
+            fontSize: '12px',
+            cursor: 'pointer',
+            padding: '4px 0',
+            display: 'flex',
+            alignItems: 'center',
+            gap: '6px'
+          }}
+        >
+          <span style={{ transform: showOrgGlossary ? 'rotate(90deg)' : 'none', transition: 'transform 0.2s', fontSize: '10px' }}>
+            &#9654;
+          </span>
+          Shared team glossary — org terms override personal when conflicts
+        </button>
+
+        {showOrgGlossary && (
+          <div style={{ marginTop: '8px' }}>
+            <div style={{ display: 'flex', gap: '6px', marginBottom: '8px', flexWrap: 'wrap' }}>
+              <button onClick={() => handleImport('org')} disabled={disabled} style={glossaryButtonStyle}>
+                Import JSON/CSV
+              </button>
+              {orgGlossaryTerms.length > 0 && (
+                <>
+                  <button onClick={() => handleExport('org', 'json')} disabled={disabled} style={glossaryButtonStyle}>
+                    Export JSON
+                  </button>
+                  <button onClick={() => handleExport('org', 'csv')} disabled={disabled} style={glossaryButtonStyle}>
+                    Export CSV
+                  </button>
+                  <button
+                    onClick={() => {
+                      onOrgGlossaryTermsChange([])
+                      window.api.saveOrgGlossary([])
+                      setGlossaryStatus('Organization glossary cleared')
+                    }}
+                    disabled={disabled}
+                    style={{ ...glossaryButtonStyle, color: '#ef4444' }}
+                  >
+                    Clear
+                  </button>
+                </>
+              )}
+              <span style={{ fontSize: '11px', color: '#64748b', alignSelf: 'center' }}>
+                {orgGlossaryTerms.length} terms
+              </span>
+            </div>
+
+            {orgGlossaryTerms.length === 0 ? (
+              <div style={{ fontSize: '12px', color: '#64748b', textAlign: 'center', padding: '12px 0' }}>
+                No organization glossary imported. Import a JSON or CSV file shared by your team.
+              </div>
+            ) : (
+              <div style={{ maxHeight: '150px', overflowY: 'auto' }}>
+                {orgGlossaryTerms.map((term, idx) => (
+                  <div
+                    key={idx}
+                    style={{
+                      display: 'flex',
+                      alignItems: 'center',
+                      gap: '8px',
+                      padding: '4px 0',
+                      borderBottom: '1px solid #1e293b',
+                      fontSize: '12px'
+                    }}
+                  >
+                    <span style={{ flex: 1, minWidth: 0, color: '#e2e8f0', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }} title={term.source}>
+                      {term.source}
+                    </span>
+                    <span style={{ color: '#64748b', flexShrink: 0 }}>&rarr;</span>
+                    <span style={{ flex: 1, minWidth: 0, color: '#a78bfa', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }} title={term.target}>
+                      {term.target}
+                    </span>
+                  </div>
+                ))}
+              </div>
+            )}
+
+            {/* Conflict preview */}
+            {conflicts.length > 0 && (
+              <div style={{ marginTop: '8px', padding: '8px', background: '#1e293b', borderRadius: '6px' }}>
+                <div style={{ fontSize: '11px', fontWeight: 600, color: '#f59e0b', marginBottom: '4px' }}>
+                  {conflicts.length} conflict{conflicts.length > 1 ? 's' : ''} (org overrides personal)
+                </div>
+                {conflicts.slice(0, 5).map((c, idx) => (
+                  <div key={idx} style={{ fontSize: '11px', color: '#94a3b8', padding: '2px 0' }}>
+                    <span style={{ color: '#e2e8f0' }}>{c.source}</span>
+                    {' '}
+                    <span style={{ textDecoration: 'line-through', color: '#64748b' }}>{c.personalTarget}</span>
+                    {' '}
+                    <span style={{ color: '#a78bfa' }}>{c.orgTarget}</span>
+                  </div>
+                ))}
+                {conflicts.length > 5 && (
+                  <div style={{ fontSize: '11px', color: '#64748b' }}>
+                    ...and {conflicts.length - 5} more
+                  </div>
+                )}
+              </div>
+            )}
+          </div>
+        )}
+
+        {/* Status message */}
+        {glossaryStatus && (
+          <div style={{ fontSize: '11px', color: '#94a3b8', marginTop: '6px' }}>
+            {glossaryStatus}
+          </div>
+        )}
       </Section>
     </>
   )

--- a/src/renderer/hooks/useEngineSettings.ts
+++ b/src/renderer/hooks/useEngineSettings.ts
@@ -28,6 +28,8 @@ export interface EngineSettingsState {
 
   glossaryTerms: Array<{ source: string; target: string }>
   setGlossaryTerms: (v: Array<{ source: string; target: string }>) => void
+  orgGlossaryTerms: Array<{ source: string; target: string }>
+  setOrgGlossaryTerms: (v: Array<{ source: string; target: string }>) => void
 }
 
 export interface EngineSettingsInit {
@@ -47,6 +49,7 @@ export function useEngineSettings(init: EngineSettingsInit): EngineSettingsState
   const [simulMtEnabled, setSimulMtEnabled] = useState(false)
   const [simulMtWaitK, setSimulMtWaitK] = useState(3)
   const [glossaryTerms, setGlossaryTerms] = useState<Array<{ source: string; target: string }>>([])
+  const [orgGlossaryTerms, setOrgGlossaryTerms] = useState<Array<{ source: string; target: string }>>([])
 
   // Load engine-related settings on mount
   useEffect(() => {
@@ -59,6 +62,7 @@ export function useEngineSettings(init: EngineSettingsInit): EngineSettingsState
       if (s.microsoftRegion) setMicrosoftRegion(str(s.microsoftRegion, ''))
       if (s.slmKvCacheQuant !== undefined) setSlmKvCacheQuant(bool(s.slmKvCacheQuant, true))
       if (s.glossaryTerms) setGlossaryTerms(arr<{ source: string; target: string }>(s.glossaryTerms, []))
+      if (s.orgGlossaryTerms) setOrgGlossaryTerms(arr<{ source: string; target: string }>(s.orgGlossaryTerms, []))
       if (s.simulMtEnabled !== undefined) setSimulMtEnabled(bool(s.simulMtEnabled, false))
       if (s.simulMtWaitK !== undefined) setSimulMtWaitK(num(s.simulMtWaitK, 3))
 
@@ -96,6 +100,7 @@ export function useEngineSettings(init: EngineSettingsInit): EngineSettingsState
     slmKvCacheQuant, setSlmKvCacheQuant,
     simulMtEnabled, setSimulMtEnabled,
     simulMtWaitK, setSimulMtWaitK,
-    glossaryTerms, setGlossaryTerms
+    glossaryTerms, setGlossaryTerms,
+    orgGlossaryTerms, setOrgGlossaryTerms
   }
 }

--- a/src/renderer/hooks/useSettingsState.ts
+++ b/src/renderer/hooks/useSettingsState.ts
@@ -89,6 +89,8 @@ export interface SettingsState {
   // Glossary
   glossaryTerms: Array<{ source: string; target: string }>
   setGlossaryTerms: (v: Array<{ source: string; target: string }>) => void
+  orgGlossaryTerms: Array<{ source: string; target: string }>
+  setOrgGlossaryTerms: (v: Array<{ source: string; target: string }>) => void
 
   // Platform
   platform: string
@@ -267,6 +269,7 @@ export function useSettingsState(): SettingsState {
     simulMtEnabled: engine.simulMtEnabled, setSimulMtEnabled: engine.setSimulMtEnabled,
     simulMtWaitK: engine.simulMtWaitK, setSimulMtWaitK: engine.setSimulMtWaitK,
     glossaryTerms: engine.glossaryTerms, setGlossaryTerms: engine.setGlossaryTerms,
+    orgGlossaryTerms: engine.orgGlossaryTerms, setOrgGlossaryTerms: engine.setOrgGlossaryTerms,
 
     // Display
     displays: display.displays, selectedDisplay: display.selectedDisplay,


### PR DESCRIPTION
## Description

Add organization-wide glossary sharing with JSON/CSV import/export support. Teams can now share standardized terminology via glossary files, with organization terms taking precedence over personal terms when conflicts occur.

### Changes
- **glossary-manager.ts**: New module with JSON/CSV parsing, export, merge logic, and format detection
- **store.ts**: Added `orgGlossaryTerms` field for persisting organization glossary
- **settings-ipc.ts**: Added IPC handlers for import/export (via native file dialogs), org glossary save, and merged glossary preview with conflict detection
- **pipeline-ipc.ts**: Pipeline now loads merged glossary (personal + org) on start
- **preload**: Exposed 4 new IPC channels (`saveOrgGlossary`, `importGlossary`, `exportGlossary`, `getMergedGlossary`)
- **TranslatorSettings.tsx**: Split glossary section into Personal + Organization with import/export buttons, term counts, scrollable lists, and conflict preview
- **useEngineSettings/useSettingsState**: Added `orgGlossaryTerms` state management

### Key design decisions
- Merge strategy: Map-based dedup where org entries override personal entries with same source term
- Import uses Electron native `dialog.showOpenDialog` / `dialog.showSaveDialog` for security
- CSV parser handles quoted fields with commas and escaped quotes
- Conflict preview shows up to 5 conflicts with strikethrough on overridden personal terms
- 20 unit tests for glossary-manager (parse, export, merge, format detection)

Closes #517