### PR TITLE
535 Add Qwen3-ASR 0.6B as multilingual STT engine

### DIFF
--- a/src/engines/stt/Qwen3ASREngine.ts
+++ b/src/engines/stt/Qwen3ASREngine.ts
@@ -1,0 +1,228 @@
+import { execFile } from 'child_process'
+import { join } from 'path'
+import { writeFileSync, unlinkSync, existsSync } from 'fs'
+import { tmpdir } from 'os'
+import type { STTEngine, STTResult, Language } from '../types'
+import { createLogger } from '../../main/logger'
+import {
+  SPEECH_SWIFT_TRANSCRIBE_TIMEOUT_MS,
+  SPEECH_SWIFT_INIT_TIMEOUT_MS
+} from '../constants'
+
+const log = createLogger('qwen3-asr')
+
+/** Well-known paths where the speech-swift `audio` binary may be installed */
+const SPEECH_SWIFT_PATHS = [
+  '/opt/homebrew/bin/audio',
+  '/usr/local/bin/audio'
+]
+
+/**
+ * Qwen3-ASR 0.6B STT engine via speech-swift CLI (Apple Silicon only).
+ *
+ * Best combined JA+EN accuracy: JA CER 6.8%, EN WER 1.9%.
+ * Latency: ~2.2s (vs MLX Whisper ~1.3s baseline).
+ *
+ * Uses `audio transcribe --engine qwen3 --model 0.6B <wav-file>` — pure Swift + MLX,
+ * no Python dependency. Model (~600MB 4-bit) auto-downloads on first run.
+ *
+ * Install speech-swift via Homebrew:
+ *   brew tap soniqo/speech https://github.com/soniqo/speech-swift
+ *   brew install speech
+ */
+export class Qwen3ASREngine implements STTEngine {
+  readonly id = 'qwen3-asr'
+  readonly name = 'Qwen3-ASR 0.6B (Apple Silicon)'
+  readonly isOffline = true
+
+  private binaryPath: string | null = null
+  private initPromise: Promise<void> | null = null
+  private onProgress?: (message: string) => void
+
+  constructor(options?: {
+    onProgress?: (message: string) => void
+  }) {
+    this.onProgress = options?.onProgress
+  }
+
+  async initialize(): Promise<void> {
+    if (this.initPromise) return this.initPromise
+    this.initPromise = this.doInitialize()
+    return this.initPromise
+  }
+
+  private async doInitialize(): Promise<void> {
+    if (this.binaryPath) return
+
+    this.onProgress?.('Locating speech-swift binary...')
+
+    const found = findSpeechSwiftBinary()
+    if (!found) {
+      throw new Error(
+        'speech-swift `audio` binary not found. Install via Homebrew: ' +
+        'brew tap soniqo/speech https://github.com/soniqo/speech-swift && brew install speech'
+      )
+    }
+    this.binaryPath = found
+    log.info(`Using speech-swift binary: ${this.binaryPath}`)
+
+    // Warmup: trigger model download on first run (~600MB)
+    this.onProgress?.('Warming up Qwen3-ASR 0.6B (model download on first run, ~600MB)...')
+
+    const warmupPath = join(tmpdir(), `qwen3-asr-warmup-${Date.now()}.wav`)
+    try {
+      writeSilentWav(warmupPath, 8000, 16000)
+      await this.runTranscribe(warmupPath, SPEECH_SWIFT_INIT_TIMEOUT_MS)
+      this.onProgress?.('Qwen3-ASR 0.6B ready')
+    } catch (err) {
+      // Warmup failure is non-fatal — model may still be downloading
+      log.warn('Warmup failed (model may still be downloading):', err)
+      this.onProgress?.('Qwen3-ASR 0.6B ready (warmup skipped)')
+    } finally {
+      try { unlinkSync(warmupPath) } catch { /* ignore */ }
+    }
+  }
+
+  async processAudio(audioChunk: Float32Array, sampleRate: number): Promise<STTResult | null> {
+    if (!this.binaryPath) return null
+
+    const tempPath = join(tmpdir(), `qwen3-asr-${Date.now()}.wav`)
+    try {
+      writeWav(tempPath, audioChunk, sampleRate)
+
+      const text = await this.runTranscribe(tempPath, SPEECH_SWIFT_TRANSCRIBE_TIMEOUT_MS)
+      if (!text.trim()) return null
+
+      // speech-swift CLI does not output language info —
+      // use script-based fallback detection
+      const language = detectLanguageFallback(text.trim())
+
+      return {
+        text: text.trim(),
+        language,
+        isFinal: true,
+        timestamp: Date.now()
+      }
+    } catch (err) {
+      log.error('Transcription error:', err instanceof Error ? err.message : err)
+      return null
+    } finally {
+      try { unlinkSync(tempPath) } catch { /* ignore */ }
+    }
+  }
+
+  async dispose(): Promise<void> {
+    log.info('Disposing resources')
+    this.binaryPath = null
+    this.initPromise = null
+  }
+
+  /**
+   * Run `audio transcribe --engine qwen3 --model 0.6B <file>` and parse output.
+   */
+  private runTranscribe(audioPath: string, timeoutMs: number): Promise<string> {
+    return new Promise((resolve, reject) => {
+      if (!this.binaryPath) {
+        reject(new Error('Binary path not set'))
+        return
+      }
+
+      const args = ['transcribe', '--engine', 'qwen3', '--model', '0.6B', audioPath]
+
+      execFile(this.binaryPath, args, { timeout: timeoutMs }, (err, stdout, stderr) => {
+        if (err) {
+          const msg = stderr?.trim() || err.message
+          reject(new Error(`speech-swift error: ${msg}`))
+          return
+        }
+
+        // Parse "Result: <text>" line from CLI output
+        const lines = stdout.split('\n')
+        const resultLine = lines.find((l) => l.startsWith('Result: '))
+        if (resultLine) {
+          resolve(resultLine.replace('Result: ', ''))
+        } else {
+          // Fallback: return last non-empty line
+          const lastLine = lines.filter((l) => l.trim()).pop() ?? ''
+          resolve(lastLine)
+        }
+      })
+    })
+  }
+}
+
+/** Find the speech-swift `audio` binary */
+function findSpeechSwiftBinary(): string | null {
+  for (const p of SPEECH_SWIFT_PATHS) {
+    if (existsSync(p)) return p
+  }
+  return null
+}
+
+/**
+ * Fallback script-based language detection when the model does not
+ * provide a language field.
+ */
+function detectLanguageFallback(text: string): Language {
+  if (!text) return 'en'
+
+  const jpKana = text.match(/[\u3040-\u309F\u30A0-\u30FF]/g)
+  const jpCount = jpKana?.length ?? 0
+  if (jpCount / text.length > 0.3 && jpCount >= 2) return 'ja'
+
+  const cjk = text.match(/[\u4E00-\u9FFF\u3400-\u4DBF]/g)
+  const cjkCount = cjk?.length ?? 0
+  if (cjkCount / text.length > 0.3 && cjkCount >= 2 && jpCount === 0) return 'zh'
+
+  const ko = text.match(/[\uAC00-\uD7AF\u1100-\u11FF\u3130-\u318F]/g)
+  const koCount = ko?.length ?? 0
+  if (koCount / text.length > 0.3 && koCount >= 2) return 'ko'
+
+  const th = text.match(/[\u0E00-\u0E7F]/g)
+  const thCount = th?.length ?? 0
+  if (thCount / text.length > 0.3 && thCount >= 2) return 'th'
+
+  const ar = text.match(/[\u0600-\u06FF\u0750-\u077F]/g)
+  const arCount = ar?.length ?? 0
+  if (arCount / text.length > 0.3 && arCount >= 2) return 'ar'
+
+  return 'en'
+}
+
+/** Write Float32Array as a minimal WAV file */
+function writeWav(path: string, samples: Float32Array, sampleRate: number): void {
+  const numChannels = 1
+  const bitsPerSample = 16
+  const bytesPerSample = bitsPerSample / 8
+  const dataSize = samples.length * bytesPerSample
+  const buffer = Buffer.alloc(44 + dataSize)
+
+  // WAV header
+  buffer.write('RIFF', 0)
+  buffer.writeUInt32LE(36 + dataSize, 4)
+  buffer.write('WAVE', 8)
+  buffer.write('fmt ', 12)
+  buffer.writeUInt32LE(16, 16) // chunk size
+  buffer.writeUInt16LE(1, 20) // PCM
+  buffer.writeUInt16LE(numChannels, 22)
+  buffer.writeUInt32LE(sampleRate, 24)
+  buffer.writeUInt32LE(sampleRate * numChannels * bytesPerSample, 28)
+  buffer.writeUInt16LE(numChannels * bytesPerSample, 32)
+  buffer.writeUInt16LE(bitsPerSample, 34)
+  buffer.write('data', 36)
+  buffer.writeUInt32LE(dataSize, 40)
+
+  // Convert Float32 [-1, 1] to Int16
+  for (let i = 0; i < samples.length; i++) {
+    const s = Math.max(-1, Math.min(1, samples[i]))
+    buffer.writeInt16LE(Math.round(s * 32767), 44 + i * 2)
+  }
+
+  writeFileSync(path, buffer)
+}
+
+/** Write a short silent WAV file for warmup */
+function writeSilentWav(path: string, numSamples: number, sampleRate: number): void {
+  const samples = new Float32Array(numSamples)
+  writeWav(path, samples, sampleRate)
+}

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -7,6 +7,7 @@ import { KotobaWhisperEngine } from '../engines/stt/KotobaWhisperEngine'
 import { SenseVoiceEngine } from '../engines/stt/SenseVoiceEngine'
 import { SherpaOnnxEngine } from '../engines/stt/SherpaOnnxEngine'
 import { SpeechSwiftEngine } from '../engines/stt/SpeechSwiftEngine'
+import { Qwen3ASREngine } from '../engines/stt/Qwen3ASREngine'
 import { OpusMTTranslator } from '../engines/translator/OpusMTTranslator'
 import { SLMTranslator } from '../engines/translator/SLMTranslator'
 import { HunyuanMTTranslator } from '../engines/translator/HunyuanMTTranslator'
@@ -69,6 +70,12 @@ async function initPipeline(): Promise<void> {
     onProgress: (msg) => ctx.mainWindow?.webContents.send('status-update', msg),
     modelKey: (store.get('sherpaOnnxModel') as string) || undefined
   }))
+  // Qwen3-ASR 0.6B via speech-swift — Apple Silicon only, primary engine
+  if (process.platform === 'darwin') {
+    ctx.pipeline.registerSTT('qwen3-asr', () => new Qwen3ASREngine({
+      onProgress: (msg) => ctx.mainWindow?.webContents.send('status-update', msg)
+    }))
+  }
   // Experimental: requires speech-swift binary (Homebrew) — Apple Silicon only, not shown in UI
   if (process.platform === 'darwin') {
     ctx.pipeline.registerSTT('speech-swift', () => new SpeechSwiftEngine({

--- a/src/renderer/components/settings/STTSettings.tsx
+++ b/src/renderer/components/settings/STTSettings.tsx
@@ -38,6 +38,9 @@ export function STTSettings({
           <option value="kotoba-whisper">Kotoba-Whisper v2.0 (JA-optimized, Apple Silicon)</option>
         )}
         {platform === 'darwin' && (
+          <option value="qwen3-asr">Qwen3-ASR 0.6B (Best accuracy, Apple Silicon)</option>
+        )}
+        {platform === 'darwin' && (
           <option value="mlx-whisper">mlx-whisper (Apple Silicon, recommended)</option>
         )}
         <option value="whisper-local">Whisper (whisper.cpp)</option>
@@ -90,6 +93,21 @@ export function STTSettings({
               {' '}Warning: this model only outputs Japanese. Set source language to JA for best results.
             </span>
           )}
+        </div>
+      )}
+      {sttEngine === 'qwen3-asr' && (
+        <div style={{ marginTop: '4px', fontSize: '11px', color: '#94a3b8' }}>
+          Qwen3-ASR 0.6B: JA CER 6.8%, EN WER 1.9% — best combined JA+EN accuracy.
+          Requires{' '}
+          <span style={{ fontFamily: 'monospace', fontSize: '10px' }}>speech-swift</span>
+          {' '}(
+          <span style={{ fontFamily: 'monospace', fontSize: '10px' }}>
+            brew tap soniqo/speech https://github.com/soniqo/speech-swift &amp;&amp; brew install speech
+          </span>
+          ). Model (~600MB) auto-downloads on first use.
+          <div style={{ marginTop: '2px', color: '#f59e0b' }}>
+            Latency: ~2.2s per chunk (65% slower than MLX Whisper ~1.3s). Best for accuracy over speed.
+          </div>
         </div>
       )}
       {sttEngine === 'mlx-whisper' && (

--- a/src/renderer/components/settings/shared.ts
+++ b/src/renderer/components/settings/shared.ts
@@ -27,7 +27,7 @@ export const ALL_LANGUAGES = Object.keys(LANGUAGE_LABELS) as Language[]
 
 export type EngineMode = 'auto' | 'rotation' | 'online' | 'online-deepl' | 'online-gemini' | 'offline-opus' | 'offline-hymt15' | 'offline-hunyuan-mt' | 'offline-hybrid' | 'offline-lfm2' | 'offline-plamo'
 
-export type SttEngineType = 'whisper-local' | 'mlx-whisper' | 'kotoba-whisper'
+export type SttEngineType = 'whisper-local' | 'mlx-whisper' | 'kotoba-whisper' | 'qwen3-asr'
 export type WhisperVariantType = 'kotoba-v2.0' | 'large-v3-turbo' | 'distil-large-v3' | 'base' | 'small'
 export type SubtitlePositionType = 'top' | 'bottom'
 
@@ -128,6 +128,7 @@ export function getEngineDisplayName(mode: EngineMode): string {
 /** Display name for STT engine + variant */
 export function getSttDisplayName(sttEngine: SttEngineType, whisperVariant: WhisperVariantType): string {
   switch (sttEngine) {
+    case 'qwen3-asr': return 'Qwen3-ASR 0.6B (Apple Silicon)'
     case 'kotoba-whisper': return 'Kotoba-Whisper v2.0 (JA-optimized)'
     case 'mlx-whisper': return 'mlx-whisper (Apple Silicon)'
     case 'whisper-local': {


### PR DESCRIPTION
## Summary
- Add `Qwen3ASREngine.ts` wrapping speech-swift CLI (`audio transcribe --engine qwen3 --model 0.6B`)
- Register `qwen3-asr` engine in `initPipeline()` (Apple Silicon only)
- Add to STTSettings.tsx with accuracy stats (JA CER 6.8%, EN WER 1.9%) and latency warning (~2.2s)
- Add `qwen3-asr` to `SttEngineType` and `getSttDisplayName()`

## Details
- Detects `audio` binary at `/opt/homebrew/bin/audio` and `/usr/local/bin/audio`
- Model (~600MB 4-bit) auto-downloads on first use via speech-swift
- Parses `Result: <text>` line from CLI stdout with fallback to last non-empty line
- Graceful handling when speech-swift is not installed (error with install instructions)
- Uses existing `SPEECH_SWIFT_*` timeout constants from `constants.ts`

Closes #535