### PR TITLE
536 Add Moonshine Tiny JA as ultra-fast draft STT

### DIFF
--- a/resources/moonshine-tiny-ja-bridge.py
+++ b/resources/moonshine-tiny-ja-bridge.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+"""
+Python subprocess bridge for Moonshine Tiny JA STT.
+Uses transformers AutoModelForSpeechSeq2Seq pipeline on Apple Silicon (MPS) or CPU.
+
+Model: UsefulSensors/moonshine-tiny-ja (27M params, ~100MB)
+Output: Japanese only — EN input produces garbage.
+Note: Output has spaces between characters (e.g. "お は よ う") — caller strips them.
+
+Protocol:
+  Input (one per line):
+    {"action": "init", "model": "UsefulSensors/moonshine-tiny-ja"}
+    {"action": "transcribe", "audio_path": "/tmp/audio.wav", "sample_rate": 16000}
+    {"action": "dispose"}
+  Output (one per line):
+    {"ready": true, "model": "...", "device": "..."}
+    {"text": "...", "language": "ja"}
+    {"error": "..."}
+"""
+import sys
+import json
+
+pipe = None
+_current_req_id = None
+
+
+def output(data):
+    if _current_req_id is not None:
+        data["_reqId"] = _current_req_id
+    print(json.dumps(data, ensure_ascii=False), flush=True)
+
+
+def init_model(model_name="UsefulSensors/moonshine-tiny-ja"):
+    global pipe
+    try:
+        import torch
+        from transformers import pipeline
+
+        device = "mps" if torch.backends.mps.is_available() else "cpu"
+        dtype = torch.float16 if device == "mps" else torch.float32
+
+        output({"status": f"Loading {model_name} on {device}..."})
+
+        pipe = pipeline(
+            "automatic-speech-recognition",
+            model=model_name,
+            torch_dtype=dtype,
+            device=device,
+        )
+
+        output({"ready": True, "model": model_name, "device": device})
+    except Exception as e:
+        output({"error": f"Failed to initialize: {e}"})
+
+
+def transcribe(audio_path, sample_rate=16000):
+    global pipe
+    if pipe is None:
+        output({"error": "Model not initialized"})
+        return
+
+    try:
+        result = pipe(audio_path)
+        text = result.get("text", "").strip() if isinstance(result, dict) else str(result).strip()
+        output({"text": text, "language": "ja"})
+    except Exception as e:
+        output({"error": f"Transcription failed: {e}"})
+
+
+def main():
+    global _current_req_id
+    for line in sys.stdin:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            msg = json.loads(line)
+            _current_req_id = msg.get("_reqId")
+            action = msg.get("action")
+
+            if action == "init":
+                init_model(msg.get("model", "UsefulSensors/moonshine-tiny-ja"))
+            elif action == "transcribe":
+                transcribe(msg["audio_path"], msg.get("sample_rate", 16000))
+            elif action == "dispose":
+                output({"disposed": True})
+                sys.exit(0)
+            else:
+                output({"error": f"Unknown action: {action}"})
+        except json.JSONDecodeError:
+            _current_req_id = None
+            output({"error": "Invalid JSON"})
+        except Exception as e:
+            output({"error": str(e)})
+        finally:
+            _current_req_id = None
+
+
+if __name__ == "__main__":
+    main()

--- a/src/engines/constants.ts
+++ b/src/engines/constants.ts
@@ -80,6 +80,16 @@ export const SENSEVOICE_TRANSCRIBE_TIMEOUT_MS = 30_000
 export const SENSEVOICE_INIT_TIMEOUT_MS = 180_000
 
 // ---------------------------------------------------------------------------
+// Moonshine Tiny JA (draft STT)
+// ---------------------------------------------------------------------------
+
+/** Command timeout for Moonshine Tiny JA transcription (ms) */
+export const MOONSHINE_TINY_JA_TRANSCRIBE_TIMEOUT_MS = 15_000
+
+/** Init timeout for Moonshine Tiny JA bridge — model download on first run (~100MB) (ms) */
+export const MOONSHINE_TINY_JA_INIT_TIMEOUT_MS = 120_000
+
+// ---------------------------------------------------------------------------
 // ANE translator
 // ---------------------------------------------------------------------------
 

--- a/src/engines/stt/MoonshineTinyJaEngine.ts
+++ b/src/engines/stt/MoonshineTinyJaEngine.ts
@@ -1,0 +1,196 @@
+import { execSync } from 'child_process'
+import { join } from 'path'
+import { writeFileSync, unlinkSync, existsSync } from 'fs'
+import { tmpdir, homedir } from 'os'
+import type { STTEngine, STTResult } from '../types'
+import { SubprocessBridge, type SpawnConfig, type InitResult } from '../SubprocessBridge'
+import {
+  MOONSHINE_TINY_JA_TRANSCRIBE_TIMEOUT_MS,
+  MOONSHINE_TINY_JA_INIT_TIMEOUT_MS,
+  PYTHON_IMPORT_CHECK_TIMEOUT_MS
+} from '../constants'
+
+/**
+ * Moonshine Tiny JA — ultra-fast draft STT engine for Japanese.
+ *
+ * 27M params (~100MB model), achieves 845ms latency (37% faster than baseline).
+ * JA CER 10.1% — lower accuracy than primary STT but much faster for interim results.
+ *
+ * IMPORTANT:
+ * - Outputs ONLY Japanese — EN input becomes garbage.
+ * - Only useful when source language is JA.
+ * - Output has spaces between characters (e.g. "お は よ う") — stripped in processAudio.
+ * - Uses Python 3.12 (Python 3.14 has segfault issues with torch).
+ * - Apple Silicon preferred (MPS), but also works on CPU.
+ */
+export class MoonshineTinyJaEngine extends SubprocessBridge implements STTEngine {
+  readonly id = 'moonshine-tiny-ja'
+  readonly name = 'Moonshine Tiny JA (Ultra-fast draft)'
+  readonly isOffline = true
+
+  private model: string
+  private onProgress?: (message: string) => void
+
+  constructor(options?: {
+    model?: string
+    onProgress?: (message: string) => void
+  }) {
+    super()
+    this.model = options?.model ?? 'UsefulSensors/moonshine-tiny-ja'
+    this.onProgress = options?.onProgress
+  }
+
+  protected getLogPrefix(): string {
+    return '[moonshine-tiny-ja]'
+  }
+
+  protected getInitTimeout(): number {
+    return MOONSHINE_TINY_JA_INIT_TIMEOUT_MS
+  }
+
+  protected getCommandTimeout(): number {
+    return MOONSHINE_TINY_JA_TRANSCRIBE_TIMEOUT_MS
+  }
+
+  protected getSpawnConfig(): SpawnConfig {
+    this.onProgress?.('Starting Moonshine Tiny JA bridge...')
+    const python3 = findPython3WithTransformers()
+    this.onProgress?.(`Using Python: ${python3}`)
+    return {
+      command: python3,
+      args: [join(__dirname, '../../resources/moonshine-tiny-ja-bridge.py')],
+      initMessage: {
+        action: 'init',
+        model: this.model
+      }
+    }
+  }
+
+  protected getSpawnError(): Error {
+    return new Error(
+      'Python 3 with transformers and torch not found. ' +
+      'Install: python3.12 -m pip install transformers torch'
+    )
+  }
+
+  protected onInitComplete(_result: InitResult): void {
+    this.onProgress?.('Moonshine Tiny JA ready')
+  }
+
+  async processAudio(audioChunk: Float32Array, sampleRate: number): Promise<STTResult | null> {
+    if (!this.process) return null
+
+    const tempPath = join(tmpdir(), `moonshine-tiny-ja-${Date.now()}.wav`)
+    try {
+      writeWav(tempPath, audioChunk, sampleRate)
+
+      let result: Record<string, unknown>
+      try {
+        result = await this.sendCommand({
+          action: 'transcribe',
+          audio_path: tempPath,
+          sample_rate: sampleRate
+        })
+      } catch (err) {
+        this.log.error('Bridge error:', err instanceof Error ? err.message : err)
+        return null
+      }
+
+      if (result.error) {
+        this.log.error('Transcription error:', result.error)
+        return null
+      }
+
+      if (!result.text || !(result.text as string).trim()) return null
+
+      // Strip spaces between Japanese characters — model outputs "お は よ う"
+      const rawText = (result.text as string).trim()
+      const text = stripJapaneseSpaces(rawText)
+
+      return {
+        text,
+        language: 'ja',
+        isFinal: true,
+        timestamp: Date.now()
+      }
+    } finally {
+      try { unlinkSync(tempPath) } catch (e) { this.log.warn('Failed to delete temp file:', e) }
+    }
+  }
+}
+
+/**
+ * Strip spaces between Japanese characters.
+ * Moonshine Tiny JA outputs text like "お は よ う ご ざ い ま す".
+ * Remove spaces that are flanked by CJK/Kana/Katakana characters.
+ */
+function stripJapaneseSpaces(text: string): string {
+  // Match a space preceded and followed by CJK unified ideograph, hiragana, or katakana
+  return text.replace(
+    /([\u3040-\u309F\u30A0-\u30FF\u4E00-\u9FFF\u3400-\u4DBF])\s+([\u3040-\u309F\u30A0-\u30FF\u4E00-\u9FFF\u3400-\u4DBF])/g,
+    '$1$2'
+  )
+}
+
+/**
+ * Find a python3 binary that has transformers and torch installed.
+ * Prefers Python 3.12 (3.14 has segfault issues with torch on Apple Silicon).
+ */
+function findPython3WithTransformers(): string {
+  // Check common venv locations first
+  const venvPaths = [
+    join(homedir(), 'mlx-env', 'bin', 'python3'),
+    join(homedir(), '.venv', 'bin', 'python3'),
+    join(homedir(), 'venv', 'bin', 'python3')
+  ]
+
+  for (const p of venvPaths) {
+    if (!existsSync(p)) continue
+    try {
+      execSync(`${p} -c "import transformers; import torch"`, { stdio: 'ignore', timeout: PYTHON_IMPORT_CHECK_TIMEOUT_MS })
+      return p
+    } catch { /* transformers not installed in this venv */ }
+  }
+
+  // Try versioned python binaries (prefer 3.12 over 3.14 due to torch segfault)
+  for (const bin of ['python3.12', 'python3.13', 'python3']) {
+    try {
+      execSync(`${bin} -c "import transformers; import torch"`, { stdio: 'ignore', timeout: PYTHON_IMPORT_CHECK_TIMEOUT_MS })
+      return bin
+    } catch { /* not available or deps not installed */ }
+  }
+
+  throw new Error('Python 3 with transformers and torch not found')
+}
+
+/** Write Float32Array as a minimal WAV file */
+function writeWav(path: string, samples: Float32Array, sampleRate: number): void {
+  const numChannels = 1
+  const bitsPerSample = 16
+  const bytesPerSample = bitsPerSample / 8
+  const dataSize = samples.length * bytesPerSample
+  const buffer = Buffer.alloc(44 + dataSize)
+
+  // WAV header
+  buffer.write('RIFF', 0)
+  buffer.writeUInt32LE(36 + dataSize, 4)
+  buffer.write('WAVE', 8)
+  buffer.write('fmt ', 12)
+  buffer.writeUInt32LE(16, 16)
+  buffer.writeUInt16LE(1, 20) // PCM
+  buffer.writeUInt16LE(numChannels, 22)
+  buffer.writeUInt32LE(sampleRate, 24)
+  buffer.writeUInt32LE(sampleRate * numChannels * bytesPerSample, 28)
+  buffer.writeUInt16LE(numChannels * bytesPerSample, 32)
+  buffer.writeUInt16LE(bitsPerSample, 34)
+  buffer.write('data', 36)
+  buffer.writeUInt32LE(dataSize, 40)
+
+  // Convert Float32 [-1, 1] to Int16
+  for (let i = 0; i < samples.length; i++) {
+    const s = Math.max(-1, Math.min(1, samples[i]))
+    buffer.writeInt16LE(Math.round(s * 32767), 44 + i * 2)
+  }
+
+  writeFileSync(path, buffer)
+}

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -8,6 +8,7 @@ import { SenseVoiceEngine } from '../engines/stt/SenseVoiceEngine'
 import { SherpaOnnxEngine } from '../engines/stt/SherpaOnnxEngine'
 import { SpeechSwiftEngine } from '../engines/stt/SpeechSwiftEngine'
 import { Qwen3ASREngine } from '../engines/stt/Qwen3ASREngine'
+import { MoonshineTinyJaEngine } from '../engines/stt/MoonshineTinyJaEngine'
 import { OpusMTTranslator } from '../engines/translator/OpusMTTranslator'
 import { SLMTranslator } from '../engines/translator/SLMTranslator'
 import { HunyuanMTTranslator } from '../engines/translator/HunyuanMTTranslator'
@@ -82,6 +83,11 @@ async function initPipeline(): Promise<void> {
       onProgress: (msg) => ctx.mainWindow?.webContents.send('status-update', msg)
     }))
   }
+  // Moonshine Tiny JA: ultra-fast draft STT for Japanese interim results (#536)
+  // Not a primary engine — used as draft STT alongside the primary STT
+  ctx.pipeline.registerSTT('moonshine-tiny-ja', () => new MoonshineTinyJaEngine({
+    onProgress: (msg) => ctx.mainWindow?.webContents.send('status-update', msg)
+  }))
 
   // Register translator engines
   // ONNX-based OPUS-MT — fast default offline translator
@@ -170,6 +176,12 @@ async function initPipeline(): Promise<void> {
   ctx.pipeline.on('draft-result', (result: TranslationResult) => {
     ctx.subtitleWindow?.webContents.send('draft-result', result)
     ctx.mainWindow?.webContents.send('draft-result', result)
+  })
+
+  // Forward draft STT interim results (#536)
+  ctx.pipeline.on('draft-stt-result', (result: TranslationResult) => {
+    ctx.subtitleWindow?.webContents.send('interim-result', result)
+    ctx.mainWindow?.webContents.send('interim-result', result)
   })
 
   ctx.pipeline.on('error', (err: Error) => {

--- a/src/main/ipc/pipeline-ipc.ts
+++ b/src/main/ipc/pipeline-ipc.ts
@@ -128,6 +128,9 @@ export function registerPipelineIpc(ctx: AppContext): void {
       // Configure SimulMT (#239)
       ctx.pipeline!.setSimulMt(store.get('simulMtEnabled'), store.get('simulMtWaitK'))
 
+      // Configure draft STT (#536)
+      ctx.pipeline!.setDraftSttEnabled(store.get('draftSttEnabled'))
+
       // Start logger
       ctx.logger = new TranscriptLogger((msg) => ctx.mainWindow?.webContents.send('status-update', msg))
       const sessionLabel = config.mode === 'e2e'

--- a/src/main/ipc/settings-ipc.ts
+++ b/src/main/ipc/settings-ipc.ts
@@ -46,7 +46,8 @@ export function registerSettingsIpc(ctx: AppContext): void {
       ttsVoice: store.get('ttsVoice'),
       ttsOutputDevice: store.get('ttsOutputDevice'),
       ttsVolume: store.get('ttsVolume'),
-      hasCompletedSetup: store.get('hasCompletedSetup')
+      hasCompletedSetup: store.get('hasCompletedSetup'),
+      draftSttEnabled: store.get('draftSttEnabled')
     }
   })
 

--- a/src/main/store.ts
+++ b/src/main/store.ts
@@ -91,6 +91,8 @@ export interface AppSettings {
   virtualMicEnabled: boolean
   /** PortAudio device ID for virtual mic output (#515) */
   virtualMicDeviceId: number
+  /** Enable draft STT (Moonshine Tiny JA) for fast interim results (#536) */
+  draftSttEnabled: boolean
 }
 
 export const store = new Store<AppSettings>({
@@ -138,6 +140,7 @@ export const store = new Store<AppSettings>({
     ttsOutputDevice: '',
     ttsVolume: 0.8,
     virtualMicEnabled: false,
-    virtualMicDeviceId: -1
+    virtualMicDeviceId: -1,
+    draftSttEnabled: false
   }
 })

--- a/src/pipeline/EngineManager.ts
+++ b/src/pipeline/EngineManager.ts
@@ -24,6 +24,7 @@ export class EngineManager {
   sttEngine: STTEngine | null = null
   translator: TranslatorEngine | null = null
   e2eEngine: E2ETranslationEngine | null = null
+  draftSttEngine: STTEngine | null = null
   config: EngineConfig | null = null
 
   registerSTT(id: string, factory: () => STTEngine): void {
@@ -89,12 +90,26 @@ export class EngineManager {
     }
   }
 
+  /**
+   * Initialize the draft STT engine for fast interim results (#536).
+   * Called separately from initializeEngines since draft STT is optional.
+   */
+  async initDraftStt(engineId: string, emitter: EventEmitter): Promise<void> {
+    const factory = this.sttFactories.get(engineId)
+    if (!factory) throw new Error(`Draft STT engine not found: ${engineId}`)
+
+    emitter.emit('engine-loading', 'Loading draft STT model...')
+    this.draftSttEngine = await Promise.resolve(factory())
+    await this.withTimeout(this.draftSttEngine.initialize(), ENGINE_INIT_TIMEOUT_MS, 'Draft STT initialization')
+  }
+
   /** Dispose all active engines and clear references */
   async disposeEngines(): Promise<void> {
-    const engines = [this.sttEngine, this.translator, this.e2eEngine]
+    const engines = [this.sttEngine, this.translator, this.e2eEngine, this.draftSttEngine]
     this.sttEngine = null
     this.translator = null
     this.e2eEngine = null
+    this.draftSttEngine = null
 
     for (const engine of engines) {
       if (engine) {

--- a/src/pipeline/StreamingProcessor.ts
+++ b/src/pipeline/StreamingProcessor.ts
@@ -32,6 +32,8 @@ export interface StreamingDeps {
   decrementProcessing(): void
   /** GER processor for async STT post-correction */
   getGER?(): GERProcessor | null
+  /** Draft STT engine for fast interim results (#536) */
+  getDraftSTTEngine?(): STTEngine | null
 }
 
 /**
@@ -79,6 +81,12 @@ export class StreamingProcessor {
     this.deps.incrementProcessing()
     this.streamingLock = true
     try {
+      // Fire draft STT in parallel for fast interim results (#536)
+      const draftSttEngine = this.deps.getDraftSTTEngine?.()
+      if (draftSttEngine) {
+        this.runDraftStt(draftSttEngine, audioBuffer, sampleRate)
+      }
+
       const t0 = performance.now()
       const sttResult = await sttEngine.processAudio(audioBuffer, sampleRate)
       const sttMs = (performance.now() - t0).toFixed(0)
@@ -240,6 +248,42 @@ export class StreamingProcessor {
       for (const r of this.streamingLockResolvers) r()
       this.streamingLockResolvers = []
     }
+  }
+
+  /**
+   * Run draft STT (Moonshine Tiny JA) in parallel with primary STT.
+   * Emits result as 'draft-stt-result' immediately for fast interim display (#536).
+   * Fire-and-forget — errors are logged but do not affect primary pipeline.
+   */
+  private runDraftStt(draftEngine: STTEngine, audioBuffer: Float32Array, sampleRate: number): void {
+    const t0 = performance.now()
+    draftEngine.processAudio(audioBuffer, sampleRate)
+      .then((draftResult) => {
+        const draftMs = (performance.now() - t0).toFixed(0)
+        if (!draftResult || !draftResult.text.trim()) {
+          log.info(`Draft STT: ${draftMs}ms → (no result)`)
+          return
+        }
+        log.info(`Draft STT: ${draftMs}ms → "${draftResult.text}" [${draftResult.language}]`)
+
+        const targetLang = this.deps.resolveTargetLanguage(draftResult.language)
+        const speakerId = draftResult.speakerId ?? this.deps.speakerTracker.update(Date.now())
+
+        const draftTranslationResult: TranslationResult = {
+          sourceText: draftResult.text,
+          translatedText: '', // Draft STT only provides source text — no translation yet
+          sourceLanguage: draftResult.language,
+          targetLanguage: targetLang,
+          timestamp: Date.now(),
+          isInterim: true,
+          speakerId
+        }
+
+        this.deps.emitter.emit('draft-stt-result', draftTranslationResult)
+      })
+      .catch((err) => {
+        log.warn('Draft STT error (non-fatal):', err instanceof Error ? err.message : err)
+      })
   }
 
   /**

--- a/src/pipeline/TranslationPipeline.ts
+++ b/src/pipeline/TranslationPipeline.ts
@@ -25,6 +25,8 @@ export interface PipelineEvents {
   'interim-result': (result: TranslationResult) => void
   /** Draft result from hybrid translation mode — shown immediately before LLM refinement */
   'draft-result': (result: TranslationResult) => void
+  /** Draft STT interim result — fast Moonshine Tiny JA result before primary STT (#536) */
+  'draft-stt-result': (result: TranslationResult) => void
   /** GER-corrected result — async post-correction of STT errors (#409) */
   'ger-corrected': (result: TranslationResult) => void
   error: (error: Error) => void
@@ -82,6 +84,9 @@ export class TranslationPipeline extends EventEmitter {
   private simulMtEnabled = false
   private simulMtWaitK = 3
 
+  // Draft STT state (#536)
+  private draftSttEnabled = false
+
   // Batch processing mutex — STT engines assume sequential access (#217)
   private batchLock = false
 
@@ -121,7 +126,8 @@ export class TranslationPipeline extends EventEmitter {
           this.processingDoneResolvers = []
         }
       },
-      getGER: () => this.ger
+      getGER: () => this.ger,
+      getDraftSTTEngine: () => this.draftSttEnabled ? this.engineManager.draftSttEngine : null
     })
     this.ger = new GERProcessor({
       emitter: this,
@@ -199,6 +205,11 @@ export class TranslationPipeline extends EventEmitter {
     this.ger.setEnabled(enabled)
   }
 
+  /** Enable or disable draft STT for fast interim results (#536) */
+  setDraftSttEnabled(enabled: boolean): void {
+    this.draftSttEnabled = enabled
+  }
+
   // --- Engine registration (delegated to EngineManager) ---
 
   registerSTT(id: string, factory: () => STTEngine): void {
@@ -238,6 +249,16 @@ export class TranslationPipeline extends EventEmitter {
       await this.waitForProcessing()
       await this.engineManager.disposeEngines()
       await this.engineManager.initializeEngines(config, this)
+
+      // Initialize draft STT if enabled (#536)
+      if (this.draftSttEnabled) {
+        try {
+          await this.engineManager.initDraftStt('moonshine-tiny-ja', this)
+        } catch (err) {
+          log.warn('Draft STT initialization failed (non-fatal):', err)
+          this.emit('engine-loading', 'Draft STT not available — continuing without fast interim results')
+        }
+      }
 
       // If was RUNNING (hot-swap), go back to RUNNING; otherwise stay IDLE until start()
       if (prevState === PipelineState.RUNNING) {

--- a/src/renderer/components/SettingsPanel.tsx
+++ b/src/renderer/components/SettingsPanel.tsx
@@ -108,6 +108,8 @@ function SettingsPanel(): React.JSX.Element {
             platform={s.platform}
             disabled={disabled}
             sourceLanguage={s.sourceLanguage}
+            draftSttEnabled={s.draftSttEnabled}
+            onDraftSttEnabledChange={s.setDraftSttEnabled}
           />
 
           <TranslatorSettings

--- a/src/renderer/components/settings/STTSettings.tsx
+++ b/src/renderer/components/settings/STTSettings.tsx
@@ -11,6 +11,8 @@ interface STTSettingsProps {
   platform: string
   disabled: boolean
   sourceLanguage: SourceLanguage
+  draftSttEnabled: boolean
+  onDraftSttEnabledChange: (v: boolean) => void
 }
 
 export function STTSettings({
@@ -20,7 +22,9 @@ export function STTSettings({
   onWhisperVariantChange,
   platform,
   disabled,
-  sourceLanguage
+  sourceLanguage,
+  draftSttEnabled,
+  onDraftSttEnabledChange
 }: STTSettingsProps): React.JSX.Element {
   // Kotoba-Whisper outputs JA only — show when source is JA or auto, on Apple Silicon
   const showKotobaWhisper = platform === 'darwin' && (sourceLanguage === 'ja' || sourceLanguage === 'auto')
@@ -113,6 +117,28 @@ export function STTSettings({
       {sttEngine === 'mlx-whisper' && (
         <div style={{ marginTop: '4px', fontSize: '11px', color: '#94a3b8' }}>
           MLX Whisper: optimized for Apple Silicon. JA CER 8.1%, EN WER 3.8%, ~3s latency.
+        </div>
+      )}
+      {(sourceLanguage === 'ja' || sourceLanguage === 'auto') && (
+        <div style={{ marginTop: '12px', borderTop: '1px solid #334155', paddingTop: '10px' }}>
+          <label style={{ display: 'flex', alignItems: 'center', gap: '8px', fontSize: '13px', color: '#e2e8f0', cursor: 'pointer' }}>
+            <input
+              type="checkbox"
+              checked={draftSttEnabled}
+              onChange={(e) => onDraftSttEnabledChange(e.target.checked)}
+              disabled={disabled}
+              style={{ width: '16px', height: '16px' }}
+            />
+            Fast interim results (Moonshine Tiny JA)
+          </label>
+          <div style={{ marginTop: '4px', fontSize: '11px', color: '#94a3b8' }}>
+            Uses ultra-fast draft STT (27M params, 845ms) for instant interim transcription while primary STT processes final results. Japanese source only.
+          </div>
+          {draftSttEnabled && sourceLanguage === 'auto' && (
+            <div style={{ marginTop: '2px', fontSize: '11px', color: '#f59e0b' }}>
+              Warning: draft STT outputs Japanese only. Non-JA audio will produce incorrect interim results.
+            </div>
+          )}
         </div>
       )}
     </Section>

--- a/src/renderer/hooks/useLanguageSettings.ts
+++ b/src/renderer/hooks/useLanguageSettings.ts
@@ -12,6 +12,8 @@ export interface LanguageSettingsState {
   whisperVariant: WhisperVariantType
   setWhisperVariant: (v: WhisperVariantType) => void
   platform: string
+  draftSttEnabled: boolean
+  setDraftSttEnabled: (v: boolean) => void
 }
 
 export function useLanguageSettings(): LanguageSettingsState {
@@ -20,6 +22,7 @@ export function useLanguageSettings(): LanguageSettingsState {
   const [sttEngine, setSttEngine] = useState<SttEngineType>('mlx-whisper')
   const [whisperVariant, setWhisperVariant] = useState<WhisperVariantType>('kotoba-v2.0')
   const [platform, setPlatform] = useState<string>('darwin')
+  const [draftSttEnabled, setDraftSttEnabled] = useState(false)
 
   // Load language/STT settings on mount
   useEffect(() => {
@@ -28,6 +31,7 @@ export function useLanguageSettings(): LanguageSettingsState {
       if (s.whisperVariant) setWhisperVariant(str(s.whisperVariant, 'kotoba-v2.0') as WhisperVariantType)
       if (s.sourceLanguage) setSourceLanguage(str(s.sourceLanguage, 'auto') as SourceLanguage)
       if (s.targetLanguage) setTargetLanguage(str(s.targetLanguage, 'en') as Language)
+      if (s.draftSttEnabled !== undefined) setDraftSttEnabled(!!s.draftSttEnabled)
     })
 
     // Set platform-aware STT default (mlx-whisper on macOS)
@@ -58,6 +62,7 @@ export function useLanguageSettings(): LanguageSettingsState {
     targetLanguage, setTargetLanguage,
     sttEngine, setSttEngine,
     whisperVariant, setWhisperVariant,
-    platform
+    platform,
+    draftSttEnabled, setDraftSttEnabled
   }
 }

--- a/src/renderer/hooks/useSettingsState.ts
+++ b/src/renderer/hooks/useSettingsState.ts
@@ -64,6 +64,10 @@ export interface SettingsState {
   whisperVariant: WhisperVariantType
   setWhisperVariant: (v: WhisperVariantType) => void
 
+  // Draft STT
+  draftSttEnabled: boolean
+  setDraftSttEnabled: (v: boolean) => void
+
   // Subtitle
   subtitleFontSize: number
   setSubtitleFontSize: (v: number) => void
@@ -167,7 +171,8 @@ export function useSettingsState(): SettingsState {
         sourceLanguage: language.sourceLanguage,
         targetLanguage: language.targetLanguage,
         noiseSuppressionEnabled: session.noiseSuppression.enabled,
-        audioSource: session.audio.audioSource
+        audioSource: session.audio.audioSource,
+        draftSttEnabled: language.draftSttEnabled
       }), 10_000, 'saveSettings')
 
       const resolvedMode = resolveEngineMode(engine.engineMode, apiKeys, engine.gpuInfo)
@@ -290,6 +295,7 @@ export function useSettingsState(): SettingsState {
     sttEngine: language.sttEngine, setSttEngine: language.setSttEngine,
     whisperVariant: language.whisperVariant, setWhisperVariant: language.setWhisperVariant,
     platform: language.platform,
+    draftSttEnabled: language.draftSttEnabled, setDraftSttEnabled: language.setDraftSttEnabled,
 
     // Session
     status: session.status, setStatus: session.setStatus,


### PR DESCRIPTION
## Description

Integrates Moonshine Tiny JA (27M params, ~100MB) as an ultra-fast draft STT engine for real-time interim results. When enabled, streaming audio chunks are processed by both the draft STT (Moonshine, ~845ms) and the primary STT in parallel. Draft results appear instantly as interim text while the primary STT processes the final, higher-accuracy result.

### Changes

- **New engine**: `MoonshineTinyJaEngine.ts` — Python bridge STT engine using `transformers` pipeline with MPS/CPU support
- **Python bridge**: `resources/moonshine-tiny-ja-bridge.py` — subprocess bridge adapted from benchmark version
- **Dual-STT mode**: `StreamingProcessor` fires draft STT in parallel (fire-and-forget) and emits `draft-stt-result` events
- **Pipeline integration**: `EngineManager.initDraftStt()` for optional draft engine lifecycle, `TranslationPipeline.setDraftSttEnabled()`
- **Settings**: `draftSttEnabled` persisted in electron-store, UI toggle in STTSettings (shown when source language is JA or auto)
- **Japanese space stripping**: Model outputs "お は よ う" — regex strips spaces between CJK/Kana characters

### Key decisions

- Draft STT initialization failure is non-fatal — pipeline continues without fast interim results
- Draft STT only provides source text (no translation) — displayed as interim while primary STT + translator produce the final result
- Only shown when source language is JA or auto, with a warning for auto mode

Closes #536