### PR TITLE
#511 Add Windows cross-platform support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,3 +47,38 @@ jobs:
           files: dist/*.dmg
           draft: true
           generate_release_notes: true
+
+  build-windows:
+    name: Build Windows NSIS
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - run: npm ci
+
+      - name: Build and package NSIS installer
+        env:
+          # Windows code signing (optional — skip if secrets not set)
+          CSC_LINK: ${{ secrets.WIN_CSC_LINK }}
+          CSC_KEY_PASSWORD: ${{ secrets.WIN_CSC_KEY_PASSWORD }}
+        run: npm run package:win
+
+      - name: Upload NSIS artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: live-translate-windows-nsis
+          path: dist/*.exe
+          if-no-files-found: error
+
+      - name: Upload to GitHub Release
+        if: startsWith(github.ref, 'refs/tags/v')
+        uses: softprops/action-gh-release@v2
+        with:
+          files: dist/*.exe
+          draft: true
+          generate_release_notes: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,8 +12,11 @@ concurrency:
 
 jobs:
   typecheck:
-    name: Type Check
-    runs-on: ubuntu-latest
+    name: Type Check (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest]
     steps:
       - uses: actions/checkout@v4
 
@@ -22,15 +25,18 @@ jobs:
           node-version: 20
           cache: npm
 
-      # Skip postinstall (native addon scripts are macOS-only)
+      # Skip postinstall (native addon scripts are platform-specific)
       - run: npm ci --ignore-scripts
 
       # VAD assets are not needed for type checking
       - run: npm run typecheck
 
   test:
-    name: Unit Tests
-    runs-on: ubuntu-latest
+    name: Unit Tests (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest]
     steps:
       - uses: actions/checkout@v4
 
@@ -44,8 +50,11 @@ jobs:
       - run: npm run test
 
   build:
-    name: Vite Build
-    runs-on: ubuntu-latest
+    name: Vite Build (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest]
     steps:
       - uses: actions/checkout@v4
 

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -38,6 +38,9 @@ win:
       arch:
         - x64
   icon: build/icon.ico
+  asarUnpack:
+    - 'node_modules/@kutalia/whisper-node-addon/**'
+    - 'node_modules/node-llama-cpp/**'
 nsis:
   oneClick: false
   perMachine: false

--- a/scripts/after-pack.js
+++ b/scripts/after-pack.js
@@ -1,14 +1,21 @@
 // After-pack hook for electron-builder:
 // Recreate whisper-node-addon symlinks and fix rpath in the unpacked asar directory.
+// Handles both macOS (symlinks + rpath) and Windows (junctions).
 const fs = require('fs')
 const path = require('path')
 const { execSync } = require('child_process')
 
 exports.default = async function afterPack(context) {
-  // macOS-specific fixes: symlinks and rpath for whisper-node-addon
-  // Windows uses .dll and doesn't need these fixes
-  if (process.platform !== 'darwin') return
+  const platform = context.packager.platform.name // 'mac', 'windows', 'linux'
 
+  if (platform === 'mac') {
+    await fixMacOS(context)
+  } else if (platform === 'windows') {
+    await fixWindows(context)
+  }
+}
+
+async function fixMacOS(context) {
   const appOutDir = context.appOutDir
   const unpackedBase = path.join(
     appOutDir,
@@ -57,5 +64,46 @@ exports.default = async function afterPack(context) {
     }
   }
 
-  console.log('[after-pack] whisper-node-addon fixes applied')
+  console.log('[after-pack] macOS whisper-node-addon fixes applied')
+}
+
+async function fixWindows(context) {
+  const appOutDir = context.appOutDir
+  const unpackedBase = path.join(
+    appOutDir,
+    'resources',
+    'app.asar.unpacked',
+    'node_modules',
+    '@kutalia',
+    'whisper-node-addon',
+    'dist'
+  )
+
+  if (!fs.existsSync(unpackedBase)) {
+    console.log('[after-pack] whisper-node-addon dist not found in unpacked asar, skipping')
+    return
+  }
+
+  // Recreate win-x64 → win32-x64 junction (may be lost during packaging)
+  const symlinkMappings = [
+    { from: 'win-x64', to: 'win32-x64' }
+  ]
+
+  for (const { from, to } of symlinkMappings) {
+    const source = path.join(unpackedBase, from)
+    const target = path.join(unpackedBase, to)
+
+    if (fs.existsSync(source) && !fs.existsSync(target)) {
+      try {
+        fs.symlinkSync(source, target, 'junction')
+        console.log(`[after-pack] Created junction: ${to} -> ${from}`)
+      } catch (e) {
+        // Fallback: copy directory
+        fs.cpSync(source, target, { recursive: true })
+        console.log(`[after-pack] Copied directory: ${from} -> ${to}`)
+      }
+    }
+  }
+
+  console.log('[after-pack] Windows whisper-node-addon fixes applied')
 }

--- a/scripts/fix-whisper-addon.js
+++ b/scripts/fix-whisper-addon.js
@@ -1,7 +1,8 @@
-// Fix whisper-node-addon issues on macOS:
-// 1. Directory naming: addon expects 'darwin-arm64' but ships as 'mac-arm64'
-// 2. dylib rpath: libraries have hardcoded build paths, need to add local rpath
-// 3. Copy vad-web assets to renderer public dir for serving
+// Fix whisper-node-addon platform-specific issues:
+// macOS: 1. Directory naming (mac-arm64 → darwin-arm64 symlink)
+//        2. dylib rpath (hardcoded build paths → local rpath)
+// Windows: 3. Directory naming (win-x64 → win32-x64 symlink)
+// All platforms: 4. Copy vad-web assets to renderer public dir for serving
 const fs = require('fs')
 const path = require('path')
 const { execSync } = require('child_process')
@@ -13,7 +14,7 @@ if (!fs.existsSync(addonDist)) {
   process.exit(0)
 }
 
-// Fix 1: Create symlinks for platform naming (macOS only)
+// Fix 1: Create symlinks for platform naming (macOS)
 if (process.platform === 'darwin') {
   const symlinkMappings = [
     { from: 'mac-arm64', to: 'darwin-arm64' },
@@ -29,8 +30,6 @@ if (process.platform === 'darwin') {
       console.log(`[fix-whisper-addon] Created symlink: ${to} -> ${from}`)
     }
   }
-} else {
-  console.log('[fix-whisper-addon] Skipping symlinks on non-macOS platform')
 }
 
 // Fix 2: Add rpath for dylib loading (macOS only)
@@ -45,6 +44,32 @@ if (process.platform === 'darwin') {
       console.log(`[fix-whisper-addon] Added rpath: ${addonDir}`)
     } catch (e) {
       console.warn(`[fix-whisper-addon] Failed to add rpath: ${e.message}`)
+    }
+  }
+}
+
+// Fix 3: Create symlinks for platform naming (Windows)
+// whisper-node-addon ships 'win-x64' but Node.js resolves 'win32-x64'
+if (process.platform === 'win32') {
+  const symlinkMappings = [
+    { from: 'win-x64', to: 'win32-x64' }
+  ]
+
+  for (const { from, to } of symlinkMappings) {
+    const source = path.join(addonDist, from)
+    const target = path.join(addonDist, to)
+
+    if (fs.existsSync(source) && !fs.existsSync(target)) {
+      try {
+        // Use junction on Windows (doesn't require admin privileges unlike symlinks)
+        fs.symlinkSync(source, target, 'junction')
+        console.log(`[fix-whisper-addon] Created junction: ${to} -> ${from}`)
+      } catch (e) {
+        // Fallback: copy directory if junction fails (e.g. on FAT32)
+        console.warn(`[fix-whisper-addon] Junction failed, copying directory: ${e.message}`)
+        fs.cpSync(source, target, { recursive: true })
+        console.log(`[fix-whisper-addon] Copied directory: ${from} -> ${to}`)
+      }
     }
   }
 }

--- a/src/engines/hardware-recommender.ts
+++ b/src/engines/hardware-recommender.ts
@@ -43,6 +43,12 @@ function isAppleSilicon(platform: string, gpuInfo: GpuInfo): boolean {
   )
 }
 
+/** Detect if running on Windows with NVIDIA CUDA-capable GPU */
+function hasNvidiaCuda(platform: string, gpuInfo: GpuInfo): boolean {
+  if (platform !== 'win32') return false
+  return gpuInfo.gpuNames.some((name) => /nvidia|geforce|rtx|gtx/i.test(name))
+}
+
 /**
  * Recommend optimal engines based on hardware capabilities.
  *
@@ -144,7 +150,58 @@ export function recommendEngines(
     }
   }
 
-  // Non-Apple Silicon (Intel Mac or other platforms)
+  // Windows with NVIDIA GPU: CUDA-accelerated Whisper + GGUF translation
+  const nvidiaCuda = hasNvidiaCuda(platform, gpuInfo)
+
+  if (nvidiaCuda && totalMemoryMB >= 16384) {
+    // Windows + NVIDIA + 16GB+: Whisper Local (CUDA) + HY-MT1.5
+    const whisperVariant: WhisperVariant = 'base'
+    if (!isModelDownloaded(whisperVariant)) {
+      const v = WHISPER_VARIANTS[whisperVariant]
+      downloads.push({ type: 'whisper', key: whisperVariant, filename: v.filename, url: v.url, sizeMB: v.sizeMB, label: v.label })
+    }
+    const gguf = HUNYUAN_MT_15_VARIANTS['Q4_K_M']
+    if (!isGGUFDownloaded(gguf.filename)) {
+      downloads.push({ type: 'gguf', key: gguf.filename, filename: gguf.filename, url: gguf.url, sizeMB: gguf.sizeMB, label: gguf.label })
+    }
+
+    return {
+      sttEngine: 'whisper-local' as const,
+      translationEngine: 'offline-hymt15',
+      whisperVariant,
+      downloads,
+      totalDownloadMB: downloads.reduce((sum, d) => sum + d.sizeMB, 0),
+      needsDownload: downloads.length > 0,
+      fallbackEngine: downloads.length > 0 ? 'offline-opus' : null,
+      reason: 'Windows with NVIDIA GPU + 16GB+ RAM — using CUDA Whisper + HY-MT 1.5 for best offline quality'
+    }
+  }
+
+  if (nvidiaCuda && totalMemoryMB >= 8192) {
+    // Windows + NVIDIA + 8GB+: Whisper Local (CUDA) + LFM2
+    const whisperVariant: WhisperVariant = 'base'
+    if (!isModelDownloaded(whisperVariant)) {
+      const v = WHISPER_VARIANTS[whisperVariant]
+      downloads.push({ type: 'whisper', key: whisperVariant, filename: v.filename, url: v.url, sizeMB: v.sizeMB, label: v.label })
+    }
+    const gguf = LFM2_VARIANTS['Q4_K_M']
+    if (!isGGUFDownloaded(gguf.filename)) {
+      downloads.push({ type: 'gguf', key: gguf.filename, filename: gguf.filename, url: gguf.url, sizeMB: gguf.sizeMB, label: gguf.label })
+    }
+
+    return {
+      sttEngine: 'whisper-local' as const,
+      translationEngine: 'offline-lfm2',
+      whisperVariant,
+      downloads,
+      totalDownloadMB: downloads.reduce((sum, d) => sum + d.sizeMB, 0),
+      needsDownload: downloads.length > 0,
+      fallbackEngine: downloads.length > 0 ? 'offline-opus' : null,
+      reason: 'Windows with NVIDIA GPU + 8GB RAM — using CUDA Whisper + LFM2 for lightweight offline translation'
+    }
+  }
+
+  // Non-Apple Silicon, no NVIDIA CUDA (Intel Mac, Windows without GPU, or Linux)
   const sttEngine = 'whisper-local' as const
   const whisperVariant: WhisperVariant = 'base'
 
@@ -161,6 +218,6 @@ export function recommendEngines(
     totalDownloadMB: downloads.reduce((sum, d) => sum + d.sizeMB, 0),
     needsDownload: downloads.length > 0,
     fallbackEngine: null,
-    reason: 'Non-Apple Silicon — using Whisper Local (base) + OPUS-MT for broad compatibility'
+    reason: 'Using Whisper Local (base) + OPUS-MT for broad compatibility'
   }
 }

--- a/src/renderer/components/settings/AudioSettings.tsx
+++ b/src/renderer/components/settings/AudioSettings.tsx
@@ -47,6 +47,11 @@ export function AudioSettings({ audio, disabled, noiseSuppressionEnabled, onNois
             {' '}— Requires Screen Recording permission
           </span>
         )}
+        {audio.audioSource !== 'microphone' && platform === 'win32' && (
+          <span style={{ color: '#94a3b8' }}>
+            {' '}— Uses WASAPI loopback (no extra setup needed)
+          </span>
+        )}
       </div>
       {/* Microphone device selector — hidden when system-only mode */}
       {showMicSelector && (

--- a/src/renderer/components/settings/QuickStartPanel.tsx
+++ b/src/renderer/components/settings/QuickStartPanel.tsx
@@ -107,7 +107,7 @@ export function QuickStartPanel({ onSetupComplete }: QuickStartPanelProps): Reac
           <div style={infoRowStyle}>
             <span style={infoLabelStyle}>Platform</span>
             <span style={infoValueStyle}>
-              {systemInfo.platform === 'darwin' ? 'macOS' : systemInfo.platform}
+              {systemInfo.platform === 'darwin' ? 'macOS' : systemInfo.platform === 'win32' ? 'Windows' : systemInfo.platform}
             </span>
           </div>
           <div style={infoRowStyle}>

--- a/src/renderer/hooks/useAudioCapture.ts
+++ b/src/renderer/hooks/useAudioCapture.ts
@@ -137,7 +137,11 @@ export function useAudioCapture(noiseSuppression?: NoiseSuppressionProcessor, st
         // #48: surface permission errors to UI with specific messages
         const message = err instanceof Error ? err.message : String(err)
         if (message.includes('NotAllowedError') || message.includes('Permission')) {
-          setPermissionError('Microphone access denied. Please grant permission in System Settings > Privacy & Security > Microphone.')
+          // Platform-specific permission guidance
+          const permissionHint = navigator.userAgent.includes('Windows')
+            ? 'Please grant permission in Windows Settings > Privacy > Microphone.'
+            : 'Please grant permission in System Settings > Privacy & Security > Microphone.'
+          setPermissionError(`Microphone access denied. ${permissionHint}`)
         } else if (message.includes('NotFoundError') || message.includes('DevicesNotFoundError')) {
           setPermissionError('No microphone detected. Please connect a microphone and restart.')
         } else if (message.includes('NotReadableError') || message.includes('TrackStartError')) {

--- a/src/renderer/hooks/useLanguageSettings.ts
+++ b/src/renderer/hooks/useLanguageSettings.ts
@@ -34,12 +34,16 @@ export function useLanguageSettings(): LanguageSettingsState {
       if (s.draftSttEnabled !== undefined) setDraftSttEnabled(!!s.draftSttEnabled)
     })
 
-    // Set platform-aware STT default (mlx-whisper on macOS)
+    // Set platform-aware STT default (mlx-whisper on macOS, whisper-local on Windows)
     window.api.getPlatform().then((p) => {
       setPlatform(p)
       window.api.getSettings().then((s) => {
-        if (!s.sttEngine && p === 'darwin') {
-          setSttEngine('mlx-whisper')
+        if (!s.sttEngine) {
+          if (p === 'darwin') {
+            setSttEngine('mlx-whisper')
+          } else {
+            setSttEngine('whisper-local')
+          }
         }
       })
     }).catch((e) => console.warn('[settings] Failed to load platform/settings:', e))


### PR DESCRIPTION
## Description

Add Windows cross-platform support for CI, build, native addon postinstall, hardware recommendation, and UI platform hints.

### Changes

**CI/CD:**
- Add `build-windows` job to `build.yml` (Windows NSIS installer on `windows-latest`)
- Add `windows-latest` to CI matrix for typecheck, unit tests, and Vite build in `ci.yml`

**Native Addon (whisper-node-addon):**
- `fix-whisper-addon.js`: Add Windows `win-x64` → `win32-x64` junction/copy in postinstall
- `after-pack.js`: Add Windows packaging path (`resources/app.asar.unpacked/`) with junction recreation

**electron-builder:**
- Add Windows-specific `asarUnpack` for whisper-node-addon and node-llama-cpp DLLs

**Hardware Recommender:**
- Add NVIDIA CUDA GPU detection (`hasNvidiaCuda`) for Windows
- Add Windows + NVIDIA recommendation paths: 16GB+ → CUDA Whisper + HY-MT 1.5, 8GB+ → CUDA Whisper + LFM2

**UI Platform Awareness:**
- `useAudioCapture.ts`: Platform-specific mic permission error messages (Windows Settings vs System Settings)
- `AudioSettings.tsx`: Show "WASAPI loopback (no extra setup needed)" hint on Windows for system audio
- `QuickStartPanel.tsx`: Display "Windows" instead of raw `win32` platform string
- `useLanguageSettings.ts`: Default to `whisper-local` on non-macOS platforms

### Notes

- System audio loopback already works cross-platform via `electron-audio-loopback` (IPC handlers registered by `initMain()`)
- macOS-only engines (MLX Whisper, Kotoba, Qwen3-ASR, ANE) already guarded by `process.platform === 'darwin'`
- Model storage uses `app.getPath('userData')` (cross-platform)
- Audio capture uses platform-agnostic Web Audio API + Silero VAD

Closes #511