### PR TITLE
Research: LFM2.5 ENJP-MT and LFM2-Audio status (#587)

### DIFF
--- a/docs/research/562-gemma4-translation.md
+++ b/docs/research/562-gemma4-translation.md
@@ -1,0 +1,146 @@
+# Gemma 4 E2B/E4B JA↔EN Translation Evaluation Research
+
+**Date**: 2026-04-09
+**Issue**: #562
+**Status**: Research only — implementation NOT started
+
+---
+
+## Summary
+
+Gemma 4 was released on 2026-03-31 (Apache 2.0) with four variants: E2B, E4B, 26B-A4B (MoE), and 31B. The E2B and E4B are edge-optimized multimodal models with native audio/speech capability (a first for open models at this size). TranslateGemma — the dedicated translation fine-tune — remains Gemma 3-based as of research date with no Gemma 4 version announced.
+
+**Key finding: No public JA↔EN translation benchmarks exist for Gemma 4 yet.** The blockers listed in #562 remain unresolved. Recommendation is to **wait** (reassess in ~4 weeks).
+
+---
+
+## Gemma 4 Variants — Specs
+
+| Variant | Active Params | Architecture | GGUF Q4_K_M | Audio |
+|---------|--------------|--------------|-------------|-------|
+| E2B | 2.3B | Dense | ~3.1 GB | Yes (ASR + speech-to-translation) |
+| E4B | ~4B | Dense | TBD | Yes |
+| 26B-A4B | 3.8B active (26B total) | MoE (128 experts, 8+1 active) | ~16.8 GB | No |
+| 31B | 31B | Dense | large | No |
+
+> Note: The GGUF Q4_K_M for E2B is **3.11 GB** (not ~1.5 GB as estimated in the issue). The issue estimate appears to have been optimistic. For comparison: HY-MT1.5-1.8B is ~1 GB.
+
+---
+
+## GGUF Availability
+
+All variants have GGUF quantizations via **unsloth** on HuggingFace:
+
+- `unsloth/gemma-4-E2B-it-GGUF` — Q2 through BF16, Q4_K_M = 3.11 GB
+- `unsloth/gemma-4-E4B-it-GGUF`
+- `unsloth/gemma-4-26B-A4B-it-GGUF`
+- `unsloth/gemma-4-31B-it-GGUF`
+
+Unsloth Dynamic 2.0 (`UD-*`) variants also available with improved quantization accuracy.
+Integration via existing `LlamaWorkerTranslator` extension is confirmed feasible.
+
+---
+
+## Translation Benchmarks
+
+### Gemma 4 — Official Benchmarks
+
+No JA↔EN translation benchmarks have been published by Google DeepMind or the community for Gemma 4. The model card reports:
+
+| Metric | E2B | E4B | 26B-A4B | 31B |
+|--------|-----|-----|---------|-----|
+| MMMLU (multilingual reasoning) | 67.4% | 76.6% | 86.3% | 88.4% |
+| CoVoST (speech translation, avg) | 33.47 | 35.54 | — | — |
+
+CoVoST is an aggregate AST (automatic speech translation) score, not specific to JA↔EN. FLORES, WMT, BLEU, and COMET scores for Japanese pairs are **not published**.
+
+Community reports (as of 2026-04-09): users testing German, Arabic, Vietnamese, French report Gemma 4 "outperforms Qwen 3.5 in non-English tasks" and makes TranslateGemma feel outdated, but no Japanese-specific data points have emerged.
+
+### TranslateGemma (Gemma 3-based) — for reference
+
+TranslateGemma was released 2026-01-15 (Gemma 3 base, 4B/12B/27B). This is the closest proxy for what a translation-tuned Gemma 4 might achieve.
+
+**en→ja_JP MetricX (WMT24++, lower = better):**
+
+| Model | MetricX |
+|-------|---------|
+| Gemma 3 27B (baseline) | 4.11 |
+| TranslateGemma 27B | 3.53 |
+| Gemma 3 12B (baseline) | 4.30 |
+| TranslateGemma 12B | 3.82 |
+| Gemma 3 4B (baseline) | 5.09 |
+| TranslateGemma 4B | 4.44 |
+
+**ja→en direction**: TranslateGemma shows a **regression vs Gemma 3 baseline** due to named entity mistranslation. This is the same failure mode reported for Gemma 3 in live-translate evaluations.
+
+**WMT24++ overall (55 languages):**
+
+| Metric | TG 4B | TG 12B | TG 27B |
+|--------|-------|--------|--------|
+| MetricX ↓ | 5.32 | 3.60 | 3.09 |
+| COMET ↑ | 81.6 | 83.5 | 84.4 |
+
+No WMT24++ per-language JA→EN table was published in the TranslateGemma technical report.
+
+---
+
+## Known Issues / Risks
+
+1. **JA→EN named entity regression**: TranslateGemma (Gemma 3 base) regresses on ja→en specifically due to proper noun/named entity errors. This issue is documented in the technical report (arXiv:2601.09012) and consistent with prior live-translate evaluation notes. Likely to carry over to any Gemma 4-based translation fine-tune.
+
+2. **E2B GGUF size**: Q4_K_M is 3.11 GB, significantly larger than the ~1.5 GB estimate in the issue. This exceeds HY-MT1.5-1.8B (~1 GB) and approaches HunyuanMT 7B territory for the Q4_K_M variant.
+
+3. **No TranslateGemma Gemma 4 version**: TranslateGemma is still Gemma 3-based. No roadmap item for a Gemma 4 fine-tune. Community comment: "makes TranslateGemma feel outdated," but no release is announced.
+
+4. **Text translation ≠ speech translation**: Gemma 4 E2B/E4B audio supports speech-to-translated-text (AST), but that requires audio input. In live-translate's pipeline (Whisper STT → translator), only the text translation capability is relevant unless we redesign the pipeline for end-to-end STT+MT with E2B.
+
+5. **Latency unknown**: No community-measured latency for text translation via GGUF on Apple Silicon. The CoVoST AST pipeline would have different latency characteristics from text-only translation.
+
+---
+
+## Comparison with Current Engines
+
+| Engine | JA→EN | Memory | Offline | Status |
+|--------|-------|--------|---------|--------|
+| HY-MT1.5-1.8B | ~180ms | ~1 GB | Yes | Default (fast) |
+| OPUS-MT | ~279ms | ~0.98 GB | Yes | Legacy fallback |
+| HunyuanMT 7B | 3.7s | ~4 GB | Yes | Quality mode |
+| Gemma 4 E2B Q4_K_M | Unknown | ~3.1 GB | Yes | **Not evaluated** |
+| TranslateGemma 4B | Unknown (text only) | ~3 GB | Yes | **Not in pipeline** |
+
+Gemma 4 E2B at 3.11 GB Q4_K_M occupies a gap between HY-MT1.5-1.8B and HunyuanMT 7B in memory terms but offers no latency data yet. If quality turns out comparable to TranslateGemma 4B (COMET 81.6), it would be a modest improvement over OPUS-MT but likely inferior to HY-MT1.5-1.8B which was specifically optimized for this task.
+
+---
+
+## Recommendation: **WAIT**
+
+### Criteria to unblock
+
+- [ ] Community JA→EN translation quality reports for Gemma 4 (any variant)
+- [ ] OR: TranslateGemma Gemma 4 base version released
+- [ ] Confirmed latency on Apple Silicon (M-series) for text translation via GGUF
+
+### Rationale
+
+Both blockers from issue #562 remain unresolved:
+1. No JA↔EN translation quality data for Gemma 4 exists (community or official)
+2. No TranslateGemma Gemma 4 release announced
+
+Additionally, the E2B GGUF is 2x larger than estimated (3.11 GB vs 1.5 GB), reducing the memory advantage over existing engines.
+
+The ja→en named entity regression in TranslateGemma (Gemma 3) is a direct precedent concern — this failure mode is already a known problem in live-translate and would need to be specifically validated before any production use.
+
+**Reassess**: ~4 weeks from release (early May 2026). By then community benchmarks for JA should be available, and if Google follows the pattern of Gemma 3 → TranslateGemma in ~10 months, a Gemma 4-based TranslateGemma would be further out.
+
+---
+
+## Sources
+
+- Google DeepMind Gemma 4 model card: https://ai.google.dev/gemma/docs/core/model_card_4
+- Gemma releases page: https://ai.google.dev/gemma/docs/releases
+- unsloth/gemma-4-E2B-it-GGUF: https://huggingface.co/unsloth/gemma-4-E2B-it-GGUF
+- TranslateGemma HuggingFace (4B): https://huggingface.co/google/translategemma-4b-it
+- TranslateGemma technical report: https://arxiv.org/abs/2601.09012
+- TranslateGemma analysis (lhl): https://github.com/lhl/realitycheck-data/blob/main/analysis/sources/google-2026-translategemma-tech-report.md
+- Gemma 4 community 24h review: https://dev.to/dentity007/-gemma-4-after-24-hours-what-the-community-found-vs-what-google-promised-3a2f
+- TranslateGemma blog (Google): https://blog.google/innovation-and-ai/technology/developers-tools/translategemma/

--- a/docs/research/576-cohere-transcribe.md
+++ b/docs/research/576-cohere-transcribe.md
@@ -1,0 +1,209 @@
+# Cohere Transcribe Evaluation for live-translate
+
+**Issue:** #576
+**Date:** 2026-04-09
+**Status:** Research complete — integration viable via Python bridge (Option A) or Transformers.js/ONNX (Option B)
+
+## 1. Summary
+
+Cohere Transcribe (`CohereLabs/cohere-transcribe-03-2026`) is a 2B-parameter Conformer-based encoder-decoder ASR model released March 26, 2026 under **Apache 2.0**. It ranks #1 on the Hugging Face Open ASR Leaderboard with 5.42% average WER for English, outperforming Whisper Large v3 (7.44%) and Qwen3-ASR-1.7B (5.76%).
+
+For Japanese, human preference evaluation shows **70% win rate vs Qwen3-ASR-1.7B** and **66% win rate vs Whisper Large v3**. Specific JA CER values are not publicly disclosed but appear as chart data (CER for zh/ja/ko) in the official blog; the model consistently outperforms or matches the best open-source model per language across FLEURS, Common Voice 17.0, MLS, and Wenet test sets.
+
+## 2. Model Architecture
+
+| Property | Value |
+|----------|-------|
+| Architecture | Conformer encoder (>90% of params) + lightweight Transformer decoder |
+| Parameters | 2B |
+| Input | 16 kHz mono audio → log-Mel spectrogram (128 bins) |
+| Chunk length | 35s max; auto-splits longer audio at energy boundaries |
+| Vocabulary size | 16,384 tokens |
+| License | Apache 2.0 |
+| Release date | 2026-03-26 |
+| Training | Supervised cross-entropy from scratch on 14 languages |
+
+## 3. Supported Languages
+
+14 languages: `en`, `fr`, `de`, `es`, `it`, `pt`, `nl`, `pl`, `el`, `ar`, `ja`, `zh`, `vi`, `ko`
+
+**Language must be specified explicitly** — no automatic language detection.
+
+## 4. Benchmarks
+
+### English ASR Leaderboard (WER — lower is better)
+
+| Model | Avg WER | LS clean | LS other | AMI | Earnings22 | Gigaspeech |
+|-------|---------|----------|----------|-----|-----------|-----------|
+| **Cohere Transcribe** | **5.42** | **1.25** | **2.37** | **8.15** | 10.84 | 9.33 |
+| Zoom Scribe v1 | 5.47 | 1.63 | 2.81 | 10.03 | 9.53 | 9.61 |
+| IBM Granite 4.0 1B | 5.52 | 1.42 | 2.85 | 8.44 | 8.48 | 10.14 |
+| Qwen3-ASR-1.7B | 5.76 | 1.63 | 3.40 | 10.56 | 10.25 | **8.74** |
+| Whisper Large v3 | 7.44 | 2.01 | 3.91 | 15.95 | 11.29 | 10.02 |
+
+### Japanese (Human Preference Evaluation)
+
+| Comparison | Cohere Transcribe Win Rate |
+|------------|---------------------------|
+| vs Qwen3-ASR-1.7B | **70%** |
+| vs Whisper Large v3 | **66%** |
+
+Note: JA CER absolute values are in a chart image in the blog post but not published as a table. Benchmarked against FLEURS, Common Voice 17.0, MLS, and Wenet.
+
+### Context for live-translate
+
+| Engine | JA CER | EN WER | Notes |
+|--------|--------|--------|-------|
+| MLX Whisper | 8.1% | 3.8% | Current best JA, primary quality engine |
+| Moonshine Tiny JA | 10.1% | — | Experimental, ultra-fast |
+| Qwen3-ASR-1.7B | — | 5.76% | Under evaluation (#268) |
+| **Cohere Transcribe** | **est. <8%** | **5.42%** | 70% win rate vs Qwen3-ASR in JA |
+
+## 5. Model Size and Memory
+
+| Artifact | Size |
+|----------|------|
+| `model.safetensors` (fp32/bf16) | **4.13 GB** |
+| `tokenizer.model` | 493 kB |
+| ONNX q4 (via `onnx-community`) | ~1–1.5 GB (estimated from 20 quantization variants) |
+
+**Runtime memory (estimated):**
+- PyTorch bf16 GPU: ~4–5 GB VRAM
+- PyTorch CPU: ~8–10 GB RAM
+- ONNX q4 CPU: ~1.5–2 GB RAM (estimated)
+
+No official memory benchmarks published; estimates based on 2B parameter count at different precisions.
+
+## 6. Inference Latency
+
+| Metric | Value |
+|--------|-------|
+| RTFx (real-time factor multiple) | 524.88× |
+| Throughput vs peers | 3× faster than similar-size dedicated ASR models |
+| Example | 55-minute audio transcribed in ~11–15s on GPU |
+| MLX (Apple Silicon) | 4× faster than PyTorch via `mlx-audio` (if supported) |
+
+Note: RTFx 524.88× means the model processes 524 minutes of audio per minute on the evaluation GPU. On M-series Mac CPU with PyTorch MPS, real-time performance for 3-second chunks would need empirical benchmarking.
+
+## 7. Integration Options
+
+### Option A: Python Bridge (like MlxWhisperEngine) — RECOMMENDED
+
+**How:** Spawn a Python subprocess with JSON-over-stdio protocol, same pattern as `MlxWhisperEngine.ts`.
+
+**Dependencies:**
+```bash
+pip install "transformers>=5.4.0" torch soundfile librosa sentencepiece protobuf huggingface_hub
+```
+
+**Bridge script pattern:**
+```python
+from transformers import AutoProcessor, CohereAsrForConditionalGeneration
+import torch, json, sys
+
+processor = AutoProcessor.from_pretrained("CohereLabs/cohere-transcribe-03-2026")
+model = CohereAsrForConditionalGeneration.from_pretrained(
+    "CohereLabs/cohere-transcribe-03-2026",
+    device_map="auto",
+    torch_dtype=torch.bfloat16,
+)
+
+for line in sys.stdin:
+    req = json.loads(line)
+    audio = req["audio"]  # list[float] at 16kHz
+    inputs = processor(audio, sampling_rate=16000, return_tensors="pt", language="ja")
+    inputs = inputs.to(model.device, dtype=model.dtype)
+    outputs = model.generate(**inputs, max_new_tokens=256)
+    text = processor.decode(outputs, skip_special_tokens=True)
+    print(json.dumps({"text": text}), flush=True)
+```
+
+**Pros:**
+- Official transformers support (≥5.4.0) — stable API
+- MPS (Apple Silicon), CUDA, and CPU all work
+- Long-form auto-chunking built-in
+- Proven pattern in codebase (`MlxWhisperEngine`)
+- Model auto-downloads from HuggingFace
+
+**Cons:**
+- Requires Python 3.12+ and PyTorch (~2.5 GB with deps)
+- 4.13 GB model download on first use
+- Subprocess startup latency (~3–6s cold start)
+- No timestamps or speaker diarization
+- Language must be hard-coded to `"ja"` — cannot do multilingual auto-detect
+
+**Effort:** Low-medium. Re-use `MlxWhisperEngine` pattern with new bridge script.
+
+### Option B: Transformers.js + ONNX (WebGPU in renderer) — EXPERIMENTAL
+
+**How:** Use `onnx-community/cohere-transcribe-03-2026-ONNX` via `@huggingface/transformers` in the Electron renderer process.
+
+**Dependencies:**
+```bash
+npm i @huggingface/transformers
+```
+
+**Usage:**
+```js
+import { pipeline } from "@huggingface/transformers";
+
+const transcriber = await pipeline(
+  "automatic-speech-recognition",
+  "onnx-community/cohere-transcribe-03-2026-ONNX",
+  { dtype: "q4", device: "webgpu" },
+);
+const output = await transcriber(audio, { max_new_tokens: 1024, language: "ja" });
+```
+
+**Pros:**
+- No Python dependency — pure JS
+- ONNX q4 ~1–1.5 GB vs 4.13 GB safetensors
+- WebGPU uses Apple Neural Engine/Metal on M-series
+
+**Cons:**
+- WebGPU in Electron renderer requires explicit context setup
+- ONNX export is community-maintained (`onnx-community`), not official Cohere
+- 20 quantization variants need testing for JA accuracy vs size tradeoff
+- No community reports yet on JA accuracy for ONNX q4 variant
+- Large model still downloads on first use
+
+**Effort:** Medium. More unknowns than Option A; needs careful testing.
+
+### Option C: Rust (`cohere_transcribe_rs`) — FUTURE
+
+A Rust crate `cohere_transcribe_rs` exists (mentioned in official model card) but no NAPI-RS bindings exist. High effort, skip for now.
+
+## 8. Limitations and Risks
+
+| Risk | Severity | Notes |
+|------|----------|-------|
+| No auto language detection | Medium | Must specify `language="ja"` — breaks mixed-language sessions |
+| Hallucination on silence/noise | Medium | "Eager transcription" — prone to hallucinating on noisy background |
+| No timestamps | Low | Not needed for subtitle overlay use case |
+| 4.13 GB model size | Medium | Comparable to PLaMo-2 (5.5 GB); needs resume-download support |
+| No JA CER absolute value published | Low | Can only infer from win-rate comparisons |
+| PyTorch MPS latency unknown | High | Must benchmark on M-series Mac for real-time suitability |
+
+## 9. Recommendation
+
+**Verdict: Viable for quality mode — proceed to implementation with benchmarking gate.**
+
+Cohere Transcribe is the strongest open-source ASR model for Japanese as of April 2026, with a 70% human preference win rate over Qwen3-ASR-1.7B and 66% over Whisper Large v3. Apache 2.0 license and first-class transformers integration make it a low-risk addition.
+
+**Recommended path:**
+1. Implement `CohereTranscribeEngine.ts` via Python bridge (Option A), following `MlxWhisperEngine` pattern
+2. Register as experimental STT engine (hidden from UI until benchmarks pass)
+3. Benchmark JA CER against MLX Whisper (8.1% target) on internal JA test set
+4. Benchmark latency on Apple M-series CPU (3s chunk target: <2s for real-time)
+5. If JA CER < 8.1% AND latency < 2s, promote to primary quality-mode engine
+
+**Do not promote to UI until real-time latency is confirmed on CPU.** The model is large (4.13 GB) and CPU inference for 3-second chunks may exceed real-time, unlike the GPU-measured RTFx of 524×.
+
+## 10. References
+
+- HuggingFace model card: https://huggingface.co/CohereLabs/cohere-transcribe-03-2026
+- HuggingFace blog post: https://huggingface.co/blog/CohereLabs/cohere-transcribe-03-2026-release
+- Cohere blog: https://cohere.com/blog/transcribe
+- Transformers docs: https://huggingface.co/docs/transformers/model_doc/cohere_asr
+- ONNX variant: https://huggingface.co/onnx-community/cohere-transcribe-03-2026-ONNX
+- Open ASR Leaderboard: https://huggingface.co/spaces/hf-audio/open_asr_leaderboard

--- a/docs/research/582-chrome-translator-api.md
+++ b/docs/research/582-chrome-translator-api.md
@@ -1,0 +1,237 @@
+# Chrome Built-in AI Translator API — Research
+
+**Date:** 2026-04-09
+**Issue:** [#582](https://github.com/rioX432/live-translate/issues/582)
+**Researcher:** agent
+
+---
+
+## Summary
+
+Chrome's built-in Translator API (`Translator.create()`) uses an on-device expert model (distinct from the full Gemini Nano LLM) to perform translations entirely within the browser. As of Chrome 138+ (stable), the Translator API and Language Detector API are generally available on desktop without origin trial. Japanese ↔ English is a confirmed supported language pair. The API is **desktop-only** and has steep hardware requirements (22 GB free disk, 4 GB VRAM or 16 GB RAM). Quality is roughly on par with Google Translate for common language pairs but has not been independently benchmarked for JA↔EN specifically.
+
+---
+
+## 1. API Availability & Status
+
+| Dimension | Detail |
+|---|---|
+| **Status** | Generally available (Chrome 138+ stable) — no origin trial required |
+| **API surface** | `Translator.create()`, `translator.translate()`, `translator.translateStreaming()` |
+| **Platforms** | Desktop only: Windows 10/11, macOS 13+, Linux, ChromeOS 16389+ |
+| **Mobile** | Not supported (Chrome Android / iOS) |
+| **Other browsers** | Not supported (Edge, Firefox, Safari) |
+| **W3C status** | Adopted by W3C WebML Working Group alongside Language Detector API |
+
+Feature detection:
+
+```javascript
+if ('Translator' in self) {
+  // API is supported
+}
+```
+
+Availability check before creating:
+
+```javascript
+const availability = await Translator.availability({
+  sourceLanguage: 'ja',
+  targetLanguage: 'en'
+});
+// Returns: 'unavailable' | 'downloadable' | 'downloading' | 'available'
+```
+
+---
+
+## 2. How to Enable
+
+For **production use**, no flags are needed in Chrome 138+. The API is enabled by default.
+
+For **development / local testing** or enabling on older builds:
+
+1. Navigate to `chrome://flags/#optimization-guide-on-device-model` → set to **Enabled**
+2. For the Prompt API (Gemini Nano LLM, not Translator): also enable `chrome://flags/#prompt-api-for-gemini-nano`
+3. Relaunch Chrome
+
+**Important:** The Translator API uses a separate expert model, not the Gemini Nano LLM — the Prompt API flag is not needed for translation.
+
+---
+
+## 3. Language Pair Coverage
+
+JA↔EN is explicitly confirmed as supported. The API supports 40+ languages total including:
+
+- Japanese (`ja`) ↔ English (`en`) — **confirmed**
+- Spanish (`es`), French (`fr`), German (`de`), Italian (`it`)
+- Simplified Chinese (`zh`), Traditional Chinese (`zh-Hant`)
+- Korean (`ko`), Portuguese (`pt`), Arabic (`ar`), Russian (`ru`), and others
+
+Language pair support is checked dynamically via `Translator.availability()`. Chrome is tracking an issue (#68) to expose a programmatic API to list all supported pairs without enumerating them individually.
+
+**Privacy note:** Chrome intentionally reports *all* language pairs as "downloadable" regardless of actual availability — to prevent fingerprinting the user's installed languages.
+
+---
+
+## 4. Hardware Requirements & Model Size
+
+| Requirement | Value |
+|---|---|
+| **Free disk space** | 22 GB minimum (model is removed if disk drops below 10 GB after download) |
+| **GPU VRAM** | > 4 GB (GPU path), OR |
+| **RAM + CPU** | 16 GB RAM + 4+ cores (CPU path) |
+| **Network** | Unmetered connection for initial download only; offline after that |
+| **Model size** | ~1.5–2 GB per language pair (download on first use) |
+
+The model is downloaded the first time a website or extension uses a given language pair. Subsequent uses are fully offline.
+
+**Implication for live-translate:** The 22 GB disk space requirement and 1.5–2 GB per language pair download are significant barriers for casual users. Users with < 22 GB free disk will see `availability: 'unavailable'`.
+
+---
+
+## 5. API Usage & Chrome Extension Integration
+
+### Basic usage
+
+```javascript
+// Check if API is available
+if (!('Translator' in self)) {
+  // Fallback to desktop relay
+}
+
+const availability = await Translator.availability({
+  sourceLanguage: 'ja',
+  targetLanguage: 'en'
+});
+
+if (availability === 'unavailable') {
+  // Fallback
+}
+
+const translator = await Translator.create({
+  sourceLanguage: 'ja',
+  targetLanguage: 'en',
+  // Monitor download progress if status is 'downloadable'
+  monitor(m) {
+    m.addEventListener('downloadprogress', (e) => {
+      console.log(`Downloaded ${e.loaded} of ${e.total} bytes`);
+    });
+  }
+});
+
+// Await model ready (if still downloading)
+await translator.ready;
+
+const result = await translator.translate('こんにちは');
+console.log(result); // "Hello"
+```
+
+### Streaming (for long text)
+
+```javascript
+const stream = translator.translateStreaming(longText);
+for await (const chunk of stream) {
+  // Append chunk to UI
+}
+```
+
+### Chrome Extension pattern
+
+- **Service worker / background script**: Call `Translator.create()` and cache the translator instance per language pair
+- **Content script**: Collect text → send via `chrome.runtime.sendMessage()` → background translates → return result
+- **User activation**: `create()` requires transient user activation (click, keypress, etc.) if a download is pending. Background service workers cannot initiate downloads autonomously — the user must have triggered the extension action.
+- **Permissions**: Add `"permissions": ["aiLanguageModelOriginTrial"]` (or `"ai"` in newer manifests) as needed per Chrome extension docs
+
+### API changes to watch
+
+Significant structural changes occurred between Chrome 138 and 141 (e.g., `window.translation` → `Translator`, method renames). Always use feature detection rather than version checks.
+
+---
+
+## 6. Limitations & Constraints
+
+| Limitation | Detail |
+|---|---|
+| **Sequential processing** | Requests are queued and processed one at a time — no parallel translation |
+| **Desktop only** | Mobile Chrome not supported |
+| **Storage gating** | 22 GB free disk required; model deleted if storage drops below 10 GB |
+| **User activation** | Download requires a user gesture (cannot silently pre-download in background) |
+| **No rate limits documented** | No official rate limits, but sequential-only processing limits throughput |
+| **API stability** | Experimental; breaking changes occurred between minor Chrome versions |
+| **Privacy fingerprinting mitigation** | All language pairs reported as "downloadable" — cannot detect pre-installed pairs |
+| **Not in Web Workers** | API unavailable in Worker contexts |
+| **HTTPS required** | Secure context only |
+
+---
+
+## 7. Quality Assessment
+
+### What we know
+
+- Uses a dedicated **expert translation model** (not the Gemini Nano LLM) — purpose-built for translation, expected to be better than prompting Gemini Nano directly
+- Described as "high-quality" in official docs but no independent BLEU/ChrF benchmarks for this API have been published
+- Community feedback: mixed ratings for Chrome extensions using the API (e.g., "Translate with Gemini Nano" = 3.3/5, "Gemini Translator" = 4.4/5)
+
+### Comparison to current live-translate engines
+
+| Engine | JA→EN Quality | Latency | Offline | Notes |
+|---|---|---|---|---|
+| Chrome Translator API | Unknown (rough parity with Google Translate expected) | ~low | Yes (after download) | On-device, privacy-safe |
+| HY-MT1.5-1.8B (current default) | Good | ~180ms | Yes | Confirmed good JA quality |
+| Google Translate API | Good | ~100ms | No | 500K chars/month free |
+| DeepL | Very good | ~100ms | No | Best for European pairs; JA quality debated |
+
+**Verdict on quality:** The Chrome Translator API is likely comparable to Google Translate for JA↔EN, but inferior to DeepL and probably inferior to the tuned local model (HY-MT1.5-1.8B). No live-translate-specific benchmarking has been done. **Quality must be benchmarked before using as a primary engine.**
+
+---
+
+## 8. Recommendation
+
+### Should we implement as a translation option in the Chrome extension?
+
+**Yes, as an optional/fallback engine — not a default.**
+
+**Reasons to implement:**
+1. Zero operational cost after initial model download
+2. Privacy-safe (no data leaves device)
+3. Reduces dependency on desktop Electron app for extension users
+4. Good alignment with the offline-capable requirement
+
+**Reasons not to make it default:**
+1. 22 GB free disk requirement will disqualify many users
+2. Quality unverified for JA↔EN — needs benchmarking
+3. Sequential-only processing limits throughput for rapid subtitle translation
+4. API still evolving; breaking changes are frequent
+5. Desktop-only — no path to mobile
+
+### Recommended implementation plan
+
+1. **Prototype** `Translator.create()` in a Chrome extension content/background script with JA↔EN
+2. **Benchmark quality** against HY-MT1.5-1.8B and Google Translate using 100 representative JA sentences (conference/meeting domain)
+3. **Add as optional engine** in extension settings (off by default)
+4. **Implement graceful fallback**: if `availability === 'unavailable'` or language pair not supported, fall back to desktop relay (existing Electron app IPC)
+5. **Do not block** on model download — show download progress and fall back immediately if not ready
+
+### Integration architecture
+
+```
+Chrome Extension
+├── background.js
+│   ├── Check Translator.availability('ja', 'en')
+│   ├── If available: use Translator.create() for translation
+│   └── If unavailable: relay to Electron app via native messaging
+└── content.js
+    └── Capture audio/subtitle text → send to background
+```
+
+---
+
+## References
+
+- [Chrome Translator API docs](https://developer.chrome.com/docs/ai/translator-api)
+- [Client-side translation with AI](https://developer.chrome.com/docs/ai/translate-on-device)
+- [Get started with built-in AI](https://developer.chrome.com/docs/ai/get-started)
+- [Built-in AI overview](https://developer.chrome.com/docs/ai/built-in/overview)
+- [MDN: Translator and Language Detector APIs](https://developer.mozilla.org/en-US/docs/Web/API/Translator_and_Language_Detector_APIs)
+- [Chrome Status: Translator API](https://chromestatus.com/feature/5172811302961152)
+- [Half a year with Chrome Built-in AI (Aug 2025)](https://thangman22.com/2025/08/29/half-a-year-has-passed-lets-see-what-built-in-ai-on-chrome-can-do-today/)
+- [Building Chrome Built-in AI Translation Demo](https://techhub.iodigital.com/articles/building-a-translation-demo-with-chromes-built-in-ai-apis)

--- a/docs/research/585-iq4xs-requantization.md
+++ b/docs/research/585-iq4xs-requantization.md
@@ -1,0 +1,258 @@
+# Research: IQ4_XS GGUF Re-quantization with Importance Matrix
+
+**Date**: 2026-04-09
+**Issue**: [#585](https://github.com/rioX432/live-translate/issues/585)
+**Models in scope**: HY-MT1.5-1.8B, Hunyuan-MT-7B
+
+---
+
+## Summary
+
+IQ4_XS is an importance-matrix-guided 4-bit i-quant that achieves ~9% smaller file size than Q4_K_M with comparable or slightly better perplexity when built with a high-quality imatrix. For the two models currently shipped:
+
+| Model | Q4_K_M size | IQ4_XS estimate | Saving |
+|---|---|---|---|
+| HY-MT1.5-1.8B | ~1.1 GB | ~1.0 GB | ~100 MB |
+| Hunyuan-MT-7B | ~4.7 GB | ~4.2 GB | ~500 MB |
+
+The primary benefit for live-translate is reduced first-launch download time and lower RAM headroom required for the fast (1.8B) model, with no code changes needed beyond updating URLs, sizes, and SHA256 hashes in `model-downloader.ts`.
+
+---
+
+## Quantization Type Comparison
+
+| Format | bpw | Size (8B ref) | PP speed | TG speed | imatrix req | Notes |
+|---|---|---|---|---|---|---|
+| Q4_K_M | 4.89 | 4.58 GiB | Fast | Fast | No | Reliable default, no imatrix needed |
+| IQ4_XS | 4.46 | 4.17 GiB | Slightly slower | Slightly faster | **Yes** | Best balanced i-quant; requires good imatrix |
+| IQ4_NL | ~4.5 | ~4.3 GiB | CPU-friendly | Similar to IQ4_XS | Yes | Non-linear 32-block variant; often redundant vs IQ4_XS |
+| IQ3_XXS | ~3.28 | ~3.1 GiB | Slow (5–10%) | Slow (5–10%) | Yes | Aggressive compression; perplexity noticeably worse |
+| Q3_K_M | 3.91 | 3.74 GiB | Fast | Fast | No | Simpler 3-bit, no imatrix, lower quality floor |
+
+Perplexity reference (Llama-3.1-8B, wikitext):
+- Q4_K_M: ~3.0184
+- IQ4_XS: ~3.0310 (+0.4% vs Q4_K_M — within noise)
+- IQ4_NL: ~3.0261 (~same as IQ4_XS)
+- IQ3_XXS: ~3.9671 (+31% — visible quality drop)
+
+**Key finding**: IQ4_XS perplexity is essentially identical to Q4_K_M when quantized with a domain-matched imatrix. Without an imatrix, IQ4_XS can be worse than Q4_K_M, making the imatrix step mandatory.
+
+---
+
+## Importance Matrix (imatrix) Overview
+
+The imatrix tool runs the model on a calibration corpus and records per-layer activation magnitudes. These statistics are passed to `llama-quantize` so that weights with higher activation importance are quantized more carefully (more bits allocated implicitly via the i-quant lookup tables).
+
+**Effect**: Reduces effective perplexity by 10–30% compared to naive IQ4_XS quantization and is required to match Q4_K_M quality at lower bit depth.
+
+### Calibration Data Guidelines
+
+- Use domain-representative text — for JA↔EN translation models, this means bilingual parallel sentences (JA and EN)
+- Corpus size: 1,000–10,000 sentences is typical; diminishing returns beyond ~5,000
+- Avoid single-domain overfitting: mix formal (news), informal (conversation), and technical (software) registers
+- Pseudo-random / wiki data is an acceptable fallback but slightly worse than domain-matched data for translation models
+- For Japanese: ensure the calibration set has adequate JA coverage (Japanese requires more tokens for equivalent semantic coverage vs English)
+
+Suggested calibration sources for translation:
+- [JESC](https://nlp.stanford.edu/projects/jesc/) — 3.2M JA/EN parallel sentences, conversational
+- [JParaCrawl](https://www.kecl.ntt.co.jp/icl/lirg/jparacrawl/) — web-crawled JA/EN parallel corpus
+- [tatoeba JA/EN](https://tatoeba.org) — short sentence pairs, good for dialogue
+
+---
+
+## Step-by-Step Re-quantization Process
+
+### Prerequisites
+
+```bash
+# Clone and build llama.cpp (latest master recommended)
+git clone https://github.com/ggml-org/llama.cpp
+cd llama.cpp
+cmake -B build -DLLAMA_METAL=ON   # macOS Apple Silicon
+cmake --build build --config Release -j8
+
+# Tools needed:
+#   build/bin/llama-imatrix
+#   build/bin/llama-quantize
+#   build/bin/llama-gguf-split (if model is multi-part)
+```
+
+### Step 1: Obtain the F16 base GGUF
+
+```bash
+# Download F16 (or BF16) GGUF — needed as quantization source
+# HY-MT1.5-1.8B
+huggingface-cli download tencent/HY-MT1.5-1.8B-GGUF \
+  HY-MT1.5-1.8B-F16.gguf --local-dir ./models/hy-mt15
+
+# Hunyuan-MT-7B
+huggingface-cli download Mungert/Hunyuan-MT-7B-GGUF \
+  Hunyuan-MT-7B-f16.gguf --local-dir ./models/hunyuan7b
+# Note: if F16 is not available on HF, convert from safetensors:
+# python llama.cpp/convert_hf_to_gguf.py <hf_model_dir> --outtype f16
+```
+
+### Step 2: Prepare calibration data
+
+```bash
+# Create a bilingual calibration text file (one sentence/paragraph per line)
+# Recommended: 2,000–5,000 lines of mixed JA/EN translation pairs
+# Example using Tatoeba:
+python -c "
+import json, random
+# load JA/EN pairs from tatoeba tsv or similar source
+# write to calibration.txt, one sentence per line
+"
+# Alternatively, use llama.cpp's bundled wikitext as a starting fallback:
+# wget https://huggingface.co/datasets/ggml-org/ci/resolve/main/wikitext-2-raw-v1.zip
+```
+
+### Step 3: Generate the importance matrix
+
+```bash
+# HY-MT1.5-1.8B (fast, ~5–10 min on M-series Mac)
+./build/bin/llama-imatrix \
+  -m ./models/hy-mt15/HY-MT1.5-1.8B-F16.gguf \
+  -f calibration.txt \
+  --chunk 512 \
+  -o ./models/hy-mt15/imatrix.dat \
+  -ngl 99   # offload all layers to Metal
+
+# Hunyuan-MT-7B (slower, ~30–60 min on M-series Mac)
+./build/bin/llama-imatrix \
+  -m ./models/hunyuan7b/Hunyuan-MT-7B-f16.gguf \
+  -f calibration.txt \
+  --chunk 512 \
+  -o ./models/hunyuan7b/imatrix.dat \
+  -ngl 99
+```
+
+### Step 4: Quantize to IQ4_XS
+
+```bash
+# HY-MT1.5-1.8B
+./build/bin/llama-quantize \
+  --imatrix ./models/hy-mt15/imatrix.dat \
+  ./models/hy-mt15/HY-MT1.5-1.8B-F16.gguf \
+  ./models/hy-mt15/HY-MT1.5-1.8B-IQ4_XS.gguf \
+  IQ4_XS
+
+# Hunyuan-MT-7B
+./build/bin/llama-quantize \
+  --imatrix ./models/hunyuan7b/imatrix.dat \
+  ./models/hunyuan7b/Hunyuan-MT-7B-f16.gguf \
+  ./models/hunyuan7b/Hunyuan-MT-7B-IQ4_XS.gguf \
+  IQ4_XS
+```
+
+### Step 5: Benchmark quality
+
+```bash
+# Perplexity check (compare to Q4_K_M baseline)
+./build/bin/llama-perplexity \
+  -m ./models/hy-mt15/HY-MT1.5-1.8B-IQ4_XS.gguf \
+  -f calibration.txt --chunks 50
+
+# Translation quality: run a BLEU/COMET eval against a held-out test set
+# e.g. FLORES-200 devtest JA→EN subset (1,012 sentences)
+# Target: BLEU within ±0.5 and COMET within ±0.01 of Q4_K_M baseline
+
+# Inference speed
+./build/bin/llama-bench -m ./models/hy-mt15/HY-MT1.5-1.8B-IQ4_XS.gguf -p 512 -n 128
+```
+
+### Step 6: Compute SHA256 and update model-downloader.ts
+
+```bash
+shasum -a 256 ./models/hy-mt15/HY-MT1.5-1.8B-IQ4_XS.gguf
+shasum -a 256 ./models/hunyuan7b/Hunyuan-MT-7B-IQ4_XS.gguf
+```
+
+Upload GGUFs to a Hugging Face repo (or use a fork of the existing repos), then update `src/engines/model-downloader.ts`:
+
+```typescript
+// Replace in HUNYUAN_MT_15_VARIANTS
+'IQ4_XS': {
+  filename: 'HY-MT1.5-1.8B-IQ4_XS.gguf',
+  url: 'https://huggingface.co/<org>/HY-MT1.5-1.8B-GGUF/resolve/main/HY-MT1.5-1.8B-IQ4_XS.gguf',
+  sha256: '<hash>',
+  sizeMB: 1020,   // ~1.0 GB estimated
+  label: 'IQ4_XS (Recommended, ~1.0GB)'
+}
+
+// Replace in HUNYUAN_MT_VARIANTS
+'IQ4_XS': {
+  filename: 'Hunyuan-MT-7B-IQ4_XS.gguf',
+  url: 'https://huggingface.co/<org>/Hunyuan-MT-7B-GGUF/resolve/main/Hunyuan-MT-7B-IQ4_XS.gguf',
+  sha256: '<hash>',
+  sizeMB: 4200,   // ~4.2 GB estimated
+  label: 'IQ4_XS (Recommended, ~4.2GB)'
+}
+```
+
+---
+
+## Alternative Quantization Types
+
+| Format | Recommendation | Use case |
+|---|---|---|
+| IQ4_NL | Skip (redundant vs IQ4_XS) | CPU-only systems; test if IQ4_XS is slow on target hardware |
+| IQ3_XXS | Not recommended for MT | ~31% perplexity increase; translation quality likely to degrade noticeably |
+| IQ3_S | Possible fallback | 3.44 bpw, ~20% smaller than IQ4_XS; evaluate with COMET before shipping |
+| Q5_K_M | Conservative alternative | Slightly larger than Q4_K_M but better quality; no imatrix needed |
+
+---
+
+## Memory and Speed Impact
+
+For the primary use-case (HY-MT1.5-1.8B, real-time translation):
+
+| Metric | Q4_K_M | IQ4_XS (estimated) |
+|---|---|---|
+| File size | 1,130 MB | ~1,020 MB (~−9%) |
+| RAM at runtime | ~1.3 GB | ~1.2 GB |
+| TG speed | baseline | +2–5% faster |
+| PP speed | baseline | −3–5% slower |
+| Perplexity delta | 0 | +0.1–0.5% with good imatrix |
+
+For Hunyuan-MT-7B (quality mode):
+
+| Metric | Q4_K_M | IQ4_XS (estimated) |
+|---|---|---|
+| File size | 4,700 MB | ~4,200 MB (~−11%) |
+| RAM at runtime | ~5.5 GB | ~5.0 GB |
+| TG speed | baseline | +2–5% faster |
+| PP speed | baseline | −3–5% slower |
+
+---
+
+## Recommendation
+
+**Proceed with IQ4_XS re-quantization for both models, conditioned on benchmark results.**
+
+Priority:
+1. HY-MT1.5-1.8B first — smaller model, faster iteration, higher user impact (default fast path)
+2. Hunyuan-MT-7B second — quality mode, 500 MB saving is meaningful but less critical
+
+Go/no-go criteria:
+- BLEU delta < 0.5 points vs Q4_K_M on FLORES-200 JA→EN
+- COMET delta < 0.01 (absolute) vs Q4_K_M
+- Inference latency for HY-MT1.5 < 200 ms per segment (currently ~180 ms)
+
+If benchmarks pass, ship IQ4_XS as the new default variant and keep Q4_K_M as the fallback option in the UI variant selector.
+
+**IQ4_NL and IQ3_XXS are not recommended** — IQ4_NL is redundant and IQ3_XXS causes unacceptable quality loss for MT tasks.
+
+---
+
+## References
+
+- [llama.cpp quantize README](https://github.com/ggml-org/llama.cpp/blob/master/tools/quantize/README.md)
+- [llama.cpp imatrix README](https://github.com/ggml-org/llama.cpp/blob/master/tools/imatrix/README.md)
+- [GGUF quantizations overview (community gist)](https://gist.github.com/Artefact2/b5f810600771265fc1e39442288e8ec9)
+- [Kaitchup: Choosing a GGUF Model — K-Quants, I-Quants](https://kaitchup.substack.com/p/choosing-a-gguf-model-k-quants-i)
+- [imatrix overfitting discussion](https://github.com/ggml-org/llama.cpp/discussions/5263)
+- [imatrix best on near-random data discussion](https://github.com/ggml-org/llama.cpp/discussions/5006)
+- [Mungert/Hunyuan-MT-7B-GGUF (HF)](https://huggingface.co/Mungert/Hunyuan-MT-7B-GGUF)
+- [tencent/HY-MT1.5-1.8B-GGUF (HF)](https://huggingface.co/tencent/HY-MT1.5-1.8B-GGUF)
+- [Blind testing different quants — llama.cpp discussion #5962](https://github.com/ggml-org/llama.cpp/discussions/5962)

--- a/docs/research/587-lfm25-audio.md
+++ b/docs/research/587-lfm25-audio.md
@@ -1,0 +1,142 @@
+# LFM2.5 ENJP-MT and LFM2-Audio Research
+
+**Issue:** #587
+**Date:** 2026-04-09
+**Status:** Research complete — LFM2.5 ENJP-MT not yet released; LFM2-Audio English-only for now. **Recommendation: Wait.**
+
+---
+
+## 1. LFM2.5 Overview
+
+Liquid AI released the LFM2.5 family in **January 2026** as the next generation of their on-device foundation models.
+
+### Key Improvements over LFM2
+
+| Dimension | LFM2 | LFM2.5 |
+|-----------|------|---------|
+| Pre-training tokens | 10T | 28T |
+| Post-training | SFT + preference alignment | SFT + preference alignment + large-scale multi-stage RL |
+| Audio detokenizer | Mimi | Custom LFM-based (8x faster on mobile CPU) |
+| Instruction following | Baseline | Significantly improved |
+| Tool use / data extraction | Limited | Strong (reliable at 350M scale) |
+| Multilingual vision | Limited | Arabic, Chinese, French, German, **Japanese**, Korean, Spanish |
+
+### Release Timeline
+
+- **January 6, 2026** — LFM2.5-1.2B (Instruct, Base, JP, Audio, VL) announced
+- **January 20, 2026** — LFM2.5-1.2B-Thinking (reasoning variant, <1GB)
+- **March 31, 2026** — LFM2.5-350M released (28T tokens, scaled RL)
+
+### Architecture
+
+LFM2 / LFM2.5 is **not a pure SSM/S4 model**. It uses a hardware-in-the-loop architecture search that resulted in a hybrid:
+- **10 double-gated short-range convolution blocks** (cheap, fast)
+- **6 grouped-query attention (GQA) blocks** (global context)
+
+The search explored SSMs (S4, Liquid-S4, S5, Mamba, Mamba2), linear attention, and Liquid-Time Constant networks (CfC), but found that short convolution + sparse attention dominates under device-side latency/memory budgets. On CPU benchmarks, LFM2 delivers 200% faster decode/prefill than Qwen3 and Gemma 3.
+
+LFM2.5 extends this architecture with 28T-token pretraining (80,000:1 token-to-parameter ratio for the 350M variant) and multi-stage RL post-training.
+
+---
+
+## 2. LFM2.5 ENJP-MT Variant
+
+### Current Status: **Not Released**
+
+As of 2026-04-09, there is **no LFM2.5-ENJP-MT model on HuggingFace**. The existing translation-specific model remains:
+
+- `LiquidAI/LFM2-350M-ENJP-MT` — fine-tuned on LFM2-350M for bidirectional JA↔EN
+- `LiquidAI/LFM2-350M-ENJP-MT-GGUF` — GGUF quantized (Q4_K_M ~230MB)
+- `onnx-community/LFM2-350M-ENJP-MT-ONNX` — ONNX community port
+
+### Related Japanese Releases
+
+- `LiquidAI/LFM2.5-1.2B-JP` — Japanese general-purpose text model (not MT-specialized)
+- `LiquidAI/LFM2.5-1.2B-JP-GGUF` — GGUF variant
+
+The LFM2.5-1.2B-JP targets Japanese knowledge and instruction-following, **not** optimized for bidirectional JA↔EN machine translation.
+
+### Drop-in Upgrade Potential
+
+If/when Liquid AI releases `LFM2.5-350M-ENJP-MT`, it should be a near drop-in upgrade for `LFM2Translator.ts`:
+- Same model size class (~230–300MB quantized)
+- Same system prompt interface (`"Translate to Japanese."` / `"Translate to English."`)
+- Same GGUF format compatible with node-llama-cpp
+- Expected latency similar or better (~180ms), with improved translation quality from 28T token pretraining
+
+The `LFM2Translator.ts` currently wraps `LlamaWorkerTranslator` and calls `getLFM2Variants()` from `model-downloader`. A new `LFM25Translator.ts` could be added alongside it (or the variants config updated) with minimal changes.
+
+---
+
+## 3. LFM2-Audio / LFM2.5-Audio
+
+### Available Models
+
+| Model | HuggingFace | Notes |
+|-------|-------------|-------|
+| `LiquidAI/LFM2-Audio-1.5B` | Released | LFM2 generation |
+| `LiquidAI/LFM2.5-Audio-1.5B` | Released Jan 2026 | LFM2.5 generation, 8x faster detokenizer |
+| `LiquidAI/LFM2.5-Audio-1.5B-GGUF` | Released | llama.cpp-compatible |
+| `LiquidAI/LFM2.5-Audio-1.5B-ONNX` | Released | ONNX port |
+
+### Capabilities
+
+LFM2.5-Audio is an **end-to-end multimodal speech+text model** — no separate ASR/TTS components required. It supports two generation modes:
+
+- **Interleaved mode**: alternating text+audio tokens; minimal TTFA, ideal for real-time speech-to-speech on constrained devices
+- **Sequential mode**: model-controlled modality switching via special tokens; suitable for ASR (speech→text) and TTS (text→speech)
+
+### Language Support: **English Only (Current)**
+
+As of April 2026, LFM2.5-Audio officially supports **English only**. Liquid AI has stated in the HuggingFace discussion threads that they are working to extend support to all languages covered by LFM2.5-Base (which includes Japanese), but no timeline has been confirmed.
+
+A HuggingFace discussion on `LFM2.5-Audio-1.5B-GGUF` ("More Language Support") shows community interest in Japanese but no official response yet.
+
+### Speech Translation
+
+Neither LFM2-Audio nor LFM2.5-Audio is currently marketed as a **speech translation** model (speech-in, translated-text-out). The focus is on ASR and TTS, not cross-lingual translation. For now, a JA→EN speech translation pipeline would still require the STT → Translator cascade.
+
+---
+
+## 4. Architecture Summary (LFM2 / LFM2.5)
+
+LFM2.5 is **not** a pure State Space Model. Marketing refers to "Liquid Foundation Models" drawing from their SSM/LTC research lineage, but the deployed architecture is:
+
+- **Hybrid convolution + sparse attention** (hardware-optimized via architecture search)
+- Compatible with llama.cpp (GGUF) — same inference path as transformer models
+- No special SSM runtime required; node-llama-cpp works as-is
+
+This means the existing `LlamaWorkerTranslator` / `slm-worker.ts` / `worker-pool.ts` infrastructure can serve LFM2.5 variants without changes.
+
+---
+
+## 5. Recommendation
+
+| Item | Verdict |
+|------|---------|
+| LFM2.5-ENJP-MT integration | **Wait** — not yet released; monitor `LiquidAI` HuggingFace org |
+| LFM2.5-350M as general base for fine-tune | Possible, but requires MT-specific fine-tuning effort |
+| LFM2.5-Audio for unified STT+Translation | **Wait** — English-only; Japanese support roadmap unclear |
+| LFM2-Audio for JA speech translation | Not viable now; no JA output capability |
+
+**Action items:**
+1. Set up a GitHub Actions workflow or cron to poll `https://huggingface.co/api/models?search=LFM2.5-ENJP-MT&author=LiquidAI` weekly
+2. When LFM2.5-ENJP-MT drops: update `getLFM2Variants()` in `model-downloader.ts` and benchmark vs current LFM2-350M-ENJP-MT and HY-MT1.5-1.8B
+3. Re-evaluate LFM2.5-Audio when Japanese language support is announced
+
+---
+
+## Sources
+
+- [Introducing LFM2.5: The Next Generation of On-Device AI — Liquid AI](https://www.liquid.ai/blog/introducing-lfm2-5-the-next-generation-of-on-device-ai)
+- [LFM2.5-350M: No Size Left Behind — Liquid AI](https://www.liquid.ai/blog/lfm2-5-350m-no-size-left-behind)
+- [Liquid AI Releases LFM2.5 — MarkTechPost (Jan 6, 2026)](https://www.marktechpost.com/2026/01/06/liquid-ai-releases-lfm2-5-a-compact-ai-model-family-for-real-on-device-agents/)
+- [Liquid AI Released LFM2.5-350M — MarkTechPost (Mar 31, 2026)](https://www.marktechpost.com/2026/03/31/liquid-ai-released-lfm2-5-350m-a-compact-350m-parameter-model-trained-on-28t-tokens-with-scaled-reinforcement-learning/)
+- [LFM2 Technical Report — arXiv:2511.23404](https://arxiv.org/html/2511.23404v1)
+- [LiquidAI/LFM2-350M-ENJP-MT — HuggingFace](https://huggingface.co/LiquidAI/LFM2-350M-ENJP-MT)
+- [LiquidAI/LFM2.5-Audio-1.5B — HuggingFace](https://huggingface.co/LiquidAI/LFM2.5-Audio-1.5B)
+- [LiquidAI/LFM2.5-Audio-1.5B — Language Support Discussion](https://huggingface.co/LiquidAI/LFM2.5-Audio-1.5B/discussions/6)
+- [LiquidAI/LFM2.5-1.2B-JP — HuggingFace](https://huggingface.co/LiquidAI/LFM2.5-1.2B-JP)
+- [💧 LFM2.5 Collection — HuggingFace](https://huggingface.co/collections/LiquidAI/lfm25)
+- [Liquid AI LFM2.5 Makes On-Device Speech Agents Real — COEY](https://coey.com/resources/blog/2026/01/06/liquid-ai-lfm2-5-makes-on-device-speech-agents-real/)
+- [GitHub: liquid-audio — Liquid4All](https://github.com/Liquid4All/liquid-audio)


### PR DESCRIPTION
## Description

Research findings for #587 — monitoring LFM2.5 ENJP-MT and LFM2-Audio for potential integration into the live-translate pipeline.

**Key findings:**
- LFM2.5-ENJP-MT does **not yet exist** on HuggingFace (only LFM2-350M-ENJP-MT and LFM2.5-1.2B-JP are available)
- LFM2.5-350M was released March 31, 2026 with 28T token pretraining + multi-stage RL; a fine-tuned ENJP-MT variant would be a near drop-in upgrade for `LFM2Translator.ts` when released
- LFM2.5-Audio (1.5B) is released but **English-only**; Japanese support is on the roadmap but no timeline confirmed
- Neither audio model supports speech translation (cross-lingual); the STT→Translator cascade remains necessary for now
- Recommendation: **Wait** on both; set up HuggingFace polling for LFM2.5-ENJP-MT release

Full findings: `docs/research/587-lfm25-audio.md`

Closes #587