### PR TITLE
534 Add Kotoba-Whisper v2.0 as JA-optimized STT engine

### DIFF
--- a/src/engines/hardware-recommender.ts
+++ b/src/engines/hardware-recommender.ts
@@ -10,7 +10,7 @@ import type { WhisperVariant } from './model-downloader'
 
 /** Engine recommendation produced by hardware analysis */
 export interface EngineRecommendation {
-  sttEngine: 'whisper-local' | 'mlx-whisper'
+  sttEngine: 'whisper-local' | 'mlx-whisper' | 'kotoba-whisper'
   translationEngine: string
   whisperVariant: WhisperVariant
   /** Models that need downloading before offline engines can run */
@@ -47,22 +47,28 @@ function isAppleSilicon(platform: string, gpuInfo: GpuInfo): boolean {
  * Recommend optimal engines based on hardware capabilities.
  *
  * Priority:
- * 1. Apple Silicon M1+ with >=16GB: MLX Whisper + HY-MT1.5-1.8B
- * 2. Apple Silicon M1+ with >=8GB: MLX Whisper + LFM2 (lighter)
- * 3. Apple Silicon M1+ with <8GB: MLX Whisper + API fallback
+ * 1. Apple Silicon M1+ with >=16GB: MLX Whisper (or Kotoba-Whisper for JA) + HY-MT1.5-1.8B
+ * 2. Apple Silicon M1+ with >=8GB: MLX Whisper (or Kotoba-Whisper for JA) + LFM2 (lighter)
+ * 3. Apple Silicon M1+ with <8GB: MLX Whisper (or Kotoba-Whisper for JA) + API fallback
  * 4. Intel Mac / other: Whisper Local (base) + API fallback
+ *
+ * When sourceLanguage is 'ja', Kotoba-Whisper v2.0 is preferred on Apple Silicon
+ * (JA CER 5.6% vs MLX Whisper's 8.1%).
  */
 export function recommendEngines(
   gpuInfo: GpuInfo,
   platform: string,
-  totalMemoryMB: number
+  totalMemoryMB: number,
+  sourceLanguage?: string
 ): EngineRecommendation {
   const appleSilicon = isAppleSilicon(platform, gpuInfo)
   const downloads: DownloadItem[] = []
+  // Prefer Kotoba-Whisper for JA-only setups on Apple Silicon
+  const preferKotoba = appleSilicon && sourceLanguage === 'ja'
 
   if (appleSilicon && totalMemoryMB >= 16384) {
-    // Best experience: MLX Whisper + HY-MT1.5
-    const sttEngine = 'mlx-whisper' as const
+    // Best experience: MLX Whisper (or Kotoba-Whisper for JA) + HY-MT1.5
+    const sttEngine = preferKotoba ? 'kotoba-whisper' as const : 'mlx-whisper' as const
     const translationEngine = 'offline-hymt15'
     const whisperVariant: WhisperVariant = 'kotoba-v2.0'
 
@@ -89,8 +95,8 @@ export function recommendEngines(
   }
 
   if (appleSilicon && totalMemoryMB >= 8192) {
-    // Good experience: MLX Whisper + LFM2 (ultra-light)
-    const sttEngine = 'mlx-whisper' as const
+    // Good experience: MLX Whisper (or Kotoba-Whisper for JA) + LFM2 (ultra-light)
+    const sttEngine = preferKotoba ? 'kotoba-whisper' as const : 'mlx-whisper' as const
     const translationEngine = 'offline-lfm2'
     const whisperVariant: WhisperVariant = 'kotoba-v2.0'
 
@@ -116,8 +122,8 @@ export function recommendEngines(
   }
 
   if (appleSilicon) {
-    // Low memory Apple Silicon: MLX Whisper + OPUS-MT (no GGUF download needed)
-    const sttEngine = 'mlx-whisper' as const
+    // Low memory Apple Silicon: MLX Whisper (or Kotoba-Whisper for JA) + OPUS-MT (no GGUF download needed)
+    const sttEngine = preferKotoba ? 'kotoba-whisper' as const : 'mlx-whisper' as const
     const translationEngine = 'offline-opus'
     const whisperVariant: WhisperVariant = 'base'
 

--- a/src/engines/stt/KotobaWhisperEngine.ts
+++ b/src/engines/stt/KotobaWhisperEngine.ts
@@ -1,0 +1,30 @@
+import { MlxWhisperEngine } from './MlxWhisperEngine'
+
+/**
+ * Kotoba-Whisper v2.0 — Japanese-optimized STT engine.
+ *
+ * Uses the same mlx-whisper Python bridge as MlxWhisperEngine but with the
+ * kaiinui/kotoba-whisper-v2.0-mlx model, which achieves JA CER 5.6%
+ * (31% better than baseline MLX Whisper's 8.1%).
+ *
+ * IMPORTANT: This model outputs ONLY Japanese — EN WER is ~100%.
+ * Only use when source language is JA or auto with JA-dominant audio.
+ * Apple Silicon only (requires MLX).
+ */
+export class KotobaWhisperEngine extends MlxWhisperEngine {
+  override readonly id = 'kotoba-whisper'
+  override readonly name = 'Kotoba-Whisper v2.0 (JA-optimized)'
+
+  constructor(options?: {
+    onProgress?: (message: string) => void
+  }) {
+    super({
+      model: 'kaiinui/kotoba-whisper-v2.0-mlx',
+      onProgress: options?.onProgress
+    })
+  }
+
+  protected override getLogPrefix(): string {
+    return '[kotoba-whisper]'
+  }
+}

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -3,6 +3,7 @@ import { initMain as initAudioLoopback } from 'electron-audio-loopback'
 import { TranslationPipeline } from '../pipeline/TranslationPipeline'
 import { WhisperLocalEngine } from '../engines/stt/WhisperLocalEngine'
 import { MlxWhisperEngine } from '../engines/stt/MlxWhisperEngine'
+import { KotobaWhisperEngine } from '../engines/stt/KotobaWhisperEngine'
 import { SenseVoiceEngine } from '../engines/stt/SenseVoiceEngine'
 import { SherpaOnnxEngine } from '../engines/stt/SherpaOnnxEngine'
 import { SpeechSwiftEngine } from '../engines/stt/SpeechSwiftEngine'
@@ -52,6 +53,10 @@ async function initPipeline(): Promise<void> {
   // mlx-whisper is Apple Silicon only — skip registration on other platforms
   if (process.platform === 'darwin') {
     ctx.pipeline.registerSTT('mlx-whisper', () => new MlxWhisperEngine({
+      onProgress: (msg) => ctx.mainWindow?.webContents.send('status-update', msg)
+    }))
+    // Kotoba-Whisper v2.0: JA-optimized MLX Whisper variant (JA CER 5.6%, JA-only output)
+    ctx.pipeline.registerSTT('kotoba-whisper', () => new KotobaWhisperEngine({
       onProgress: (msg) => ctx.mainWindow?.webContents.send('status-update', msg)
     }))
   }

--- a/src/renderer/components/SettingsPanel.tsx
+++ b/src/renderer/components/SettingsPanel.tsx
@@ -107,6 +107,7 @@ function SettingsPanel(): React.JSX.Element {
             onWhisperVariantChange={s.setWhisperVariant}
             platform={s.platform}
             disabled={disabled}
+            sourceLanguage={s.sourceLanguage}
           />
 
           <TranslatorSettings

--- a/src/renderer/components/settings/STTSettings.tsx
+++ b/src/renderer/components/settings/STTSettings.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { Section } from './Section'
 import { selectStyle } from './shared'
-import type { SttEngineType, WhisperVariantType } from './shared'
+import type { SttEngineType, WhisperVariantType, SourceLanguage } from './shared'
 
 interface STTSettingsProps {
   sttEngine: SttEngineType
@@ -10,6 +10,7 @@ interface STTSettingsProps {
   onWhisperVariantChange: (v: WhisperVariantType) => void
   platform: string
   disabled: boolean
+  sourceLanguage: SourceLanguage
 }
 
 export function STTSettings({
@@ -18,8 +19,12 @@ export function STTSettings({
   whisperVariant,
   onWhisperVariantChange,
   platform,
-  disabled
+  disabled,
+  sourceLanguage
 }: STTSettingsProps): React.JSX.Element {
+  // Kotoba-Whisper outputs JA only — show when source is JA or auto, on Apple Silicon
+  const showKotobaWhisper = platform === 'darwin' && (sourceLanguage === 'ja' || sourceLanguage === 'auto')
+
   return (
     <Section label="Speech Recognition">
       <select
@@ -29,6 +34,9 @@ export function STTSettings({
         disabled={disabled}
         aria-label="STT engine"
       >
+        {showKotobaWhisper && (
+          <option value="kotoba-whisper">Kotoba-Whisper v2.0 (JA-optimized, Apple Silicon)</option>
+        )}
         {platform === 'darwin' && (
           <option value="mlx-whisper">mlx-whisper (Apple Silicon, recommended)</option>
         )}
@@ -71,6 +79,16 @@ export function STTSettings({
             <div style={{ marginTop: '4px', fontSize: '11px', color: '#f59e0b' }}>
               Fastest mode: minimal latency (&lt;1s) but significantly lower accuracy. Best for speed-critical use cases.
             </div>
+          )}
+        </div>
+      )}
+      {sttEngine === 'kotoba-whisper' && (
+        <div style={{ marginTop: '4px', fontSize: '11px', color: '#94a3b8' }}>
+          Kotoba-Whisper v2.0: JA CER 5.6% (31% better than MLX Whisper). Japanese output only.
+          {sourceLanguage === 'auto' && (
+            <span style={{ color: '#f59e0b' }}>
+              {' '}Warning: this model only outputs Japanese. Set source language to JA for best results.
+            </span>
           )}
         </div>
       )}

--- a/src/renderer/components/settings/shared.ts
+++ b/src/renderer/components/settings/shared.ts
@@ -27,7 +27,7 @@ export const ALL_LANGUAGES = Object.keys(LANGUAGE_LABELS) as Language[]
 
 export type EngineMode = 'auto' | 'rotation' | 'online' | 'online-deepl' | 'online-gemini' | 'offline-opus' | 'offline-hymt15' | 'offline-hunyuan-mt' | 'offline-hybrid' | 'offline-lfm2' | 'offline-plamo'
 
-export type SttEngineType = 'whisper-local' | 'mlx-whisper'
+export type SttEngineType = 'whisper-local' | 'mlx-whisper' | 'kotoba-whisper'
 export type WhisperVariantType = 'kotoba-v2.0' | 'large-v3-turbo' | 'distil-large-v3' | 'base' | 'small'
 export type SubtitlePositionType = 'top' | 'bottom'
 
@@ -128,6 +128,7 @@ export function getEngineDisplayName(mode: EngineMode): string {
 /** Display name for STT engine + variant */
 export function getSttDisplayName(sttEngine: SttEngineType, whisperVariant: WhisperVariantType): string {
   switch (sttEngine) {
+    case 'kotoba-whisper': return 'Kotoba-Whisper v2.0 (JA-optimized)'
     case 'mlx-whisper': return 'mlx-whisper (Apple Silicon)'
     case 'whisper-local': {
       const variantLabels: Record<string, string> = {

--- a/src/renderer/hooks/useLanguageSettings.ts
+++ b/src/renderer/hooks/useLanguageSettings.ts
@@ -41,6 +41,18 @@ export function useLanguageSettings(): LanguageSettingsState {
     }).catch((e) => console.warn('[settings] Failed to load platform/settings:', e))
   }, [])
 
+  // Auto-select Kotoba-Whisper when source language is set to JA on Apple Silicon (#534)
+  // Revert to mlx-whisper when source changes away from JA
+  useEffect(() => {
+    if (platform !== 'darwin') return
+    if (sourceLanguage === 'ja' && sttEngine === 'mlx-whisper') {
+      setSttEngine('kotoba-whisper')
+    } else if (sourceLanguage !== 'ja' && sourceLanguage !== 'auto' && sttEngine === 'kotoba-whisper') {
+      // Kotoba-Whisper only outputs JA — switch back to mlx-whisper for non-JA sources
+      setSttEngine('mlx-whisper')
+    }
+  }, [sourceLanguage, platform, sttEngine])
+
   return {
     sourceLanguage, setSourceLanguage,
     targetLanguage, setTargetLanguage,


### PR DESCRIPTION
## Description

Integrate Kotoba-Whisper v2.0 (`kaiinui/kotoba-whisper-v2.0-mlx`) as a Japanese-optimized STT engine, achieving JA CER 5.6% (31% better than MLX Whisper's 8.1%).

### Changes
- **KotobaWhisperEngine.ts**: New engine extending MlxWhisperEngine with Kotoba-Whisper model
- **initPipeline()**: Register `kotoba-whisper` engine (Apple Silicon only)
- **STTSettings.tsx**: Show Kotoba-Whisper option when source language is JA or auto; display JA-only warning when source=auto
- **useLanguageSettings.ts**: Auto-select Kotoba-Whisper when user sets source=JA on Apple Silicon; revert to mlx-whisper for non-JA sources
- **hardware-recommender.ts**: Prefer Kotoba-Whisper for JA-only setups on Apple Silicon
- **shared.ts**: Add `kotoba-whisper` to SttEngineType and getSttDisplayName

### Notes
- Kotoba-Whisper outputs ONLY Japanese (EN WER ~100%) — only shown when source=JA or auto
- Uses the same mlx-whisper Python bridge, just different HuggingFace model ID
- Apple Silicon only (requires MLX)

Closes #534