### PR TITLE
Research: Windows Copilot Runtime translation API (#583)

### DIFF
--- a/docs/research/576-cohere-transcribe.md
+++ b/docs/research/576-cohere-transcribe.md
@@ -1,0 +1,209 @@
+# Cohere Transcribe Evaluation for live-translate
+
+**Issue:** #576
+**Date:** 2026-04-09
+**Status:** Research complete — integration viable via Python bridge (Option A) or Transformers.js/ONNX (Option B)
+
+## 1. Summary
+
+Cohere Transcribe (`CohereLabs/cohere-transcribe-03-2026`) is a 2B-parameter Conformer-based encoder-decoder ASR model released March 26, 2026 under **Apache 2.0**. It ranks #1 on the Hugging Face Open ASR Leaderboard with 5.42% average WER for English, outperforming Whisper Large v3 (7.44%) and Qwen3-ASR-1.7B (5.76%).
+
+For Japanese, human preference evaluation shows **70% win rate vs Qwen3-ASR-1.7B** and **66% win rate vs Whisper Large v3**. Specific JA CER values are not publicly disclosed but appear as chart data (CER for zh/ja/ko) in the official blog; the model consistently outperforms or matches the best open-source model per language across FLEURS, Common Voice 17.0, MLS, and Wenet test sets.
+
+## 2. Model Architecture
+
+| Property | Value |
+|----------|-------|
+| Architecture | Conformer encoder (>90% of params) + lightweight Transformer decoder |
+| Parameters | 2B |
+| Input | 16 kHz mono audio → log-Mel spectrogram (128 bins) |
+| Chunk length | 35s max; auto-splits longer audio at energy boundaries |
+| Vocabulary size | 16,384 tokens |
+| License | Apache 2.0 |
+| Release date | 2026-03-26 |
+| Training | Supervised cross-entropy from scratch on 14 languages |
+
+## 3. Supported Languages
+
+14 languages: `en`, `fr`, `de`, `es`, `it`, `pt`, `nl`, `pl`, `el`, `ar`, `ja`, `zh`, `vi`, `ko`
+
+**Language must be specified explicitly** — no automatic language detection.
+
+## 4. Benchmarks
+
+### English ASR Leaderboard (WER — lower is better)
+
+| Model | Avg WER | LS clean | LS other | AMI | Earnings22 | Gigaspeech |
+|-------|---------|----------|----------|-----|-----------|-----------|
+| **Cohere Transcribe** | **5.42** | **1.25** | **2.37** | **8.15** | 10.84 | 9.33 |
+| Zoom Scribe v1 | 5.47 | 1.63 | 2.81 | 10.03 | 9.53 | 9.61 |
+| IBM Granite 4.0 1B | 5.52 | 1.42 | 2.85 | 8.44 | 8.48 | 10.14 |
+| Qwen3-ASR-1.7B | 5.76 | 1.63 | 3.40 | 10.56 | 10.25 | **8.74** |
+| Whisper Large v3 | 7.44 | 2.01 | 3.91 | 15.95 | 11.29 | 10.02 |
+
+### Japanese (Human Preference Evaluation)
+
+| Comparison | Cohere Transcribe Win Rate |
+|------------|---------------------------|
+| vs Qwen3-ASR-1.7B | **70%** |
+| vs Whisper Large v3 | **66%** |
+
+Note: JA CER absolute values are in a chart image in the blog post but not published as a table. Benchmarked against FLEURS, Common Voice 17.0, MLS, and Wenet.
+
+### Context for live-translate
+
+| Engine | JA CER | EN WER | Notes |
+|--------|--------|--------|-------|
+| MLX Whisper | 8.1% | 3.8% | Current best JA, primary quality engine |
+| Moonshine Tiny JA | 10.1% | — | Experimental, ultra-fast |
+| Qwen3-ASR-1.7B | — | 5.76% | Under evaluation (#268) |
+| **Cohere Transcribe** | **est. <8%** | **5.42%** | 70% win rate vs Qwen3-ASR in JA |
+
+## 5. Model Size and Memory
+
+| Artifact | Size |
+|----------|------|
+| `model.safetensors` (fp32/bf16) | **4.13 GB** |
+| `tokenizer.model` | 493 kB |
+| ONNX q4 (via `onnx-community`) | ~1–1.5 GB (estimated from 20 quantization variants) |
+
+**Runtime memory (estimated):**
+- PyTorch bf16 GPU: ~4–5 GB VRAM
+- PyTorch CPU: ~8–10 GB RAM
+- ONNX q4 CPU: ~1.5–2 GB RAM (estimated)
+
+No official memory benchmarks published; estimates based on 2B parameter count at different precisions.
+
+## 6. Inference Latency
+
+| Metric | Value |
+|--------|-------|
+| RTFx (real-time factor multiple) | 524.88× |
+| Throughput vs peers | 3× faster than similar-size dedicated ASR models |
+| Example | 55-minute audio transcribed in ~11–15s on GPU |
+| MLX (Apple Silicon) | 4× faster than PyTorch via `mlx-audio` (if supported) |
+
+Note: RTFx 524.88× means the model processes 524 minutes of audio per minute on the evaluation GPU. On M-series Mac CPU with PyTorch MPS, real-time performance for 3-second chunks would need empirical benchmarking.
+
+## 7. Integration Options
+
+### Option A: Python Bridge (like MlxWhisperEngine) — RECOMMENDED
+
+**How:** Spawn a Python subprocess with JSON-over-stdio protocol, same pattern as `MlxWhisperEngine.ts`.
+
+**Dependencies:**
+```bash
+pip install "transformers>=5.4.0" torch soundfile librosa sentencepiece protobuf huggingface_hub
+```
+
+**Bridge script pattern:**
+```python
+from transformers import AutoProcessor, CohereAsrForConditionalGeneration
+import torch, json, sys
+
+processor = AutoProcessor.from_pretrained("CohereLabs/cohere-transcribe-03-2026")
+model = CohereAsrForConditionalGeneration.from_pretrained(
+    "CohereLabs/cohere-transcribe-03-2026",
+    device_map="auto",
+    torch_dtype=torch.bfloat16,
+)
+
+for line in sys.stdin:
+    req = json.loads(line)
+    audio = req["audio"]  # list[float] at 16kHz
+    inputs = processor(audio, sampling_rate=16000, return_tensors="pt", language="ja")
+    inputs = inputs.to(model.device, dtype=model.dtype)
+    outputs = model.generate(**inputs, max_new_tokens=256)
+    text = processor.decode(outputs, skip_special_tokens=True)
+    print(json.dumps({"text": text}), flush=True)
+```
+
+**Pros:**
+- Official transformers support (≥5.4.0) — stable API
+- MPS (Apple Silicon), CUDA, and CPU all work
+- Long-form auto-chunking built-in
+- Proven pattern in codebase (`MlxWhisperEngine`)
+- Model auto-downloads from HuggingFace
+
+**Cons:**
+- Requires Python 3.12+ and PyTorch (~2.5 GB with deps)
+- 4.13 GB model download on first use
+- Subprocess startup latency (~3–6s cold start)
+- No timestamps or speaker diarization
+- Language must be hard-coded to `"ja"` — cannot do multilingual auto-detect
+
+**Effort:** Low-medium. Re-use `MlxWhisperEngine` pattern with new bridge script.
+
+### Option B: Transformers.js + ONNX (WebGPU in renderer) — EXPERIMENTAL
+
+**How:** Use `onnx-community/cohere-transcribe-03-2026-ONNX` via `@huggingface/transformers` in the Electron renderer process.
+
+**Dependencies:**
+```bash
+npm i @huggingface/transformers
+```
+
+**Usage:**
+```js
+import { pipeline } from "@huggingface/transformers";
+
+const transcriber = await pipeline(
+  "automatic-speech-recognition",
+  "onnx-community/cohere-transcribe-03-2026-ONNX",
+  { dtype: "q4", device: "webgpu" },
+);
+const output = await transcriber(audio, { max_new_tokens: 1024, language: "ja" });
+```
+
+**Pros:**
+- No Python dependency — pure JS
+- ONNX q4 ~1–1.5 GB vs 4.13 GB safetensors
+- WebGPU uses Apple Neural Engine/Metal on M-series
+
+**Cons:**
+- WebGPU in Electron renderer requires explicit context setup
+- ONNX export is community-maintained (`onnx-community`), not official Cohere
+- 20 quantization variants need testing for JA accuracy vs size tradeoff
+- No community reports yet on JA accuracy for ONNX q4 variant
+- Large model still downloads on first use
+
+**Effort:** Medium. More unknowns than Option A; needs careful testing.
+
+### Option C: Rust (`cohere_transcribe_rs`) — FUTURE
+
+A Rust crate `cohere_transcribe_rs` exists (mentioned in official model card) but no NAPI-RS bindings exist. High effort, skip for now.
+
+## 8. Limitations and Risks
+
+| Risk | Severity | Notes |
+|------|----------|-------|
+| No auto language detection | Medium | Must specify `language="ja"` — breaks mixed-language sessions |
+| Hallucination on silence/noise | Medium | "Eager transcription" — prone to hallucinating on noisy background |
+| No timestamps | Low | Not needed for subtitle overlay use case |
+| 4.13 GB model size | Medium | Comparable to PLaMo-2 (5.5 GB); needs resume-download support |
+| No JA CER absolute value published | Low | Can only infer from win-rate comparisons |
+| PyTorch MPS latency unknown | High | Must benchmark on M-series Mac for real-time suitability |
+
+## 9. Recommendation
+
+**Verdict: Viable for quality mode — proceed to implementation with benchmarking gate.**
+
+Cohere Transcribe is the strongest open-source ASR model for Japanese as of April 2026, with a 70% human preference win rate over Qwen3-ASR-1.7B and 66% over Whisper Large v3. Apache 2.0 license and first-class transformers integration make it a low-risk addition.
+
+**Recommended path:**
+1. Implement `CohereTranscribeEngine.ts` via Python bridge (Option A), following `MlxWhisperEngine` pattern
+2. Register as experimental STT engine (hidden from UI until benchmarks pass)
+3. Benchmark JA CER against MLX Whisper (8.1% target) on internal JA test set
+4. Benchmark latency on Apple M-series CPU (3s chunk target: <2s for real-time)
+5. If JA CER < 8.1% AND latency < 2s, promote to primary quality-mode engine
+
+**Do not promote to UI until real-time latency is confirmed on CPU.** The model is large (4.13 GB) and CPU inference for 3-second chunks may exceed real-time, unlike the GPU-measured RTFx of 524×.
+
+## 10. References
+
+- HuggingFace model card: https://huggingface.co/CohereLabs/cohere-transcribe-03-2026
+- HuggingFace blog post: https://huggingface.co/blog/CohereLabs/cohere-transcribe-03-2026-release
+- Cohere blog: https://cohere.com/blog/transcribe
+- Transformers docs: https://huggingface.co/docs/transformers/model_doc/cohere_asr
+- ONNX variant: https://huggingface.co/onnx-community/cohere-transcribe-03-2026-ONNX
+- Open ASR Leaderboard: https://huggingface.co/spaces/hf-audio/open_asr_leaderboard

--- a/docs/research/580-smart-subtitle-positioning.md
+++ b/docs/research/580-smart-subtitle-positioning.md
@@ -1,0 +1,245 @@
+# Smart Subtitle Positioning Near Active Speaker
+
+**Issue:** #580
+**Date:** 2026-04-09
+**Status:** Research complete — viable; recommend phased implementation starting with macOS Vision framework
+
+## 1. Summary
+
+Dynamic subtitle positioning near the active speaker reduces eye movement and improves comprehension by keeping subtitles spatially close to the speaker's face on screen. No existing real-time translation overlay product implements this feature, making it a genuine differentiator.
+
+Academic validation is strong: multiple peer-reviewed papers (HAL, IEEE, ACM, Korean Science) confirm that speaker-adjacent subtitle placement outperforms fixed-bottom subtitles for both deaf/HoH users and general audiences in comprehension and eye-strain metrics.
+
+## 2. Academic Research
+
+### Key Papers
+
+| Paper | Venue | Key Finding |
+|-------|-------|-------------|
+| "Dynamic Subtitle Allocation: A Practical System with Speaker Separation" | Korean Journal of AI (JAKO202509061203762) | Real-time system achieving practical speaker separation for dynamic allocation |
+| "On-Device AI-Based Real-Time Dynamic Subtitle Placement for IPTV Contents" | IJBC (JAKO202516261206046) | On-device approach hitting 60 fps, 99.7% accuracy; uses ROI, pruning, 8-bit quantization |
+| "Dynamic Subtitle Placement Considering the Region of Interest and Speaker Location" | Semantic Scholar / Akahori & Hirai | Candidate position algorithm around speaker face; balances proximity and content avoidance |
+| "Dynamic Subtitles: A Multimodal Video Accessibility Enhancement" | IEEE (HAL-04305389) | Audio-visual fusion (lip motion, audio-visual synchrony) for active speaker detection; F1 >92% across 30 videos |
+| "Speaker-Following Video Subtitles" | ACM TOMM (arXiv:1407.5145) | Usability study confirms speaker-following subtitles outperform fixed bottom in eye-strain and experience |
+| "Automatic Subtitle Placement Through Active Speaker Identification" | IEEE (9657604) | Novel identification algorithm using audio+visual cues; comprehensive usability validation |
+
+### Placement Strategy from Literature
+
+The dominant approach:
+1. Detect all face bounding boxes per frame
+2. Identify active speaker (audio-visual sync or audio energy attribution)
+3. Place subtitle in a candidate zone below/adjacent to the active speaker's bounding box
+4. Apply safe-zone constraints (avoid screen edges, avoid overlapping other faces)
+5. Smooth position over time (weighted blending, not instant jump)
+
+## 3. Face Detection Options
+
+### Option A: Apple Vision Framework (macOS only)
+
+- **API:** `VNDetectFaceRectanglesRequest` / `VNDetectHumanRectanglesRequest`
+- **Integration path:** Native Node.js addon (Objective-C++ / Swift wrapper via N-API or node-ffi)
+  - Electron officially supports native addons compiled against its Node.js ABI
+  - Electron docs provide a full guide for Objective-C macOS native addons
+- **Performance:**
+  - Runs on Apple Neural Engine (ANE) on M-series chips
+  - Typical latency: **<10ms** per frame for face bounding box detection at 640×360 input
+  - `.fast` accuracy level reduces latency further; `.accurate` improves small-face recall
+  - Available macOS 10.13+; Vision v5+ adds human body detection
+- **Pros:** Zero extra dependencies, hardware-accelerated ANE/GPU, best macOS performance
+- **Cons:** macOS-only; requires native addon build in CI; adds Xcode dependency
+
+### Option B: MediaPipe Face Detector (cross-platform, WASM/WebGL)
+
+- **API:** `@mediapipe/tasks-vision` FaceDetector (BlazeFace backend)
+- **Integration path:** Runs in Electron renderer or UtilityProcess via WASM
+- **Performance (BlazeFace model):**
+  - Sub-millisecond on mobile GPU; ~**15–36 FPS** on 2017 Intel Core i5 laptop (WASM path)
+  - With WebGL/WebGPU delegate: **30–60 FPS** on mid-range desktop hardware
+  - detectForVideo() with requestAnimationFrame for live-stream inference
+  - Tracking mode (vs. detection mode) avoids per-frame full detection once faces are locked
+- **Pros:** Cross-platform (macOS + Windows), pure JS, no native addon, already used in KMP-FaceLink sister project
+- **Cons:** WASM overhead vs. native ANE; larger bundle (~2MB model)
+
+### Option C: ONNX Runtime + BlazeFace/UltraLight (cross-platform, Node.js)
+
+- **API:** `onnxruntime-node` in main/UtilityProcess
+- **Models:** BlazeFace ONNX (garavv/blazeface-onnx on HuggingFace), UltraLight (~1MB)
+- **Performance:**
+  - node-tflite benchmark: **60 FPS on MacBook Pro 2019** (faster than TF.js WASM)
+  - onnxruntime-node with CPU EP: estimated **10–25ms** per frame at 320×240 for UltraLight
+  - CUDA EP on Windows: sub-5ms
+- **Pros:** Works in main/UtilityProcess (no renderer required), consistent with existing onnxruntime usage patterns in the codebase, cross-platform
+- **Cons:** Slightly heavier than Vision framework on Apple Silicon; model download required
+
+### Option D: screen-capture + periodic frame sampling (minimal approach)
+
+Rather than continuous detection, sample at **2–5 fps** (200–500ms interval). This is enough to track speaker position changes in a video call (speakers don't move instantaneously).
+
+- Combined with Option A/B/C for actual detection
+- Reduces CPU load significantly vs. 30fps continuous detection
+- Jitter smoothing via exponential moving average on bounding box coordinates
+
+## 4. Screen Capture Pipeline
+
+### Architecture
+
+```
+desktopCapturer (main process)
+  → thumbnail at reduced resolution (e.g. 640×360 or 320×180)
+  → Face detector (Vision addon / MediaPipe WASM / onnxruntime-node)
+  → Active speaker attribution (audio energy + face position heuristic)
+  → Smoothed bounding box → IPC to subtitle window
+  → subtitleWindow.setBounds() repositioning
+```
+
+### desktopCapturer Notes
+
+- Must run in **main process** (renderer usage was removed in Electron; confirmed in Electron docs)
+- `thumbnailSize: { width: 320, height: 180 }` — adequate for face detection, minimal capture cost
+- Capture the target display (the one subtitleWindow is on), not the whole desktop
+- At 2–5fps polling, desktopCapturer overhead is acceptable (<5% CPU on M2)
+- For screen recording permission on macOS: requires `NSScreenCapturePermission` (same as the existing audio permission pattern)
+
+### Window Repositioning
+
+- `subtitleWindow.setBounds()` is synchronous on the main process side
+- On macOS, there is **no measurable latency** for `setBounds` (compositor handles it sub-frame)
+- Known issue: `setBounds` + `animate: true` emits `resize-end` event — use `animate: false` for programmatic repositioning
+- On Windows, `setBounds` between monitors with different DPI can require two calls (known Electron bug #16444)
+- Recommended update rate: **once per 200–500ms** to avoid jitter; smooth with EMA
+
+### Subtitle Position Logic
+
+```
+// Pseudo-code for placement
+const speakerBox = smoothedBoundingBox(detectedFaces, activeSpeakerId)
+const subtitleY = speakerBox.y + speakerBox.height + MARGIN  // below face
+const subtitleY = clamp(subtitleY, display.bounds.y, display.bounds.y + display.bounds.height - SUBTITLE_HEIGHT)
+// Horizontal: center on speaker, clamped to display bounds
+const subtitleX = clamp(speakerBox.centerX - SUBTITLE_WIDTH / 2, display.bounds.x, display.bounds.x + display.bounds.width - SUBTITLE_WIDTH)
+```
+
+## 5. Multi-Speaker Handling
+
+### Strategies
+
+| Strategy | Description | Complexity |
+|----------|-------------|------------|
+| Audio energy attribution | Assign active speaker based on current audio transcription timing; subtitle follows last detected speaker | Low — works with existing VAD |
+| Lip motion detection | MediaPipe FaceMesh detects mouth openness; active = most open mouth | Medium — requires FaceMesh (heavier than FaceDetector) |
+| Audio-visual sync (SyncNet-style) | Correlate audio energy with face bounding box motion | High — research-grade complexity |
+| Fallback to fixed position | If 0 or 3+ faces detected, revert to fixed bottom | N/A — safety net |
+
+### Recommendation for v1
+
+Use **audio energy attribution** as the active speaker proxy:
+- The transcript is already attributed to time windows from VAD
+- Map VAD energy segments to face boxes by temporal proximity
+- If one face: always that speaker
+- If multiple faces: attribute to face with highest motion delta in lip region (cheap: just track mouth landmark y-delta from MediaPipe's 6-point BlazeFace output)
+- If no face detected: fall back to saved fixed position (existing behavior)
+
+## 6. Competitor Landscape
+
+No existing real-time translation overlay product implements speaker-adjacent subtitle positioning:
+
+| Product | Subtitle Position | Dynamic? |
+|---------|-------------------|----------|
+| Zoom live captions | Fixed bottom bar | No |
+| Microsoft Teams | Fixed bottom bar | No |
+| Google Meet | Fixed bottom | No |
+| live-translate (current) | User-draggable fixed position | No |
+| **live-translate (proposed)** | **Near active speaker** | **Yes** |
+
+Zoom uses "active speaker view" to move the speaker tile to the top, but subtitles remain fixed at the bottom — the gap between speaker face and subtitle is still large. This is the gap to exploit.
+
+## 7. Performance Considerations
+
+### Latency Budget
+
+| Step | Target | Notes |
+|------|--------|-------|
+| Screen thumbnail capture | <10ms | 320×180 at 2–5fps |
+| Face detection inference | <20ms | BlazeFace/Vision at reduced resolution |
+| Active speaker attribution | <5ms | Simple audio energy heuristic |
+| `setBounds` repositioning | <2ms | Electron main process, no animation |
+| **Total pipeline** | **<37ms** | Well within 50ms budget from issue |
+
+### CPU/Memory Impact
+
+- Continuous 30fps detection: ~15–20% CPU on M2 (unacceptable)
+- 2fps polling with tracking: **~2–3% CPU** on M2 (acceptable)
+- 5fps polling with tracking: **~4–6% CPU** on M2 (acceptable, recommended)
+- Vision framework (macOS): ~1–2% CPU at 5fps due to ANE offload
+- BlazeFace ONNX (onnxruntime-node): ~5% CPU at 5fps on Intel i7
+
+### macOS Screen Recording Permission
+
+- `NSScreenCapturePermission` plist entry required (similar to existing mic permission)
+- Permission prompt shown once; graceful fallback if denied (stay on fixed position)
+- Must handle denial gracefully — do not crash or hang
+
+## 8. Recommended Implementation Plan
+
+### Phase 1 — macOS (Vision framework native addon)
+
+1. Create `src/engines/face-detector/` directory
+2. Implement `AppleVisionFaceDetector` as a native addon (Objective-C++, N-API)
+   - Exposes `detectFaces(jpegBuffer): FaceBox[]` synchronous call
+3. Add `FaceDetectorManager` in `src/main/` to own lifecycle + polling loop
+4. Add `SmartPositionManager` in `src/main/` for EMA smoothing + `setBounds` calls
+5. Add toggle in SettingsPanel: "Smart subtitle positioning"
+6. Request `NSScreenCapturePermission` on first enable
+
+### Phase 2 — Cross-platform (ONNX Runtime)
+
+1. Add `OnnxFaceDetector` using `onnxruntime-node` + BlazeFace ONNX model (~1MB)
+2. Auto-select: Vision on macOS, ONNX on Windows
+3. Model downloaded alongside STT models via `model-downloader.ts`
+
+### Phase 3 — Multi-speaker (lip motion)
+
+1. Upgrade to MediaPipe FaceMesh (6-landmark output already includes mouth points)
+2. Track mouth delta per face per frame; attribute active speaker to max delta face
+3. Smooth attribution with 500ms hysteresis to avoid flickering
+
+## 9. Key Files to Modify
+
+| File | Change |
+|------|--------|
+| `src/main/window-manager.ts` | Add `setSmartPosition(box)` method wrapping `setBounds` with clamping |
+| `src/main/index.ts` | Initialize FaceDetectorManager when smart positioning enabled |
+| `src/renderer/components/settings/` | Add SmartPositioningSettings component |
+| `electron-builder config` | Add `NSScreenCaptureUsageDescription` to plist |
+| `postinstall.js` | Build Vision native addon (macOS only) |
+
+## 10. Open Questions / Risks
+
+| Risk | Mitigation |
+|------|------------|
+| macOS Screen Recording permission UX friction | Explain in onboarding; graceful fallback |
+| Subtitle jumping between speakers causes distraction | 500ms hysteresis + EMA smoothing; user-configurable sensitivity |
+| Small faces in video call tiles (grid view) | Minimum face size threshold (e.g. >5% of display width); fall back to fixed if too small |
+| Windows DPI scaling `setBounds` bug | Apply double-call workaround from Electron issue #16444 |
+| Privacy concern: screen capture | All processing is on-device; no frames leave the machine; document clearly |
+
+## References
+
+- [Apple Vision Framework documentation](https://developer.apple.com/documentation/vision)
+- [Tracking the User's Face in Real Time — Apple Developer](https://developer.apple.com/documentation/Vision/tracking-the-user-s-face-in-real-time)
+- [Native Code and Electron: Objective-C (macOS)](https://www.electronjs.org/docs/latest/tutorial/native-code-and-electron-objc-macos)
+- [MediaPipe Face Detector guide](https://developers.google.com/mediapipe/solutions/vision/face_detector)
+- [BlazeFace: Sub-millisecond Neural Face Detection on Mobile GPUs (arXiv:1907.05047)](https://arxiv.org/abs/1907.05047)
+- [On-Device AI-Based Real-Time Dynamic Subtitle Placement for IPTV Contents (JAKO202516261206046)](https://www.koreascience.kr/article/JAKO202516261206046.view)
+- [Dynamic Subtitle Allocation: A Practical System with Speaker Separation (JAKO202509061203762)](https://www.koreascience.kr/article/JAKO202509061203762.page)
+- [Dynamic Subtitle Placement Considering ROI and Speaker Location — Semantic Scholar](https://www.semanticscholar.org/paper/Dynamic-Subtitle-Placement-Considering-the-Region-Akahori-Hirai/2864cfd949e5b787b1fd22c05b5bb6450197a72e)
+- [Dynamic Subtitles: A Multimodal Video Accessibility Enhancement — HAL](https://hal.science/hal-04305389v1)
+- [Dynamic Captioning — HAL](https://hal.science/hal-02468749)
+- [Speaker-Following Video Subtitles — ACM TOMM](https://dl.acm.org/doi/10.1145/2632111)
+- [Automatic Subtitle Placement Through Active Speaker Identification — IEEE](https://ieeexplore.ieee.org/document/9657604/)
+- [ONNX Runtime inference](https://onnxruntime.ai/inference)
+- [BlazeFace ONNX model — HuggingFace](https://huggingface.co/garavv/blazeface-onnx)
+- [Electron desktopCapturer API](https://www.electronjs.org/docs/api/desktop-capturer)
+- [BrowserWindow.setBounds — Electron](https://www.electronjs.org/docs/latest/api/browser-window)
+- [WWDC24: Discover Swift enhancements in the Vision framework](https://developer.apple.com/videos/play/wwdc2024/10163/)
+- [SpeechCompass: Enhancing Mobile Captioning with Diarization (arXiv:2502.08848)](https://arxiv.org/html/2502.08848v2)


### PR DESCRIPTION
## Description
Research findings for Windows Copilot Runtime translation API integration.

Key findings:
- Live Captions Translation API is **not yet available** to third-party apps (explicitly marked "Not yet supported" in Windows AI APIs docs as of 2026-04)
- No dedicated translation WinRT namespace exists in Windows App SDK 1.7 or 1.8
- Phi Silica (`Microsoft.Windows.AI.Text.LanguageModel`) is available but is a general SLM, not translation-tuned
- Live Captions translation only supports translation **into English** — EN→JA not confirmed
- Electron integration path exists via NodeRT or custom cppwinrt addon, but only viable once API ships
- Recommended short-term: keep HY-MT1.5-1.8B as Windows default; monitor Windows AI APIs docs for status change

Full research saved to `docs/research/583-windows-copilot-translation.md`.

## Related Issue
Closes #583

## Screenshots / Video
N/A — research only

## Test Checklist
- [ ] N/A

## Checklist
- [x] CLAUDE.md rules followed