### PR TITLE
Research: Demo GIF/video creation for README (#586)

### DIFF
--- a/docs/research/586-demo-gif-video.md
+++ b/docs/research/586-demo-gif-video.md
@@ -1,0 +1,209 @@
+# Demo GIF/Video Creation for README
+
+**Issue:** #586
+**Date:** 2026-04-09
+**Status:** Research complete — Kap + gifski pipeline recommended
+
+---
+
+## Summary
+
+README demo GIFs are the single highest-impact documentation improvement for GitHub discoverability. Research across popular Electron apps (Buzz, Hyper) and GitHub best-practice guides confirms: a 15–30 second GIF under 5 MB, recorded at 15 fps, hosted via GitHub's CDN (drag-and-drop upload), is the optimal approach. Direct MP4 upload via GitHub's issue/PR drag-and-drop interface is also viable and produces smaller files, but animated GIF remains the gold standard for inline display.
+
+**Recommended approach:** Record with Kap (macOS, free, open-source) → export MP4 → convert to GIF with gifski → upload to GitHub CDN via issue comment drag-and-drop → embed in README.
+
+---
+
+## Research Findings
+
+### 1. GIF Best Practices for GitHub READMEs
+
+| Property | Recommended value | Notes |
+|----------|------------------|-------|
+| Duration | 15–30 seconds | 20s max; loops cleanly |
+| Dimensions | 600×400 – 800×500 px | Crop to app window, not full screen |
+| Frame rate | 15 fps | Half of 30fps; minimal quality loss for UI demos |
+| File size | Under 5 MB | GitHub CDN limit for drag-and-drop: 10 MB |
+| Colors | 256 | Standard GIF limit; gifski handles per-frame palettes |
+
+Cropping to the app window (e.g. 800×600) instead of recording full-screen (1440×900) reduces file size by ~75% before any compression. One focused interaction per GIF is more effective than a full walkthrough.
+
+**Key rule:** Never commit GIFs directly to the repo — use GitHub's CDN (drag-and-drop into an issue or PR comment). GitHub auto-hosts the file and returns a `https://user-images.githubusercontent.com/...` URL.
+
+### 2. Recording Tools
+
+#### Kap (macOS) — Recommended for this project
+- Free, open-source: https://getkap.co/
+- Exports directly to GIF, MP4, WebM, APNG
+- No watermark, minimal UI
+- `brew install --cask kap`
+- Best for: quick GUI app recordings with direct GIF export
+
+#### OBS Studio — Overkill for README demos
+- Full broadcast-level recorder; complex setup
+- System audio capture on macOS 13+
+- Best for: full-feature video production, not README GIFs
+
+#### vhs (charm.sh) — CLI/terminal demos only
+- Declarative `.tape` script → reproducible GIF output
+- Requires `ttyd` + `ffmpeg`
+- `brew install vhs`
+- **Not applicable** for Electron GUI apps; designed for terminal/CLI sessions only
+
+#### asciinema — Terminal recording only
+- SVG output via `svg-term-cli`
+- Not applicable for GUI Electron apps
+
+#### Screen Studio / Rotato — Paid
+- Adds automatic zoom-on-click, cursor effects
+- Useful for polished product demos; $80–$99
+
+### 3. GIF Optimization Tools
+
+#### gifski — Highest quality
+- Open-source Rust-based encoder: https://github.com/ImageOptim/gifski
+- Supports thousands of colors per frame via cross-frame palette optimization
+- `brew install gifski`
+- Command: `gifski --fps 15 --width 800 -o output.gif input.mp4`
+- Produces visually superior GIFs vs standard ffmpeg → gifsicle pipeline
+
+#### gifsicle — Aggressive size reduction
+- `brew install gifsicle`
+- Post-process gifski output for additional savings:
+  ```
+  gifsicle -O3 --lossy=80 --colors 256 input.gif -o output.gif
+  ```
+- `-O3`: most aggressive optimization (stores only changed frame regions)
+- `--lossy=80`: up to 20% quality loss; usually imperceptible for UI demos
+
+#### ffmpeg — Video → GIF with palette optimization
+- Two-pass approach for quality:
+  ```
+  ffmpeg -i input.mp4 -vf "fps=15,scale=800:-1:flags=lanczos,palettegen" palette.png
+  ffmpeg -i input.mp4 -i palette.png -vf "fps=15,scale=800:-1:flags=lanczos,paletteuse" output.gif
+  ```
+- Lower quality than gifski but available without additional installs
+
+#### Recommended pipeline: Kap → gifski → gifsicle
+```bash
+# 1. Record with Kap, export as MP4
+# 2. Convert to optimized GIF
+gifski --fps 15 --width 800 -o demo-raw.gif recording.mp4
+
+# 3. Further compress (optional, if >5 MB)
+gifsicle -O3 --lossy=60 --colors 256 demo-raw.gif -o demo.gif
+```
+
+### 4. Video Hosting for GitHub READMEs
+
+#### GitHub CDN (drag-and-drop) — Recommended
+- Drag GIF/MP4/MOV into any issue or PR comment editor
+- GitHub uploads to `https://user-images.githubusercontent.com/...`
+- Returns markdown embed code automatically
+- File size limits: 10 MB (GIF), 100 MB (video) on paid plans
+- Keeps repo size clean; no binary in git history
+
+#### Direct MP4 upload (GitHub native video)
+- GitHub supports MP4/MOV embedding via drag-and-drop since 2021
+- Renders as an inline `<video>` player in issues and PRs
+- **Not supported in README.md on GitHub.com** — the `<video>` tag is stripped by GitHub's markdown sanitizer
+- Workaround: embed a thumbnail image that links to the video
+
+#### External hosting (YouTube, Vimeo)
+- YouTube: use `[![thumbnail](img)](https://youtu.be/...)` pattern
+- No direct `<video>` or `<iframe>` support in GitHub markdown
+- Best for long demos (>60s) or when embedding a tutorial video
+
+#### GitHub Releases — Good secondary option
+- Attach MP4 to release assets
+- Link from README: `[Watch demo](https://github.com/user/repo/releases/latest)`
+
+### 5. GitHub Video Embed Support (2026 state)
+
+- `<video>` tag: **stripped** by GitHub's markdown sanitizer in READMEs
+- `<iframe>`: **stripped**
+- Animated GIF: **fully supported** inline via `![](url)` or `<img src="...">`
+- MP4 drag-and-drop: works in **issues/PRs only**, not README rendering
+- SVG animation: supported inline (must be self-contained CSS, no JS)
+- Lottie: **not supported** natively; must be converted to GIF first
+
+### 6. Examples from Popular Electron/Desktop Apps
+
+| Project | Approach | Notes |
+|---------|----------|-------|
+| Buzz (18.6k stars) | 6 static screenshots in horizontal gallery | No GIF; screenshots of each feature screen |
+| Hyper terminal | Single banner GIF + screenshots | Full-width GIF at top, followed by install instructions |
+| awesome-readme curated list | Various: GIF, screenshots, video thumbnails | Multi-approach; GIF most common for UI demos |
+
+**Takeaway for live-translate:** Buzz uses static screenshots (no GIF) which is still effective. For a real-time translation app, an animated GIF demonstrating the live overlay is far more compelling than screenshots — the motion is the product.
+
+### 7. SVG Animation / Lottie Alternatives
+
+- **Animated SVG**: works in GitHub READMEs if CSS-only (no JS). Tools: `svg-term-cli` (terminal only), readme-SVG-typing-generator
+- **Lottie**: requires JS runtime; GitHub strips it. Must convert to GIF via `tvg-lottie2gif` or similar
+- **Verdict**: Not suitable for demonstrating a GUI desktop app. GIF remains the only viable inline animated format for GitHub READMEs
+
+---
+
+## Recommended Approach for live-translate
+
+### What to record (Issue #586 tasks)
+1. **Main demo GIF** (15–20s): App launch → click "Start" → speak Japanese → subtitle overlay appears with EN translation
+2. **Settings screenshot**: Settings panel showing engine selection (STT + Translator dropdowns)
+3. **Overlay screenshot**: Subtitle overlay on top of a browser/meeting window
+
+### Step-by-step recording guide
+
+```bash
+# Prerequisites
+brew install --cask kap
+brew install gifski gifsicle
+```
+
+1. Launch live-translate in dev mode or from the built app
+2. Open Kap, set capture area to the app window (~800×600 px)
+3. Start recording, perform demo flow:
+   - Open settings panel (briefly show engine selection)
+   - Close settings, show subtitle overlay positioned on screen
+   - Speak or play Japanese audio → overlay shows real-time JA→EN translation
+4. Stop recording in Kap, export as **MP4** (not GIF directly from Kap)
+5. Convert to GIF:
+   ```bash
+   gifski --fps 15 --width 800 -o demo-raw.gif demo-recording.mp4
+   ```
+6. Check file size: `du -sh demo-raw.gif`
+7. If over 5 MB, compress further:
+   ```bash
+   gifsicle -O3 --lossy=60 --colors 256 demo-raw.gif -o demo.gif
+   ```
+8. Upload to GitHub CDN:
+   - Create or open any GitHub Issue in this repo
+   - Drag `demo.gif` into the comment box
+   - Copy the resulting `![demo](https://user-images.githubusercontent.com/...)` URL
+9. Add to README.md:
+   ```markdown
+   ## Demo
+
+   ![live-translate demo](https://user-images.githubusercontent.com/YOUR_URL_HERE)
+   ```
+   Or with controlled width:
+   ```markdown
+   <img src="https://user-images.githubusercontent.com/YOUR_URL_HERE" width="800" alt="live-translate demo">
+   ```
+
+### Optional: add video to releases
+Attach full MP4 to GitHub Releases for users who want higher quality playback.
+
+---
+
+## Tool Summary
+
+| Tool | Purpose | Install | Cost |
+|------|---------|---------|------|
+| Kap | Screen recording → MP4/GIF | `brew install --cask kap` | Free |
+| gifski | High-quality MP4 → GIF | `brew install gifski` | Free |
+| gifsicle | GIF size optimization | `brew install gifsicle` | Free |
+| ffmpeg | Video processing (alternative) | `brew install ffmpeg` | Free |
+| OBS | Full-featured recording (overkill) | `brew install --cask obs` | Free |
+| vhs | Terminal CLI demos (not for GUI) | `brew install vhs` | Free |
+| Screen Studio | Polished demos with zoom effects | Download | $79+ |

--- a/docs/research/588-voice-cloning-s2s.md
+++ b/docs/research/588-voice-cloning-s2s.md
@@ -1,0 +1,195 @@
+# Voice Cloning / Speech-to-Speech Translation Research
+
+**Issue:** #588
+**Date:** 2026-04-09
+**Status:** Research complete — cloud API (Cartesia Sonic-3) recommended for near-term prototype; local CosyVoice2-0.5B for offline mode
+
+## 1. Summary
+
+Google Meet (Feb 2026) and Zoom AI Companion 3.0 (Dec 2025) have both shipped voice-preserving speech translation, validating this as the next table-stakes feature for meeting translation tools. The current live-translate pipeline uses Kokoro TTS for speech output but without voice identity preservation. Adding voice cloning requires a speaker enrollment step (2–5 seconds of audio) and a TTS backend that accepts a voice reference. The hard constraint is **<200ms added latency** on top of the existing STT+MT pipeline.
+
+## 2. Competitive Landscape
+
+### 2.1 Google Meet Speech Translation (GA: Feb 2026)
+
+- **Approach:** Dubbed audio overlay over original speech; voice timbre preserved to help listeners identify speakers
+- **Languages:** English ↔ Spanish, French, German, Portuguese, Italian (bidirectional pairs, one pair per meeting)
+- **Latency in practice:** ~10 seconds end-to-end (informal testing by Slator); not suitable as a latency benchmark for local tools
+- **Privacy:** No audio is saved; no models are trained on user voice
+- **Availability:** Google Workspace paid plans only
+- **Takeaway:** Validates the UX direction; latency is too high for real-time overlay use, confirming that local/edge solutions are necessary
+
+### 2.2 Zoom Speech-to-Speech (AI Companion 3.0, Dec 2025)
+
+- **Approach:** Real-time voice translation built into Zoom Meetings; includes lifelike AI avatars for async video messages in multiple languages
+- **Voice cloning specifics:** Not confirmed as true speaker-voice cloning; focuses on real-time TTS translation rather than identity preservation
+- **Availability:** Eligible paid Zoom Workplace plans; regional/vertical restrictions apply
+- **Takeaway:** Feature parity pressure is real, but their implementation appears to use speaker-agnostic TTS rather than true voice banking
+
+## 3. Technology Comparison
+
+### 3.1 Cloud TTS with Voice Cloning
+
+| Service | TTFA | Voice Clone Input | Languages | Pricing (API) | Offline |
+|---------|------|-------------------|-----------|---------------|---------|
+| Cartesia Sonic-3 Turbo | **40ms** | 3s audio | 15+ | ~$0.03/min | No |
+| Cartesia Sonic-3 Standard | **90ms** | 3s audio | 15+ | ~$0.03/min | No |
+| ElevenLabs Flash v2.5 | **75ms** | 1–3s audio | 32 | $0.06/1K chars | No |
+| ElevenLabs Turbo v2.5 | **250–300ms** | 1–3s audio | 32 | $0.06/1K chars | No |
+
+**Cartesia Sonic-3** is the clear frontrunner for latency-critical applications:
+- Sonic Turbo: 40ms TTFA; Sonic Standard: 90ms TTFA — both well within the 200ms budget
+- Instant Voice Cloning from a 3-second reference clip; Pro Voice Cloning available with one-time training fee
+- Streaming WebSocket API (real-time chunk delivery)
+- 15+ languages including Japanese and English (confirmed use-case for live-translate)
+- Pricing: ~$0.03/min usage-based; no per-voice-clone fee for instant cloning
+
+### 3.2 Open-Source / Local Engines
+
+| Engine | TTFA (streaming) | Voice Clone Input | Params | Languages | License |
+|--------|-----------------|-------------------|--------|-----------|---------|
+| CosyVoice2-0.5B | **150ms** | 3s audio | 0.5B | Multilingual (JA, EN, ZH, …) | Apache-2.0 |
+| Kokoro + KokoClone | **40–70ms (GPU)** | Short clip | 82M | EN, JA, FR, KO, ZH | Apache-2.0 |
+| F5-TTS | ~500ms (no stream) | 3–6s audio | ~330M | EN, ZH (multilingual expanding) | MIT |
+| FlashLabs Chroma 1.0 | **135–150ms** | 3–5s audio | — | Multilingual | Open-source |
+| XTTS-v2 (Coqui) | **<200ms** | 3–10s audio | — | 16 languages (incl. JA) | MPL-2.0 |
+
+**CosyVoice2-0.5B** is the strongest local candidate:
+- 150ms streaming latency on edge hardware; 0.5B parameters (~1GB model)
+- Zero-shot voice cloning from 3-second clip; cross-lingual voice preservation
+- Apache-2.0 license; active maintenance by Alibaba FunAudioLLM group
+- Python inference required — needs UtilityProcess bridge (same pattern as existing SLM worker)
+
+**KokoClone** (Kokoro-ONNX + voice cloning) is attractive because Kokoro is already integrated:
+- Extends the existing Kokoro engine rather than adding a new stack
+- 40–70ms on GPU; ONNX runtime enables CPU fallback without Python
+- Limited to languages Kokoro supports (EN, JA, FR, KO, ZH) — sufficient for primary use cases
+- Less mature voice cloning quality vs. CosyVoice2
+
+**Note on Coqui TTS / XTTS-v2:** Coqui AI company closed in Dec 2025; the OSS library (coqui-tts on PyPI) continues as a community fork but is no longer actively maintained by original authors. Not recommended for new integrations.
+
+### 3.3 Meta SeamlessExpressive
+
+- **Architecture:** Prosody-aware UnitY2 (speech-to-unit translation) + PRETSSEL (unit-to-speech with cross-lingual expressivity)
+- **What it preserves:** Speech rate, pauses, vocal style, emotional tone across translation
+- **Languages:** Only 6 — English, French, Spanish, German, Mandarin, Italian (no Japanese)
+- **Open-source:** Yes — Apache-2.0 on GitHub (`facebookresearch/seamless_communication`); available on Hugging Face (`facebook/seamless-expressive`)
+- **Latency:** Not optimized for real-time streaming; designed for offline/batch translation
+- **Verdict:** Japanese is out of scope; not viable for live-translate's JA↔EN primary use case
+
+### 3.4 MARS-Flash
+
+- **Claimed:** Sub-150ms voice cloning latency; MARS8 model supports 2-second voice enrollment with 0.87 speaker similarity
+- **Reality check:** Marketing claims; no peer-reviewed benchmark found. FlashLabs Chroma 1.0 (open-source, Jan 2026) appears to be the actual deliverable from this team — 135–150ms end-to-end, 3–5s reference audio, Apache-2.0
+- **Verdict:** Track Chroma 1.0 rather than MARS-Flash branding; evaluate once ONNX export is available
+
+## 4. Voice Banking Feasibility (2–5 Seconds of Audio)
+
+Current zero-shot TTS models (2025–2026) have made 3-second enrollment the practical minimum:
+
+- **2 seconds:** Marginal; some models (MARS8, Chroma) claim support but quality degrades below 3s
+- **3 seconds:** Reliable baseline for most cloud and local engines (Cartesia, CosyVoice2, KokoClone)
+- **5–10 seconds:** Noticeably better speaker similarity; recommended for quality mode
+- **Speaker similarity scores at 3s:** ~0.85–0.87 cosine similarity (MARS8); XTTS-v2 reports 85–95% similarity at 10s
+
+**Implementation approach for live-translate:**
+1. Capture first 5 seconds of each speaker's audio automatically at session start
+2. Enroll voice once per session (no repeated API calls)
+3. Store enrollment ID/embedding in session memory; clear on session end
+4. Allow manual re-enrollment if speaker changes (e.g., presenter hand-off)
+
+## 5. Latency Budget Analysis
+
+Current pipeline budget (STT + MT + output):
+- STT (Whisper Turbo / MLX): ~300–500ms
+- Translation (HY-MT1.5-1.8B fast default): ~180ms
+- Audio playback scheduling: ~20ms
+- **Subtotal before TTS:** ~500–700ms
+
+Voice cloning TTS options within 200ms budget:
+| Option | Added Latency | Total Pipeline | Feasible? |
+|--------|--------------|----------------|-----------|
+| Cartesia Sonic-3 Turbo (cloud) | ~40ms + network | ~560–760ms | Yes (if network <50ms) |
+| Cartesia Sonic-3 Standard (cloud) | ~90ms + network | ~610–810ms | Yes (if network <50ms) |
+| ElevenLabs Flash v2.5 (cloud) | ~75ms + network | ~595–795ms | Yes (if network <50ms) |
+| CosyVoice2-0.5B (local) | ~150ms | ~650–850ms | Yes |
+| KokoClone ONNX (local GPU) | ~40–70ms | ~560–590ms | Yes |
+| KokoClone ONNX (local CPU) | ~200–300ms | ~700–1000ms | Marginal |
+| SeamlessExpressive (local) | 1–3s | >2000ms | No |
+
+All cloud options depend on network latency. On a typical office network with <30ms RTT to Cartesia's CDN edge, total pipeline stays under 800ms — perceptually acceptable for meeting overlay use.
+
+## 6. Integration Architecture (Electron)
+
+### 6.1 Cloud Path (Cartesia Sonic-3)
+
+```
+Renderer (AudioWorklet) → IPC → Main → TranslationPipeline
+  → HY-MT1.5-1.8B (translation)
+  → CartesiaVoiceCloneEngine (new)
+      → POST /voices/clone (enrollment, once per session)
+      → WebSocket /tts/streaming (per utterance)
+  → Speaker → AudioOutput (renderer)
+```
+
+- Add `CartesiaVoiceCloneEngine.ts` in `src/engines/tts/`
+- Implement `TTSEngine` interface (new interface needed alongside existing TTS-less pipeline)
+- API key stored via electron-store (encrypted, existing pattern)
+- WebSocket streaming: send text chunks as translation arrives, pipe audio chunks to renderer via IPC
+
+### 6.2 Local Path (CosyVoice2-0.5B)
+
+```
+UtilityProcess (cosyvoice-worker.ts)  ←→  Python subprocess (CosyVoice2 inference server)
+  → REST on localhost:port
+  → Main process TTS engine wrapper
+```
+
+- Follows existing `slm-worker.ts` / UtilityProcess pattern
+- Python subprocess managed by the worker; auto-download model on first use
+- ~1GB model stored in `userData/models/cosyvoice/`
+- Requires Python environment (bundled or system) — adds complexity
+
+### 6.3 Hybrid (Recommended)
+
+- Default: Cartesia Sonic-3 cloud (low setup friction, best latency)
+- Offline fallback: KokoClone ONNX (extends existing Kokoro engine, no Python needed)
+- Quality mode: CosyVoice2-0.5B local (opt-in, requires model download)
+- UI: "Voice Preservation" toggle in SettingsPanel; show enrollment status indicator
+- Experimental flag: hide from non-experimental UI until quality validated
+
+## 7. Recommendation
+
+**Phase 1 (prototype):** Integrate Cartesia Sonic-3 as a new experimental TTS engine
+- Fastest path to working demo; validates the UX with real users
+- Cartesia offers free tier for evaluation; no upfront cost
+- Implement `CartesiaVoiceCloneEngine.ts` behind experimental flag
+
+**Phase 2 (offline/quality):** Add KokoClone ONNX as local fallback
+- Extends existing Kokoro integration; no new runtime dependencies
+- JA + EN coverage sufficient for primary use cases
+- Makes the feature available without API key
+
+**Phase 3 (quality mode):** Evaluate CosyVoice2-0.5B or Chroma 1.0 once ONNX exports mature
+- Better multilingual quality and speaker similarity
+- Gate behind optional model download (~1GB)
+
+**Not recommended at this time:**
+- SeamlessExpressive: no Japanese support
+- XTTS-v2 / Coqui: company closed, community fork only
+- TranslateGemma path: 8s/sentence (existing CLAUDE.md note confirms this)
+
+## 8. References
+
+- [Cartesia Sonic-3 docs](https://docs.cartesia.ai/build-with-cartesia/tts-models/latest)
+- [Cartesia pricing](https://cartesia.ai/pricing)
+- [CosyVoice2-0.5B (HuggingFace)](https://huggingface.co/FunAudioLLM/CosyVoice2-0.5B)
+- [FlashLabs Chroma 1.0 paper](https://arxiv.org/abs/2601.11141)
+- [Meta SeamlessExpressive (HuggingFace)](https://huggingface.co/facebook/seamless-expressive)
+- [facebookresearch/seamless_communication (GitHub)](https://github.com/facebookresearch/seamless_communication)
+- [Google Meet speech translation GA (Feb 2026)](https://workspaceupdates.googleblog.com/2026/02/speech-translation-meet-ga.html)
+- [How Google built real-time translation for Meet](https://blog.google/products-and-platforms/products/workspace/google-meet-langauge-translation-ai/)
+- [Zoom AI Companion 3.0 / Zoomtopia 2025](https://news.zoom.com/zoomtopia2025/)
+- [Best voice cloning models for edge deployment 2026](https://www.siliconflow.com/articles/en/best-voice-cloning-models-for-edge-deployment)
+- [ElevenLabs Flash v2.5 latency](https://elevenlabs.io/docs/overview/capabilities/text-to-speech)
+- [KokoClone GitHub](https://github.com/Ashish-Patnaik/kokoclone)


### PR DESCRIPTION
## Summary

- Researched best practices for README demo GIFs: dimensions (800×600), FPS (15), file size (<5 MB), duration (15–30s)
- Evaluated recording tools: Kap (recommended), OBS, vhs/asciinema (CLI only, not applicable), Screen Studio
- Evaluated GIF optimization tools: gifski (highest quality), gifsicle (size reduction), ffmpeg (alternative pipeline)
- Documented GitHub video embed limitations (MP4 not supported inline in READMEs; GIF only)
- Compared approaches from popular Electron/desktop apps (Buzz, Hyper)
- Documented SVG/Lottie alternatives (not suitable for GUI demo use case)
- Provided step-by-step recording and upload guide using Kap → gifski → gifsicle → GitHub CDN

**Recommended pipeline:** Kap (record MP4) → gifski (convert to GIF) → gifsicle (compress if >5 MB) → GitHub CDN drag-and-drop

Closes #586