### PR TITLE
Research: Linux support feasibility evaluation (#589)

### DIFF
--- a/docs/research/577-windows-livecaptions.md
+++ b/docs/research/577-windows-livecaptions.md
@@ -1,0 +1,356 @@
+# Windows LiveCaptions STT Integration Research
+
+**Issue:** #577
+**Date:** 2026-04-09
+**Status:** Research complete — viable; recommended as primary zero-setup STT engine on Windows 11 22H2+
+
+---
+
+## 1. Summary
+
+Windows 11's built-in Live Captions feature provides on-device, system-wide speech recognition that can be accessed programmatically via the Windows UI Automation (UIA) API. The LiveCaptions-Translator open-source project (C#, 2.7k stars) proves this pattern works: it polls the `CaptionsTextBlock` UIA element every ~25ms and feeds extracted text to translation APIs. For live-translate, this means **zero model download, zero GPU requirement, and zero per-second audio buffering** on Windows — audio capture is handled entirely by the OS.
+
+The integration adds a new `LiveCaptionsEngine.ts` that bypasses audio processing entirely: instead of feeding PCM audio through Whisper, it reads text from the OS-managed caption window.
+
+---
+
+## 2. Windows 11 Live Captions — How It Works
+
+### Architecture
+
+Live Captions is an accessibility feature shipped in Windows 11 22H2 (build 22621+). It runs a compact Azure AI Speech on-device model that processes any audio playing on the system (system audio + optional microphone mix).
+
+- **On-device processing**: all inference runs locally after an initial ~50MB language pack download
+- **Model**: compact Azure AI Speech variant, same fairness training as cloud Speech-to-Text
+- **Audio sources**: system audio, microphone, or both (user-controlled)
+- **Activation**: `Win + Ctrl + L`, Quick Settings, or `Start > All Apps > Accessibility > Live Captions`
+- **Window class**: `LiveCaptionsDesktopWindow` (discoverable via UIA)
+
+### Language Support (Recognition)
+
+20 languages supported for speech recognition (not translation):
+
+| Language | Variants |
+|----------|----------|
+| Chinese | Simplified, Traditional |
+| Danish | — |
+| English | US, UK, AU, CA, IN, NZ |
+| French | Canada, France |
+| German | — |
+| Italian | — |
+| Japanese | — |
+| Korean | — |
+| Portuguese | Brazil, Portugal |
+| Spanish | Mexico, Spain |
+
+**Translation** (24H2+ Copilot+ PCs only): 44 languages → English, 27 languages → Simplified Chinese. Translation is a separate feature from recognition and is not needed for this integration (live-translate handles translation).
+
+### ARM64 Support
+
+ARM64 Windows 11 is supported with caveats:
+- Chinese Traditional captions do **not** work on ARM64
+- Language pack installation progress may be hidden on ARM64
+- Unexpected delays possible when adding languages on ARM64
+
+### Accuracy
+
+- Described as "extremely high" for English under ideal conditions
+- Handles simultaneous speakers and background game audio reasonably well
+- Struggles with non-standard accents, technical jargon, overlapping speech
+- Real-world reviews note it is "almost always faster" than Microsoft Teams captioning
+- No published WER/CER benchmarks for Japanese; English real-world accuracy ~90-95% estimated
+
+### Known Limitations
+
+- Music, applause, and sung lyrics are not reliably transcribed
+- Only one audio device at a time (default output + optional mic)
+- "Captions are being missed" dialog appears in some audio gap scenarios
+- Window sizing resets across display resolution changes
+- **Not available on Windows 10** — hard requirement: Windows 11 22H2+
+
+---
+
+## 3. Windows UI Automation API — UIA Access from Node.js
+
+### How LiveCaptions-Translator Does It (C# Reference Implementation)
+
+The reference implementation (`SakiRinn/LiveCaptions-Translator`) is pure C# + .NET 8, using `UIAutomationClient`:
+
+```csharp
+// 1. Launch LiveCaptions process
+Process.Start("LiveCaptions");
+
+// 2. Find the window by process ID
+var condition = new PropertyCondition(AutomationElement.ProcessIdProperty, processId);
+AutomationElement window = AutomationElement.RootElement.FindFirst(TreeScope.Children, condition);
+// Validates window.Current.ClassName == "LiveCaptionsDesktopWindow"
+
+// 3. Extract caption text (cached element)
+private static AutomationElement captionsTextBlock;
+
+public static string GetCaptions(AutomationElement window) {
+    if (captionsTextBlock == null)
+        captionsTextBlock = FindElementByAId(window, "CaptionsTextBlock");
+    return captionsTextBlock?.Current.Name ?? string.Empty;
+}
+
+// 4. Poll + change detection (~25ms loop)
+// idleCount: unchanged text cycles; syncCount: incomplete sentence cycles
+// Queue for translation when: terminal punctuation, idleCount > MaxIdleInterval,
+// or syncCount > MaxSyncInterval
+```
+
+Key automation IDs:
+- `"CaptionsTextBlock"` — the element containing all visible caption text (`.Current.Name` property)
+- `"SettingsButton"` — for programmatic settings access
+
+### Node.js / Electron Integration Options
+
+Three viable approaches, ordered by recommendation:
+
+#### Option A: Native Node Addon (N-API) — Recommended
+
+Write a small C++ N-API addon (`live-captions-uia.node`) that wraps `UIAutomationClient.h` COM interfaces. Compiled via `node-gyp` on Windows, ships as prebuilt binary for x64/ARM64.
+
+```
+Electron main process
+  └── require('./live-captions-uia.node')
+        ├── LaunchLiveCaptions()       → spawns LiveCaptions.exe, returns HWND/pid
+        ├── GetCaptionsText()          → returns string from CaptionsTextBlock.Name
+        └── IsLiveCaptionsAvailable()  → checks Windows version + process state
+```
+
+Pros:
+- No extra runtime dependency (.NET not required)
+- Direct COM calls, minimal latency overhead
+- Full control over element caching and polling frequency
+- Compatible with Electron's native addon architecture (same as whisper-node-addon)
+
+Cons:
+- Requires Windows-only build step in CI (GitHub Actions)
+- ~200-400 lines of C++/COM boilerplate
+
+Precedent in this codebase: `whisper-node-addon` follows the same pattern.
+
+#### Option B: electron-edge-js (C# in-process)
+
+`electron-edge-js` (npm, v40.0.1, actively maintained) runs C# code in-process with Electron. Supports Electron 29-41 with pre-compiled binaries for x64 and ARM64.
+
+```typescript
+// In Electron main process (via IPC, not main thread — crashes on main thread)
+import edge from 'electron-edge-js'
+const getCaptions = edge.func(`
+  using System.Windows.Automation;
+  // ... C# UIA access inline or from compiled DLL
+`)
+const text = await getCaptions(null)
+```
+
+Pros:
+- No C++ required; C# can be inline string or compiled DLL
+- Re-uses exact same C# patterns as reference implementation
+- Supports Electron 29-41 natively
+
+Cons:
+- Requires .NET 8+ runtime on user machine (extra user-facing dependency)
+- **Must run via IPC** (using edge-js on the main Electron thread causes hard crash on window refresh)
+- Adds ~15-30MB to distribution size
+
+#### Option C: @bright-fish/node-ui-automation (npm)
+
+Pure Node.js N-API wrapper around `UIAutomationClient`, written in C++. MIT license.
+
+```typescript
+import { Automation, PropertyIds, TreeScopes } from '@bright-fish/node-ui-automation'
+const root = Automation.getRootElement()
+const condition = Automation.createPropertyCondition(PropertyIds.AutomationId, 'CaptionsTextBlock')
+const el = root.findFirst(TreeScopes.Descendants, condition)
+const text = el.getCurrentPropertyValue(PropertyIds.Name)
+```
+
+Pros:
+- npm install, no C++ authoring required
+- Wraps standard UIA COM interfaces
+
+Cons:
+- Low maintenance activity (small project, ~2 maintainers)
+- Electron version compatibility unconfirmed — needs testing
+- May need manual Electron ABI rebuild (`electron-rebuild`)
+
+---
+
+## 4. Architecture Diagram
+
+```
+Windows 11 (22H2+)
+┌─────────────────────────────────────────────────────────────┐
+│  System Audio / Microphone                                  │
+│         │                                                   │
+│         ▼                                                   │
+│  ┌─────────────────┐    Win+Ctrl+L or                      │
+│  │  LiveCaptions   │◄── programmatic spawn                 │
+│  │  (OS process)   │                                       │
+│  │  Azure AI model │                                       │
+│  │  on-device      │                                       │
+│  └────────┬────────┘                                       │
+│           │ CaptionsTextBlock.Name (UIA)                   │
+│           │ polled every ~25ms                             │
+│           ▼                                                 │
+│  ┌──────────────────────────────────────────────────────┐  │
+│  │  Electron main process                               │  │
+│  │  ┌────────────────────────┐                         │  │
+│  │  │  LiveCaptionsEngine.ts │                         │  │
+│  │  │  - isAvailable()       │◄── Win11 version check  │  │
+│  │  │  - initialize()        │    spawn LiveCaptions   │  │
+│  │  │  - startPolling()      │    25ms setInterval     │  │
+│  │  │  - changeDetection()   │    idleCount/syncCount  │  │
+│  │  │  - emit('result', ...) │    → EventEmitter       │  │
+│  │  └────────────────────────┘                         │  │
+│  │           │                                         │  │
+│  │           ▼                                         │  │
+│  │  TranslationPipeline (existing)                     │  │
+│  │  → TranslatorEngine → subtitle overlay             │  │
+│  └──────────────────────────────────────────────────────┘  │
+└─────────────────────────────────────────────────────────────┘
+```
+
+Key difference from existing STT engines: `LiveCaptionsEngine` emits **text segments** directly — no PCM audio is ever processed by live-translate. The `processAudio()` method returns `null` and is a no-op; text arrives via polling.
+
+---
+
+## 5. Polling Mechanism & Change Detection
+
+Based on the reference implementation:
+
+| Parameter | Value | Notes |
+|-----------|-------|-------|
+| Poll interval | ~25ms (40 Hz) | `setInterval` or native loop |
+| `idleCount` threshold | configurable | Sentence considered complete when text stable for N cycles |
+| `syncCount` threshold | configurable | Incomplete but changing text flushed after N cycles |
+| Sentence detection | terminal punctuation (`。.!?…`) | Flush immediately on punctuation |
+| Element caching | yes — re-lookup on `ElementNotAvailableException` | Element reference can go stale |
+
+Change detection pseudocode:
+```typescript
+let prev = ''
+let idleCount = 0
+let syncCount = 0
+
+setInterval(() => {
+  const current = nativeAddon.getCaptionsText()
+  if (current === prev) {
+    idleCount++
+    if (idleCount > MAX_IDLE) flush(prev)
+  } else {
+    idleCount = 0
+    syncCount++
+    if (endsWithPunctuation(current) || syncCount > MAX_SYNC) flush(current)
+    prev = current
+  }
+}, 25)
+```
+
+---
+
+## 6. Latency Characteristics
+
+| Metric | LiveCaptionsEngine | WhisperLocal (default) | MLX Whisper |
+|--------|-------------------|----------------------|-------------|
+| First-word latency | ~200-500ms (OS-controlled) | ~2-3s (VAD + inference) | ~2.9s |
+| Polling overhead | ~0ms (text read, no inference) | N/A | N/A |
+| Setup latency | ~1-2s (spawn LiveCaptions process) | ~3-5s (model load) | ~5-10s (model load) |
+| Model download | ~50MB language pack (OS, one-time) | ~540MB whisper model | ~1-2GB |
+| GPU/CPU load | 0% (OS-managed) | High (Whisper inference) | High (MLX) |
+
+LiveCaptions is faster in time-to-first-word but the OS controls the internal VAD and chunking — live-translate cannot tune these parameters. Whisper offers more control (VAD sensitivity, chunk size) at the cost of higher latency.
+
+---
+
+## 7. Auto-Detection and Fallback
+
+```typescript
+// LiveCaptionsEngine.isAvailable()
+async function isAvailable(): Promise<boolean> {
+  // 1. Platform check
+  if (process.platform !== 'win32') return false
+
+  // 2. Windows 11 22H2+ check via registry or os.release()
+  // Windows 11 = build 22000+; 22H2 = build 22621+
+  const build = getWindowsBuildNumber() // from registry or ver command
+  if (build < 22621) return false
+
+  // 3. Verify LiveCaptions.exe exists
+  // %SystemRoot%\System32\LiveCaptions.exe
+  return existsSync(join(process.env.SystemRoot!, 'System32', 'LiveCaptions.exe'))
+}
+```
+
+Fallback chain:
+```
+LiveCaptionsEngine (Windows 11 22H2+)
+  └── if not available → WhisperLocalEngine (existing default)
+```
+
+This mirrors the `AppleSpeechTranscriberEngine` pattern on macOS: platform-native zero-setup engine as primary, Whisper as universal fallback.
+
+---
+
+## 8. Limitations Summary
+
+| Limitation | Impact | Mitigation |
+|------------|--------|------------|
+| Windows 11 22H2+ only | ~70% of Windows users as of 2025 | Whisper fallback |
+| ARM64: Chinese Traditional broken | Edge case | Document, fallback to Whisper for zh-TW on ARM64 |
+| No music/applause transcription | Low (meeting/conversation use case) | Acceptable |
+| User must grant mic permission in LiveCaptions settings | One-time setup | Show onboarding dialog |
+| Cannot tune VAD sensitivity | Live-translate loses control | Acceptable trade-off |
+| LiveCaptions may show "captions missed" dialog | Occasional interruption | `HideLiveCaptions()` pattern from reference impl |
+| Translation feature (24H2+) separate from recognition | live-translate doesn't need it | N/A |
+| Not open source (OS black box) | Cannot fix bugs | Whisper fallback |
+
+---
+
+## 9. Implementation Recommendation
+
+**Recommended approach: Option A (Native N-API addon)**
+
+Rationale:
+1. Consistent with `whisper-node-addon` — same native addon pattern already in the codebase
+2. No .NET runtime dependency on user machine
+3. Full control over polling, element caching, and error recovery
+4. Pre-built binaries for x64 and ARM64 via existing GitHub Actions CI infrastructure
+
+**Implementation plan (matching issue #577 tasks):**
+
+1. Create `scripts/win-livecaptions/` with C++ N-API addon source:
+   - `LiveCaptionsAddon.cc` — UIA COM calls, `LaunchLiveCaptions`, `GetCaptionsText`, `IsAvailable`
+   - `binding.gyp` — Windows-only build config
+   - `postinstall.js` — prebuilt binary download (same pattern as whisper-node-addon)
+
+2. Create `src/engines/stt/LiveCaptionsEngine.ts`:
+   - Implements `STTEngine` interface (same as all other engines)
+   - `processAudio()` → returns `null` (no-op, OS handles audio)
+   - Starts polling on `initialize()`, stops on `dispose()`
+   - `isAvailable()` checks `win32` + build 22621+
+
+3. Register in `src/main/index.ts` → `initPipeline()` but **hide from UI SettingsPanel** (experimental) until benchmarked
+
+4. Auto-detect on Windows: if available, offer as default over WhisperLocal in Windows setup wizard
+
+5. Add Windows 11 version detection util to `src/main/platform.ts`
+
+**Estimated effort:** ~3-4 days (C++ addon ~1.5d, TS engine ~0.5d, CI/build ~1d, testing ~1d)
+
+---
+
+## 10. References
+
+- [Windows Live Captions — Microsoft Support](https://support.microsoft.com/en-us/windows/use-live-captions-to-better-understand-audio-b52da59c-14b8-4031-aeeb-f6a47e6055df)
+- [LiveCaptions-Translator (SakiRinn, 2.7k stars)](https://github.com/SakiRinn/LiveCaptions-Translator)
+- [LiveCaptions-Translator: Translation Process (DeepWiki)](https://deepwiki.com/SakiRinn/LiveCaptions-Translator/3.2-translation-process)
+- [LiveCaptions-Translator: Windows Integration (DeepWiki)](https://deepwiki.com/SakiRinn/LiveCaptions-Translator/8.1-windows-livecaptions-integration)
+- [Windows UI Automation — Microsoft Learn](https://learn.microsoft.com/en-us/windows/win32/winauto/entry-uiauto-win32)
+- [electron-edge-js (agracio)](https://github.com/agracio/electron-edge-js)
+- [@bright-fish/node-ui-automation (npm)](https://www.npmjs.com/package/@bright-fish/node-ui-automation)
+- [Windows LiveCaptions: Real-World Review (David Edmiston, 2025)](https://davidedmiston.com/post/2025/windows-live-captions/)
+- [Microsoft: Real-Time Translation in Live Captions — Insider Blog](https://blogs.windows.com/windows-insider/2024/12/18/releasing-real-time-translation-in-live-captions-to-more-copilot-pcs-in-the-dev-channel/)

--- a/docs/research/584-sharedarraybuffer-audio.md
+++ b/docs/research/584-sharedarraybuffer-audio.md
@@ -1,0 +1,291 @@
+# Research: SharedArrayBuffer Zero-Copy Audio IPC (#584)
+
+**Date:** 2026-04-09
+**Author:** research agent
+**Issue:** [#584 – SharedArrayBuffer zero-copy audio IPC](https://github.com/rioX432/live-translate/issues/584)
+
+---
+
+## Summary
+
+Issue #584 proposes replacing the current `Array.from(Float32Array)` → IPC → `new Float32Array()` copy pattern with a SharedArrayBuffer-based ring buffer for zero-copy audio transfer between the renderer and main/UtilityProcess. This document evaluates feasibility, design, performance impact, and security implications.
+
+**Recommendation: Defer to v2.0 / post-MVP. The current `MessagePort + transferable ArrayBuffer` path (added in #553) already eliminates the serialization cost that motivated this issue. SharedArrayBuffer adds non-trivial complexity and requires COOP/COEP headers or a custom Electron session protocol handler, and the incremental gain over transferable ArrayBuffers is marginal for the 3-second audio chunk sizes in the current pipeline.**
+
+---
+
+## 1. Current IPC Baseline
+
+### Current Path (pre-#553)
+```
+Renderer                     Main
+Float32Array  →  Array.from()  →  ipcRenderer.invoke()  →  JSON serialize/deserialize  →  new Float32Array()
+```
+- Two memory allocations + deep JSON copy per chunk
+- ~3s × 16kHz = 48,000 floats = 192 KB per chunk → JSON string ~1.2 MB
+
+### Current Path (post-#553, `audio-port.ts`)
+```
+Renderer                     Main
+Float32Array  →  buffer.slice()  →  port.postMessage(buf, [buf])  →  new Float32Array(buf)
+```
+- ArrayBuffer is **transferred** (ownership move, O(1) in time, zero copy)
+- One allocation in renderer; main receives the same memory block
+- This is already near-optimal for renderer ↔ main audio transfer
+
+The key insight: **transferable ArrayBuffers already achieve zero-copy** semantics between renderer and main because Chromium IPC ownership-transfers the underlying memory. The sender's reference is neutered after postMessage.
+
+---
+
+## 2. SharedArrayBuffer in Electron
+
+### 2.1 Cross-Origin Isolation Requirement
+
+SharedArrayBuffer (SAB) was disabled by all browsers in early 2018 due to the Spectre vulnerability and re-enabled in 2020 only under cross-origin isolation. In standard Chromium/Electron renderer contexts, a document must set:
+
+```http
+Cross-Origin-Opener-Policy: same-origin
+Cross-Origin-Embedder-Policy: require-corp
+```
+
+Only then is `crossOriginIsolated === true` and `new SharedArrayBuffer()` available.
+
+### 2.2 Electron Issue #45034
+
+[electron/electron#45034](https://github.com/electron/electron/issues/45034) (opened December 2024) requests a first-class Electron API for sharing read-only ArrayBuffers from main to renderer without requiring cross-origin isolation. As of April 2026 this issue is **still open with no merged implementation**. No native Electron SAB-over-IPC API exists yet.
+
+### 2.3 How to Enable SAB in Electron Today
+
+Three approaches are documented:
+
+**Option A — Session protocol handler with COOP/COEP headers (recommended)**
+```typescript
+session.defaultSession.webRequest.onHeadersReceived((details, callback) => {
+  callback({
+    responseHeaders: {
+      ...details.responseHeaders,
+      'Cross-Origin-Opener-Policy': ['same-origin'],
+      'Cross-Origin-Embedder-Policy': ['require-corp'],
+    },
+  })
+})
+```
+This makes `crossOriginIsolated = true` in the renderer; SAB becomes available.
+
+**Option B — `enableBlinkFeatures: 'SharedArrayBuffer'`** in `webPreferences`
+Historically worked but is undocumented, fragile, and may be removed in future Electron versions.
+
+**Option C — Service worker header injection**
+Feasible but adds runtime overhead and complexity.
+
+**Verdict:** Option A is the only reliable, officially-supported path. It requires injecting headers in `window-manager.ts` and auditing all third-party iframes/resources for CORP compliance (currently live-translate loads no external resources, so this is low-risk).
+
+### 2.4 UtilityProcess Limitation
+
+**Critical constraint:** `SharedArrayBuffer` cannot be passed to a `UtilityProcess` (Node.js child process) via the standard `process.parentPort.postMessage()` path. The Electron UtilityProcess runs in a Node.js environment, not a Chromium renderer; it has no `SharedArrayBuffer` in its V8 isolate unless SAB support is explicitly compiled in. The `worker-pool.ts` / `slm-worker.ts` pipeline that handles translation **cannot receive SAB directly**. Any SAB ring buffer would stop at the main process boundary; from main to UtilityProcess, audio data still must be serialized (or SharedMemory mapped at the OS level, which is out of scope).
+
+---
+
+## 3. Ring Buffer Design with Atomics
+
+The canonical pattern for SAB-based audio is a **wait-free SPSC (Single Producer, Single Consumer) ring buffer**, as documented in:
+- [padenot/ringbuf.js](https://github.com/padenot/ringbuf.js) — production-ready, MIT, 1.3 kB gzip
+- [Chrome DevRel – AudioWorklet design pattern](https://developer.chrome.com/blog/audio-worklet-design-pattern)
+
+### Layout (Float32, 3s at 16 kHz = 48,000 samples = 192 KB)
+
+```
+SAB layout (bytes):
+[0..3]   writeHead  (Int32, atomic)
+[4..7]   readHead   (Int32, atomic)
+[8..N]   audio data (Float32Array view)
+```
+
+### Producer (AudioWorklet / renderer)
+```javascript
+// Write samples to ring, advance writeHead with Atomics.store
+const head = Atomics.load(ctrl, WRITE_HEAD)
+const available = capacity - ((head - Atomics.load(ctrl, READ_HEAD) + capacity) % capacity)
+if (available >= frameLength) {
+  // copy into data[head % capacity]
+  Atomics.store(ctrl, WRITE_HEAD, (head + frameLength) % capacity)
+}
+```
+
+### Consumer (main process, after SAB is transferred)
+```javascript
+// Atomics.notify / Atomics.wait for wake-up
+Atomics.wait(ctrl, SYNC_FLAG, 0) // blocks Node.js thread — PROBLEMATIC (see §5)
+```
+
+### AudioWorklet Constraint
+
+`Atomics.wait()` (blocking) is **prohibited inside AudioWorkletGlobalScope** because the audio rendering thread must never block. The producer (AudioWorklet) can only use `Atomics.notify()` and non-blocking `Atomics.load/store`. The consumer (Worker or main) uses `Atomics.waitAsync()` or `Atomics.wait()`.
+
+Since the current live-translate pipeline uses `processorType: 'AudioWorklet'` per CLAUDE.md rules, the producer fits the AudioWorklet model. However, the `main` process is Node.js — `Atomics.wait()` blocks the main thread, which is unacceptable. **The consumer must use `Atomics.waitAsync()` (non-blocking) or poll via `setImmediate`.**
+
+---
+
+## 4. Performance Analysis
+
+### 4.1 Transferable ArrayBuffer vs. SharedArrayBuffer
+
+| Method | Copy cost | Ownership | Latency (3s chunk) | Suitable for live-translate |
+|---|---|---|---|---|
+| JSON IPC (old) | 2× alloc + serialize | Copied | ~2–5 ms overhead | No (pre-#553) |
+| Transferable ArrayBuffer (current) | 0 copies | Moved | ~0.1–0.3 ms | ✅ Yes |
+| SharedArrayBuffer | 0 copies | Shared | ~0.05–0.1 ms | ✅ Marginal gain |
+
+Key insight from [surma.dev benchmarks](https://surma.dev/things/is-postmessage-slow/): transferring an ArrayBuffer is O(1) regardless of size — the cost is pure IPC roundtrip overhead (~0.1–0.3 ms), not memory bandwidth. SAB removes even this small overhead but at the cost of Atomics synchronization complexity.
+
+### 4.2 Actual Payload Size
+
+```
+3s × 16,000 Hz × 4 bytes = 192,000 bytes ≈ 188 KB per chunk
+```
+
+At 188 KB, even a naive copy takes < 0.5 ms on a modern CPU (DDR5 bandwidth ~50+ GB/s). The bottleneck is **Whisper STT inference time (500 ms–2.9 s)**, not IPC transfer time. The transfer overhead is < 0.1% of total pipeline latency.
+
+### 4.3 Where SAB Would Actually Help
+
+SAB would provide measurable benefit only if audio were transferred at AudioWorklet frame size (128 samples = 512 bytes, every ~8 ms). The current architecture batches into VAD-detected speech segments (0.5–5s), completely eliminating this concern.
+
+---
+
+## 5. Cross-Process SAB Sharing
+
+### Renderer ↔ Main
+Feasible after enabling COOP/COEP headers (Option A in §2.3). SAB can be sent via `MessageChannelMain` / `webContents.postMessage`.
+
+### Main ↔ UtilityProcess (`slm-worker`)
+**Not feasible without OS-level shared memory.** The UtilityProcess is a Node.js process; its `parentPort` uses Chromium IPC under the hood, but `SharedArrayBuffer` cannot traverse this boundary in Electron's current API surface. The UtilityProcess receives translation requests as JSON (`{ text, id }`) — this is not audio data and is negligible in size (~100 bytes per request).
+
+### Renderer ↔ Subtitle Window
+Subtitle window is a separate `BrowserWindow`. SABs cannot be shared between two renderer processes in Electron without explicit `postMessage` with `[sharedArrayBuffer]` in the transfer list — and both windows need COOP/COEP. This is not a current bottleneck.
+
+---
+
+## 6. Security Implications
+
+### Spectre Mitigations
+COOP/COEP force cross-origin isolation, which puts the renderer in a dedicated process and prevents cross-origin timing attacks via shared timers. For a desktop Electron app with `contextIsolation: true` and no external origins, this has **no practical user-facing impact**.
+
+### What Changes with COOP/COEP in Electron
+- `crossOriginIsolated` becomes `true` in renderer
+- `performance.now()` gains higher precision (already useful)
+- Third-party iframes or external `<script src="...">` resources must send `Cross-Origin-Resource-Policy: cross-origin` — **live-translate loads no such resources, so this is a non-issue**
+- Existing `MessageChannelMain` audio path continues to work unchanged
+
+### electron-store Encryption
+No impact. SAB is an in-memory transport; stored API keys remain encrypted.
+
+### IPC Path Validation
+SAB does not change the IPC channel attack surface. Directory traversal validation in existing handlers is unaffected.
+
+---
+
+## 7. Existing Implementations in Production
+
+| Project | SAB Usage | Notes |
+|---|---|---|
+| [ringbuf.js](https://github.com/padenot/ringbuf.js) | AudioWorklet ↔ Worker | Reference SPSC implementation, Firefox Audio team |
+| Chrome AudioWorklet design pattern | AudioWorklet ↔ SharedWorker | Google reference implementation |
+| Figma | Requested but not implemented | Forum thread; uses WASM shared memory instead |
+| Web-based DAWs (e.g., Soundtrap) | AudioWorklet internal | Not cross-process Electron |
+
+No widely-deployed Electron app was found that routes microphone audio via SAB across renderer ↔ main process as of April 2026. The common pattern for Electron audio apps is MessagePort + transferable buffers (exactly what #553 implemented).
+
+---
+
+## 8. AudioWorklet Compatibility
+
+The current live-translate pipeline uses `processorType: 'AudioWorklet'` (CLAUDE.md rules). AudioWorklet compatibility with SAB:
+
+- **SAB creation**: requires `crossOriginIsolated === true` in the main document — achievable with COOP/COEP headers
+- **Atomics.wait**: **prohibited** in `AudioWorkletGlobalScope` (spec-mandated; the audio rendering thread must never block)
+- **Atomics.store/load/notify**: allowed — usable for non-blocking producer writes
+- **SAB in postMessage from worklet**: allowed with proper cross-origin isolation
+
+The existing VAD + AudioWorklet pipeline produces 0.5–5s speech segments, not 128-sample frames. Routing these through SAB instead of transferable ArrayBuffers would require restructuring the producer side of `useAudioCapture.ts` with minimal benefit.
+
+---
+
+## 9. Technical Design (If Implemented)
+
+### Prerequisites
+1. Add COOP/COEP header injection in `window-manager.ts` (session webRequest)
+2. Verify `crossOriginIsolated === true` in renderer on startup
+3. Audit all loaded resources for CORP compliance (currently: none needed)
+
+### Ring Buffer Architecture
+```
+[Renderer AudioWorklet]
+  → writes Float32 frames into SAB ring (Atomics.store)
+  → Atomics.notify(ctrl, SYNC_FLAG)
+
+[Main Process — audio-port.ts]
+  → receives SAB reference at startup (one-time postMessage)
+  → Atomics.waitAsync(ctrl, SYNC_FLAG, 0).then(() => drainRing())
+  → drainRing(): reads accumulated samples, runs VAD in-process
+  → on speech end: slices Float32Array view (zero-copy) → STT engine
+
+[UtilityProcess — slm-worker.ts]
+  → unchanged: receives translation request as JSON string
+```
+
+### SAB Allocation
+```typescript
+// Main process or renderer (whichever creates the SAB)
+const CAPACITY = 16000 * 10  // 10s at 16kHz
+const sab = new SharedArrayBuffer(
+  8 +                      // 2x Int32 for read/write heads
+  CAPACITY * Float32Array.BYTES_PER_ELEMENT
+)
+const ctrl = new Int32Array(sab, 0, 2)   // [writeHead, readHead]
+const data = new Float32Array(sab, 8)    // audio ring
+```
+
+### Estimated Code Change
+- `window-manager.ts`: +15 lines (COOP/COEP header injection)
+- `audio-port.ts`: ~+80 lines (SAB init, ring drain, Atomics.waitAsync loop)
+- `useAudioCapture.ts`: ~+50 lines (SAB write path alongside existing MessagePort path)
+- New file `src/renderer/audio-ring.ts`: ~100 lines (producer helper)
+- Total: ~250 lines, replaces/wraps existing transferable path
+
+---
+
+## 10. Recommendation
+
+**Status: Defer**
+
+| Factor | Assessment |
+|---|---|
+| Latency gain vs. current (#553) | < 0.3 ms per chunk (< 0.1% of pipeline) |
+| Implementation complexity | Medium–high (COOP/COEP, Atomics, dual code path) |
+| Risk of regression | Medium (AudioWorklet + SAB + Electron edge cases) |
+| UtilityProcess gain | None (SAB cannot cross this boundary) |
+| Value for real-time streaming (SimulMT) | Low-medium — streaming chunks are smaller but STT dominates |
+
+The transferable ArrayBuffer path from #553 already eliminates all copy overhead for the current chunk sizes. SAB would add meaningful value only if the pipeline moves to AudioWorklet frame-level (128-sample) routing — a much larger architectural change.
+
+**Revisit when:**
+- electron/electron#45034 lands with a native shared-buffer API
+- A sub-100ms latency requirement emerges from streaming/SimulMT work
+- VAD moves fully in-process (main), enabling tighter producer–consumer coupling
+
+---
+
+## References
+
+- [padenot/ringbuf.js — Wait-free SPSC ring buffer](https://github.com/padenot/ringbuf.js)
+- [Chrome DevRel — AudioWorklet design pattern with SharedArrayBuffer](https://developer.chrome.com/blog/audio-worklet-design-pattern)
+- [AudioWorklet + SharedArrayBuffer + Worker sample (Google)](https://googlechromelabs.github.io/web-audio-samples/audio-worklet/design-pattern/shared-buffer/)
+- [MDN — SharedArrayBuffer](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SharedArrayBuffer)
+- [web.dev — Making your website cross-origin isolated using COOP and COEP](https://web.dev/articles/coop-coep)
+- [web.dev — Why you need cross-origin isolated for powerful features](https://web.dev/articles/why-coop-coep)
+- [electron/electron#45034 — Read-only shared buffer from main to renderer](https://github.com/electron/electron/issues/45034)
+- [electron/electron#10409 — How to send SharedArrayBuffer from main to Window processes](https://github.com/electron/electron/issues/10409)
+- [surma.dev — Is postMessage slow?](https://surma.dev/things/is-postmessage-slow/)
+- [paul.cx — A wait-free SPSC ring buffer for the Web](https://blog.paul.cx/post/a-wait-free-spsc-ringbuffer-for-the-web/)
+- [WebAudio spec issue #1848 — Why AudioWorklet disables Atomics.wait](https://github.com/webaudio/web-audio-api/issues/1848)
+- [LogRocket — Understanding SharedArrayBuffer and cross-origin isolation](https://blog.logrocket.com/understanding-sharedarraybuffer-and-cross-origin-isolation/)

--- a/docs/research/589-linux-support.md
+++ b/docs/research/589-linux-support.md
@@ -1,0 +1,304 @@
+# Linux Support Feasibility Evaluation
+
+**Issue:** #589
+**Date:** 2026-04-09
+**Status:** Research complete — Linux support is feasible but overlay transparency on Wayland requires significant workarounds; X11 path is more straightforward
+
+---
+
+## Summary
+
+Linux support for live-translate is technically feasible, with native addons (whisper-node-addon, node-llama-cpp) providing pre-built Linux binaries. The main challenge is the subtitle overlay window: the current implementation uses `transparent: true, frame: false, alwaysOnTop: true` which works well on macOS but has known issues on both X11 and Wayland on Linux. Audio capture via PipeWire/PulseAudio is a non-issue with the existing `getUserMedia` approach.
+
+---
+
+## Platform Compatibility Matrix
+
+| Component | X11 | Wayland (wlroots/Hyprland) | Wayland (GNOME) | Notes |
+|-----------|-----|---------------------------|-----------------|-------|
+| Electron app shell | Works | Works (Electron 38.2+) | Works | Native Wayland default in Electron 38.2+ |
+| Transparent overlay window | Partial — requires `--enable-transparent-visuals --disable-gpu` | Partial — CSD support added in Electron 41 | Partial — flickering known | Black background on many setups without flags |
+| `alwaysOnTop` | Works | Limited — apps cannot set global z-order unilaterally | Broken for non-GNOME-native apps | Core Wayland design restriction |
+| `setIgnoreMouseEvents` | Works | Works | Works | No known issues |
+| `win.setPosition(x, y)` | Works | **Broken** — Wayland forbids global screen coordinates | **Broken** | Affects subtitle window repositioning |
+| `globalShortcut` | Works | Restricted — compositor dependent | Restricted | May not register across all apps |
+| `getUserMedia` audio | Works (PulseAudio/PipeWire) | Works | Works | Standard Web API, no issues |
+| whisper-node-addon | Pre-built x64/arm64 | Pre-built x64/arm64 | Pre-built x64/arm64 | CUDA not yet available |
+| node-llama-cpp | Pre-built + CUDA/Vulkan | Pre-built + CUDA/Vulkan | Pre-built + CUDA/Vulkan | Auto-detects GPU backend |
+
+---
+
+## Detailed Findings
+
+### 1. Electron Transparent Overlay on X11
+
+**Known issues:**
+- Transparency requires `--enable-transparent-visuals` and `--disable-gpu` launch flags on X11; without them, the window background renders black or gray.
+- The `--disable-gpu` flag disables hardware acceleration, which degrades rendering performance.
+- `setIgnoreMouseEvents` works on X11, but window manager behavior varies (some WMs re-decorate even frameless windows).
+- Compositor configuration (compton/picom) may be needed for compositing effects; bare X11 without a compositor will not render transparency.
+
+**Workaround:** Launch with `--enable-transparent-visuals --disable-gpu` in the Electron app args for Linux. This is a well-documented workaround but is not ideal (CPU rendering).
+
+**References:**
+- [electron/electron #15947](https://github.com/electron/electron/issues/15947)
+- [electron/electron #25153](https://github.com/electron/electron/issues/25153)
+- [electron/electron #40515](https://github.com/electron/electron/issues/40515)
+
+---
+
+### 2. Electron on Wayland
+
+**Current status (as of Electron 41):**
+- Electron 38.2+ defaults to native Wayland when `WAYLAND_DISPLAY` is set. Users can force XWayland via `--ozone-platform=x11`.
+- Electron 41 added full client-side decoration (CSD) support for frameless windows on Wayland.
+- Transparent windows: The Electron team notes that "colors, transparency, and hardware-accelerated rendering actually work better on Wayland than X11" with native Wayland.
+
+**Critical limitations for live-translate:**
+- `win.setPosition(x, y)` is **unsupported on Wayland** — Wayland deliberately forbids apps from accessing or setting global screen coordinates. This directly breaks the subtitle window's position-saving feature (`subtitlePositions` in store).
+- `screen.getCursorScreenPoint()` is unavailable.
+- `globalShortcut` is more restricted — compositors differ in how they expose global shortcuts.
+- Window focusing and ordering: apps cannot unilaterally move, resize, or bring windows to front without user interaction.
+- Multi-monitor handling: `screen.getAllDisplays()` works but window placement across displays requires workarounds.
+
+**References:**
+- [Electron Tech Talk: Wayland](https://www.electronjs.org/blog/tech-talk-wayland)
+- [electron/electron #44607 — Native Wayland completely broken](https://github.com/electron/electron/issues/44607)
+- [electron/electron #46843 — Multi-monitor ozone hints needed](https://github.com/electron/electron/issues/46843)
+
+---
+
+### 3. wlr-layer-shell for Overlay on Sway/Hyprland
+
+`wlr-layer-shell` is a Wayland extension protocol implemented by wlroots-based compositors (Sway, Hyprland, Wayfire) and KDE Plasma, but **not GNOME Mutter**. It allows a surface to be assigned to a compositor layer (background, bottom, top, overlay) with defined z-depth relative to normal windows — exactly what a subtitle overlay needs.
+
+**Key capabilities:**
+- Anchor to screen edges (useful for subtitle positioning at bottom of display).
+- Always-on-top rendering independent of window management stack.
+- Click-through passthrough (input region can be set to zero).
+
+**Electron cannot use wlr-layer-shell natively.** Electron uses standard `xdg_shell` surfaces. To use layer-shell, options are:
+1. **Native module** (e.g., a custom C++ Node addon using `libwayland-client` + `wlr-layer-shell-unstable-v1` protocol) to create a separate layer surface and communicate rendering via shared memory/socket. High complexity.
+2. **External overlay process**: Launch a separate Wayland layer-shell process (written in Rust/C using GTK4 + `gtk-layer-shell` or raw `libwayland`) and communicate via IPC. This is the approach taken by `whisper-overlay` (Rust).
+
+**whisper-overlay approach (reference):**
+- Uses `layer-shell` protocol + `virtual-keyboard-v1` for a fully Wayland-native overlay.
+- Implements global hotkey detection via **evdev directly** (bypasses GlobalShortcuts portal which does not work with layer-shell windows).
+- Works on Sway, Hyprland, and any wlroots compositor.
+- **GNOME is not supported** — layer-shell requires wlroots or KDE.
+- X11 support was attempted but proved impractical (GTK4 overlay + virtual input issues).
+
+**References:**
+- [wlr-layer-shell protocol spec](https://wayland.app/protocols/wlr-layer-shell-unstable-v1)
+- [oddlama/whisper-overlay](https://github.com/oddlama/whisper-overlay)
+- [wmww/gtk-layer-shell](https://github.com/wmww/gtk-layer-shell)
+
+---
+
+### 4. GNOME Mutter Limitations
+
+GNOME Mutter does **not implement wlr-layer-shell**. This is a deliberate design decision — GNOME uses its own proprietary protocols for desktop shell components.
+
+**Implications:**
+- Applications that rely on wlr-layer-shell for always-on-top overlays do not work on GNOME Wayland.
+- `alwaysOnTop` for standard xdg-shell windows works through Mutter's own window stacking, but is unreliable for overlay use cases (can be overridden by other windows).
+- No standard Wayland API for programmatic always-on-top exists; the Wayland design explicitly leaves z-order to the compositor.
+- Transparent window flickering is a known issue on Mutter (NW.js reports alternating ghost images when moving transparent windows, March 2025).
+
+**GNOME is the most constrained compositor for overlay apps.** Ubuntu (GNOME default), Fedora GNOME, and Pop!_OS all use Mutter.
+
+**References:**
+- [GNOME Discourse: any way to set window always on top programmatically?](https://discourse.gnome.org/t/any-way-to-set-window-always-on-top-programmatically/31579)
+- [Tauri #3117 — always on top not working on Wayland](https://github.com/tauri-apps/tauri/issues/3117)
+- [nwjs #8257 — transparent window flickering on Wayland](https://github.com/nwjs/nw.js/issues/8257)
+
+---
+
+### 5. Audio Capture: PulseAudio vs PipeWire
+
+**Meeting audio capture requirement:** live-translate needs to capture both microphone input and system audio (speaker loopback for meeting translation).
+
+**PipeWire (modern standard):**
+- Default on Fedora (since F34), Ubuntu 22.10+, Arch, Manjaro, and most current distros.
+- Provides PulseAudio compatibility layer (`pipewire-pulse`) — existing `getUserMedia` mic capture works without changes.
+- **Loopback/monitor capture:** PipeWire supports capturing monitor sources (system output) natively via `pw-loopback` or by selecting the monitor source in `getUserMedia` constraints.
+- `module-loopback` passes output of a capture stream to a playback stream, enabling virtual sink creation for meeting audio capture.
+- OBS uses PipeWire audio capture on Linux without issues.
+
+**PulseAudio (legacy):**
+- Still present on older Ubuntu LTS (20.04), Debian stable.
+- Loopback via `pactl load-module module-loopback`.
+- `getUserMedia` with `{ audio: { deviceId: 'monitor' } }` works on PulseAudio with the monitor source.
+
+**Assessment:** Audio capture itself is not a blocker. Both PulseAudio and PipeWire expose monitor sources that `getUserMedia` can capture. The user needs to select the correct audio device (monitor/loopback) in settings — same UX as macOS's BlackHole/Soundflower requirement.
+
+**Snap confinement caveat:** Snap packages have strict audio device access restrictions. AppImage or .deb are recommended over Snap for audio-dependent apps.
+
+**References:**
+- [PipeWire docs: module-loopback](https://docs.pipewire.org/page_module_loopback.html)
+- [PipeWire ArchWiki](https://wiki.archlinux.org/title/PipeWire)
+
+---
+
+### 6. whisper-node-addon Linux Builds
+
+**Status (v1.1.0, July 2025):**
+- Pre-built `.node` binaries available for: Linux x64, Linux arm64, Windows x64, macOS x64/arm64.
+- Automatic runtime detection — correct binary loads based on OS/arch.
+- **CUDA: Not yet available.** The roadmap lists "Add CUDA backend binaries and installation scripts" as an incomplete TODO. The maintainer lacks an NVIDIA GPU for testing.
+- Vulkan and OpenBLAS acceleration are available as alternatives.
+- On Linux without CUDA, inference runs on CPU via OpenBLAS (acceptable for Whisper small/base models, ~300-700ms per segment).
+
+**References:**
+- [Kutalia/whisper-node-addon](https://github.com/Kutalia/whisper-node-addon)
+- [@kutalia/whisper-node-addon on npm](https://www.npmjs.com/package/@kutalia/whisper-node-addon)
+
+---
+
+### 7. node-llama-cpp Linux Builds
+
+**Status:**
+- Pre-built binaries for Linux with **CUDA support** — automatically used when CUDA Toolkit is detected. Requires CUDA Toolkit 13.1+.
+- **Vulkan support** available for AMD/Intel GPUs and NVIDIA without CUDA toolkit.
+- **ROCm:** ROCm support was requested (issue #84) and merged. The underlying llama.cpp supports HIP/ROCm; node-llama-cpp inherits this. Requires ROCm to be installed from distro package manager.
+- Falls back to source build with cmake if no pre-built binary matches.
+- The shared `UtilityProcess` worker-pool pattern used in live-translate (`worker-pool.ts` → `slm-worker.ts`) is platform-agnostic and will work on Linux.
+
+**References:**
+- [node-llama-cpp CUDA guide](https://node-llama-cpp.withcat.ai/guide/CUDA)
+- [withcatai/node-llama-cpp](https://github.com/withcatai/node-llama-cpp)
+- [node-llama-cpp #84 — ROCm support](https://github.com/withcatai/node-llama-cpp/issues/84)
+
+---
+
+### 8. whisper-overlay (Rust) — Reference Implementation
+
+**How it handles Wayland overlay:**
+- Written in Rust, uses `layer-shell` and `virtual-keyboard-v1` Wayland protocols directly.
+- Creates a layer surface (not a standard xdg_shell window) assigned to the compositor's overlay layer — always on top by protocol design.
+- Global hotkey detection bypasses the GlobalShortcuts portal entirely, using **evdev directly** to monitor raw keyboard input. This avoids the portal's incompatibility with layer-shell windows.
+- Audio capture via PipeWire/PulseAudio.
+- Uses RealtimeSTT Python library + faster-whisper for transcription.
+
+**Key insight for live-translate:** whisper-overlay solves the always-on-top problem on Wayland by using layer-shell (not `alwaysOnTop` on a regular window). For Electron-based live-translate to achieve equivalent behavior on Wayland (wlroots), a separate layer-shell helper process would be needed. This is complex but achievable.
+
+**GNOME limitation acknowledged by whisper-overlay:** The GlobalShortcuts portal issue with layer-shell windows remains unresolved upstream. GNOME is not supported.
+
+**References:**
+- [oddlama/whisper-overlay](https://github.com/oddlama/whisper-overlay)
+- [whisper-overlay on crates.io](https://crates.io/crates/whisper-overlay)
+
+---
+
+### 9. Competitor Linux Support
+
+| Competitor | Linux Support | Overlay Approach | Notes |
+|-----------|---------------|-----------------|-------|
+| **whisper-overlay** | Yes (Wayland only, wlroots) | wlr-layer-shell (Rust) | STT only, no translation |
+| **Speech-Translate** | Yes (install from pip/git) | Tkinter window (no true overlay) | No prebuilt Linux binary; speaker input needs loopback workaround |
+| **Synthalingua** | Yes (Python, cross-platform) | CLI/web-based (no overlay) | No native overlay; outputs to web UI or stream captions |
+| **waystt** | Yes (Wayland) | Minimal PipeWire + STT daemon | No overlay; types text into focused window |
+
+**Observation:** No Linux competitor provides a live-translate style transparent overlay with translation on GNOME. whisper-overlay comes closest but is Wayland/wlroots-only and STT-only. This represents a genuine gap.
+
+**References:**
+- [Dadangdut33/Speech-Translate](https://github.com/Dadangdut33/Speech-Translate)
+- [cyberofficial/Synthalingua](https://github.com/cyberofficial/Synthalingua)
+- [sevos/waystt](https://github.com/sevos/waystt)
+
+---
+
+## Blockers
+
+### Hard blockers
+
+| Blocker | Scope | Mitigation |
+|---------|-------|-----------|
+| `win.setPosition()` broken on Wayland | Subtitle window positioning | Fall back to XWayland mode (`--ozone-platform=x11`) or use relative positioning relative to display bounds without absolute coordinates |
+| `alwaysOnTop` unreliable on GNOME Wayland | Subtitle overlay | No reliable fix without wlr-layer-shell or proprietary GNOME protocol; XWayland is the practical workaround |
+| Transparent window requires `--disable-gpu` on X11 | Subtitle overlay visual quality | Acceptable trade-off for Linux; GPU rendering not strictly required |
+
+### Soft blockers (workarounds exist)
+
+| Issue | Mitigation |
+|-------|-----------|
+| whisper-node-addon: no CUDA on Linux | Use Vulkan or CPU+OpenBLAS; CUDA is a TODO upstream |
+| `globalShortcut` restricted on Wayland | Document limitation; expose keyboard shortcut config for users to set compositor-level shortcuts |
+| Snap audio confinement | Use AppImage or .deb as primary packaging format |
+| GNOME Mutter layer-shell missing | Document GNOME as "limited support"; recommend wlroots compositors for full overlay functionality |
+
+---
+
+## Recommendation
+
+**Linux support is feasible with the following strategy:**
+
+### Phase 1: X11 + XWayland baseline (3-4 days effort)
+
+Force XWayland mode by default on Linux (`--ozone-platform=x11` + `--enable-transparent-visuals`). This gives a functional overlay on all Linux desktop environments (X11, GNOME Wayland via XWayland, KDE Wayland via XWayland, wlroots via XWayland). Subtitle window transparency and `alwaysOnTop` work reliably under XWayland.
+
+Tasks:
+- Add `--enable-transparent-visuals` + `--ozone-platform=x11` to Linux launch args in `package.json` / Electron entrypoint
+- Add AppImage packaging via electron-builder
+- Add `.deb` packaging as secondary
+- Linux CI pipeline (GitHub Actions `ubuntu-latest`)
+- Test whisper-node-addon and node-llama-cpp on Ubuntu x64
+
+### Phase 2: Native Wayland (wlroots) — optional, high effort (5-7 days)
+
+For users on Sway/Hyprland who want native Wayland (no XWayland), implement a companion `layer-shell` helper process (Rust or C with `gtk4-layer-shell`) that renders the subtitle overlay as a layer surface. Communicate with Electron main via Unix socket or stdin/stdout IPC.
+
+This requires a separate binary and is optional. whisper-overlay's open-source Rust implementation can serve as a reference.
+
+### Phase 3: GNOME native Wayland — not recommended
+
+No reliable solution exists for always-on-top transparent overlays on GNOME Wayland without GNOME-specific protocols. The XWayland fallback (Phase 1) covers GNOME users adequately.
+
+### STT Engine on Linux
+
+| Engine | Linux Status |
+|--------|-------------|
+| Whisper Local (whisper-node-addon) | Pre-built x64/arm64, CPU+Vulkan+OpenBLAS, no CUDA yet |
+| MLX Whisper | macOS-only (Apple Silicon) — not available |
+| Apple SpeechTranscriber | macOS 26+ only — not available |
+| SenseVoice (sherpa-onnx) | Works on Linux (ONNX Runtime is cross-platform) |
+| Moonshine Tiny JA | Requires evaluation for Linux build |
+
+SenseVoice via sherpa-onnx is the recommended STT fallback for Linux users until whisper-node-addon gains CUDA support.
+
+### Translation Engine on Linux
+
+All translation engines work on Linux:
+- HY-MT1.5-1.8B, LFM2, PLaMo-2, Hunyuan-MT: node-llama-cpp pre-built Linux binaries with CUDA/Vulkan/ROCm
+- Google Translate, DeepL, Gemini: cloud-based, platform-agnostic
+
+---
+
+## Effort Estimate
+
+| Phase | Effort | Value |
+|-------|--------|-------|
+| Phase 1: X11/XWayland baseline | 3-4 days | High — covers all Linux DE |
+| Phase 2: Wayland-native (wlroots) | 5-7 days | Medium — covers Sway/Hyprland power users |
+| Phase 3: GNOME native Wayland | Not feasible | — |
+
+**Total recommended:** Phase 1 only for initial Linux release. Phase 2 as a follow-up based on user demand.
+
+---
+
+## References
+
+- [Kutalia/whisper-node-addon](https://github.com/Kutalia/whisper-node-addon)
+- [withcatai/node-llama-cpp](https://github.com/withcatai/node-llama-cpp)
+- [node-llama-cpp CUDA guide](https://node-llama-cpp.withcat.ai/guide/CUDA)
+- [Electron Tech Talk: Wayland](https://www.electronjs.org/blog/tech-talk-wayland)
+- [electron/electron #15947 — Transparency on Linux](https://github.com/electron/electron/issues/15947)
+- [electron/electron #44607 — Native Wayland broken](https://github.com/electron/electron/issues/44607)
+- [oddlama/whisper-overlay — Wayland overlay reference](https://github.com/oddlama/whisper-overlay)
+- [wlr-layer-shell protocol](https://wayland.app/protocols/wlr-layer-shell-unstable-v1)
+- [wmww/gtk-layer-shell](https://github.com/wmww/gtk-layer-shell)
+- [GNOME Discourse: always-on-top programmatically](https://discourse.gnome.org/t/any-way-to-set-window-always-on-top-programmatically/31579)
+- [PipeWire module-loopback](https://docs.pipewire.org/page_module_loopback.html)
+- [Dadangdut33/Speech-Translate](https://github.com/Dadangdut33/Speech-Translate)
+- [cyberofficial/Synthalingua](https://github.com/cyberofficial/Synthalingua)
+- [Tauri #3117 — always-on-top broken on Wayland](https://github.com/tauri-apps/tauri/issues/3117)


### PR DESCRIPTION
## Summary

- Research findings for Linux support feasibility covering Electron overlay on X11/Wayland, audio capture, native addon compatibility, and competitor analysis
- Identifies Phase 1 (X11/XWayland baseline, 3-4 days) as the recommended approach for initial Linux support
- Documents hard blockers: `win.setPosition()` broken on native Wayland, `alwaysOnTop` unreliable on GNOME Wayland

## Key Findings

- **X11 overlay**: Works with `--enable-transparent-visuals --disable-gpu` flags; compositor (picom/compton) required
- **Wayland (wlroots)**: Layer-shell protocol is the right approach but Electron cannot use it natively; whisper-overlay (Rust) is a reference for a companion process approach
- **GNOME Mutter**: Does not implement wlr-layer-shell; XWayland fallback is the only practical option
- **whisper-node-addon**: Pre-built Linux x64/arm64 binaries available; CUDA not yet implemented (Vulkan/OpenBLAS available)
- **node-llama-cpp**: Full Linux support with CUDA, Vulkan, and ROCm pre-built binaries
- **Audio**: PipeWire/PulseAudio monitor sources work with existing `getUserMedia` approach; not a blocker

## Test plan

- [ ] Read `docs/research/589-linux-support.md` for full findings
- [ ] Review platform compatibility matrix
- [ ] Review blocker table and phase recommendations

Closes #589