### PR TITLE
#636 Standardize error handling in settings components

### DIFF
--- a/src/renderer/components/settings/CorrectionHistory.tsx
+++ b/src/renderer/components/settings/CorrectionHistory.tsx
@@ -14,7 +14,10 @@ export function CorrectionHistory(): React.JSX.Element {
   const [isEditMode, setIsEditMode] = useState(false)
 
   const loadHistory = useCallback(() => {
-    window.api.getCorrectionHistory?.().then(setHistory).catch((err) => console.warn('Failed to load correction history:', err))
+    window.api.getCorrectionHistory?.().then(setHistory).catch((err: unknown) => {
+      const e = err instanceof Error ? err : new Error(String(err))
+      console.warn('[correction-history] Failed to load correction history:', e.message)
+    })
   }, [])
 
   useEffect(() => {
@@ -37,7 +40,10 @@ export function CorrectionHistory(): React.JSX.Element {
   const handleClearHistory = useCallback(() => {
     window.api.clearCorrectionHistory?.().then(() => {
       setHistory([])
-    }).catch((err) => console.warn('Failed to clear correction history:', err))
+    }).catch((err: unknown) => {
+      const e = err instanceof Error ? err : new Error(String(err))
+      console.warn('[correction-history] Failed to clear correction history:', e.message)
+    })
   }, [])
 
   return (

--- a/src/renderer/components/settings/EnterpriseSettings.tsx
+++ b/src/renderer/components/settings/EnterpriseSettings.tsx
@@ -46,14 +46,23 @@ export function EnterpriseSettings({ disabled }: Props): React.JSX.Element {
   const [usagePeriod, setUsagePeriod] = useState(30)
 
   useEffect(() => {
-    window.api.enterpriseGetMdmConfig().then(setMdmConfig).catch((err) => console.warn('Failed to load MDM config:', err))
-    window.api.enterpriseGetTelemetryConsent().then(setTelemetry).catch((err) => console.warn('Failed to load telemetry consent:', err))
+    window.api.enterpriseGetMdmConfig().then(setMdmConfig).catch((err: unknown) => {
+      const e = err instanceof Error ? err : new Error(String(err))
+      console.warn('[enterprise] Failed to load MDM config:', e.message)
+    })
+    window.api.enterpriseGetTelemetryConsent().then(setTelemetry).catch((err: unknown) => {
+      const e = err instanceof Error ? err : new Error(String(err))
+      console.warn('[enterprise] Failed to load telemetry consent:', e.message)
+    })
   }, [])
 
   useEffect(() => {
     window.api.enterpriseGetUsageSummary(usagePeriod).then((data) => {
       if (!('error' in data)) setUsage(data)
-    }).catch((err) => console.warn('Failed to load usage summary:', err))
+    }).catch((err: unknown) => {
+      const e = err instanceof Error ? err : new Error(String(err))
+      console.warn('[enterprise] Failed to load usage summary:', e.message)
+    })
   }, [usagePeriod])
 
   const handleTelemetryToggle = async (): Promise<void> => {

--- a/src/renderer/components/settings/GlossarySettings.tsx
+++ b/src/renderer/components/settings/GlossarySettings.tsx
@@ -39,7 +39,10 @@ export function GlossarySettings({
     if (orgGlossaryTerms.length > 0 && glossaryTerms.length > 0) {
       window.api.getMergedGlossary().then((result) => {
         setConflicts(result.conflicts)
-      }).catch((err) => console.warn('Failed to merge glossary:', err))
+      }).catch((err: unknown) => {
+        const e = err instanceof Error ? err : new Error(String(err))
+        console.warn('[glossary] Failed to merge glossary:', e.message)
+      })
     } else {
       setConflicts([])
     }
@@ -69,8 +72,10 @@ export function GlossarySettings({
         }
         setGlossaryStatus(`Imported ${result.count} terms`)
       }
-    } catch (err) {
-      setGlossaryStatus(`Import failed: ${err}`)
+    } catch (err: unknown) {
+      const e = err instanceof Error ? err : new Error(String(err))
+      console.warn('[glossary] Import failed:', e.message)
+      setGlossaryStatus(`Import failed: ${e.message}`)
     }
   }
 
@@ -87,8 +92,10 @@ export function GlossarySettings({
         return
       }
       setGlossaryStatus(`Exported ${result.count} terms`)
-    } catch (err) {
-      setGlossaryStatus(`Export failed: ${err}`)
+    } catch (err: unknown) {
+      const e = err instanceof Error ? err : new Error(String(err))
+      console.warn('[glossary] Export failed:', e.message)
+      setGlossaryStatus(`Export failed: ${e.message}`)
     }
   }
 

--- a/src/renderer/components/settings/ModelDownloadProgress.tsx
+++ b/src/renderer/components/settings/ModelDownloadProgress.tsx
@@ -64,8 +64,9 @@ export function ModelDownloadProgress({
       setDownloadStatus(status)
       setIsFirstRun(firstRun)
       if (status.status === 'downloading') setDownloading(true)
-    }).catch(() => {
-      // Ignore errors on load
+    }).catch((err: unknown) => {
+      const e = err instanceof Error ? err : new Error(String(err))
+      console.warn('[model-download] Failed to load onboarding status:', e.message)
     })
   }, [])
 
@@ -90,7 +91,9 @@ export function ModelDownloadProgress({
     setDownloading(true)
     try {
       await window.api.onboardingStartDownload()
-    } catch {
+    } catch (err: unknown) {
+      const e = err instanceof Error ? err : new Error(String(err))
+      console.warn('[model-download] Failed to start download:', e.message)
       setDownloading(false)
     }
   }, [])
@@ -102,8 +105,9 @@ export function ModelDownloadProgress({
         setSwitchedToLocal(true)
         onSwitchToLocal(result.engine)
       }
-    } catch {
-      // Ignore
+    } catch (err: unknown) {
+      const e = err instanceof Error ? err : new Error(String(err))
+      console.warn('[model-download] Failed to switch to local engine:', e.message)
     }
   }, [onSwitchToLocal])
 
@@ -112,8 +116,9 @@ export function ModelDownloadProgress({
       await window.api.onboardingDismiss()
       setIsFirstRun(false)
       onDismiss()
-    } catch {
-      // Ignore
+    } catch (err: unknown) {
+      const e = err instanceof Error ? err : new Error(String(err))
+      console.warn('[model-download] Failed to dismiss onboarding:', e.message)
     }
   }, [onDismiss])
 

--- a/src/renderer/components/settings/TTSSettings.tsx
+++ b/src/renderer/components/settings/TTSSettings.tsx
@@ -59,12 +59,18 @@ export function TTSSettings({ disabled }: TTSSettingsProps): React.JSX.Element {
       setVoice(settings.voice)
       setVolume(settings.volume)
       setOutputDevice(settings.outputDevice)
-    }).catch((err) => console.warn('Failed to load TTS settings:', err))
+    }).catch((err: unknown) => {
+      const e = err instanceof Error ? err : new Error(String(err))
+      console.warn('[tts-settings] Failed to load TTS settings:', e.message)
+    })
 
     // Enumerate audio output devices
     navigator.mediaDevices.enumerateDevices().then((devices) => {
       setOutputDevices(devices.filter((d) => d.kind === 'audiooutput'))
-    }).catch((err) => console.warn('Failed to enumerate audio devices:', err))
+    }).catch((err: unknown) => {
+      const e = err instanceof Error ? err : new Error(String(err))
+      console.warn('[tts-settings] Failed to enumerate audio devices:', e.message)
+    })
   }, [])
 
   // Set up TTS audio playback listener
@@ -80,12 +86,14 @@ export function TTSSettings({ disabled }: TTSSettingsProps): React.JSX.Element {
     try {
       const result = await window.api.ttsSetEnabled(checked)
       if (result.error) {
-        console.error('TTS enable failed:', result.error)
+        console.error('[tts-settings] TTS enable failed:', result.error)
         setEnabled(false)
       } else {
         setEnabled(checked)
       }
-    } catch {
+    } catch (err: unknown) {
+      const e = err instanceof Error ? err : new Error(String(err))
+      console.warn('[tts-settings] TTS toggle failed:', e.message)
       setEnabled(false)
     } finally {
       setLoading(false)
@@ -223,13 +231,17 @@ function playTtsAudio(
 
   // Route to specific output device if supported and specified
   if (outputDeviceId && 'setSinkId' in audioCtx) {
-    (audioCtx as AudioContextWithSink).setSinkId(outputDeviceId).catch(() => {
-      // Fallback to default device if setSinkId fails
+    (audioCtx as AudioContextWithSink).setSinkId(outputDeviceId).catch((err: unknown) => {
+      const e = err instanceof Error ? err : new Error(String(err))
+      console.warn('[tts-settings] setSinkId failed, falling back to default device:', e.message)
     })
   }
 
   source.onended = (): void => {
-    audioCtx.close().catch((err) => console.warn('AudioContext close failed:', err))
+    audioCtx.close().catch((err: unknown) => {
+      const e = err instanceof Error ? err : new Error(String(err))
+      console.warn('[tts-settings] AudioContext close failed:', e.message)
+    })
   }
 
   source.start()

--- a/src/renderer/components/settings/UpdateStatus.tsx
+++ b/src/renderer/components/settings/UpdateStatus.tsx
@@ -15,7 +15,8 @@ export function UpdateStatus(): React.JSX.Element {
   useEffect(() => {
     // Load current status on mount
     window.api.updateGetStatus().then(setUpdate).catch((err: unknown) => {
-      console.warn('Failed to fetch update status:', err)
+      const e = err instanceof Error ? err : new Error(String(err))
+      console.warn('[update-status] Failed to fetch update status:', e.message)
     })
 
     // Listen for status changes from main process

--- a/src/renderer/components/settings/VirtualMicSettings.tsx
+++ b/src/renderer/components/settings/VirtualMicSettings.tsx
@@ -33,13 +33,19 @@ export function VirtualMicSettings({ disabled }: VirtualMicSettingsProps): React
       setActiveDeviceId(status.activeDeviceId)
       setActiveDeviceName(status.activeDeviceName)
       setDevices(status.availableDevices)
-    }).catch((err) => console.warn('Failed to get virtual mic status:', err))
+    }).catch((err: unknown) => {
+      const e = err instanceof Error ? err : new Error(String(err))
+      console.warn('[virtual-mic] Failed to get status:', e.message)
+    })
   }, [])
 
   const refreshDevices = useCallback(() => {
     window.api.virtualMicRefreshDevices().then((devs) => {
       setDevices(devs)
-    }).catch((err) => console.warn('Failed to refresh virtual mic devices:', err))
+    }).catch((err: unknown) => {
+      const e = err instanceof Error ? err : new Error(String(err))
+      console.warn('[virtual-mic] Failed to refresh devices:', e.message)
+    })
   }, [])
 
   const handleEnable = useCallback(async (deviceId: number) => {
@@ -56,7 +62,9 @@ export function VirtualMicSettings({ disabled }: VirtualMicSettingsProps): React
         const device = devices.find((d) => d.id === deviceId)
         setActiveDeviceName(device?.name ?? null)
       }
-    } catch {
+    } catch (err: unknown) {
+      const e = err instanceof Error ? err : new Error(String(err))
+      console.warn('[virtual-mic] Failed to enable:', e.message)
       setEnabled(false)
       setError('Failed to enable virtual mic')
     } finally {
@@ -72,7 +80,9 @@ export function VirtualMicSettings({ disabled }: VirtualMicSettingsProps): React
       setEnabled(false)
       setActiveDeviceId(null)
       setActiveDeviceName(null)
-    } catch {
+    } catch (err: unknown) {
+      const e = err instanceof Error ? err : new Error(String(err))
+      console.warn('[virtual-mic] Failed to disable:', e.message)
       setError('Failed to disable virtual mic')
     } finally {
       setLoading(false)


### PR DESCRIPTION
## Summary
- Add `[module-name]` prefixes to all `console.warn/error()` calls in settings components for structured logging consistency
- Replace empty catch blocks (`// Ignore`) with `console.warn()` calls so errors are visible in DevTools
- Normalize all caught errors with `err instanceof Error ? err : new Error(String(err))` pattern
- Add explicit `err: unknown` type annotations to all catch clauses

## Affected Files
- `TTSSettings.tsx` — 5 catches fixed (prefixes, empty setSinkId catch, bare catch)
- `VirtualMicSettings.tsx` — 4 catches fixed (prefixes, 2 bare catches)
- `UpdateStatus.tsx` — 1 catch fixed (prefix, normalization)
- `GlossarySettings.tsx` — 3 catches fixed (prefix, inline `${err}` → normalized `.message`)
- `ModelDownloadProgress.tsx` — 4 catches fixed (all were empty `// Ignore` blocks)
- `EnterpriseSettings.tsx` — 3 catches fixed (prefixes, normalization)
- `CorrectionHistory.tsx` — 2 catches fixed (prefixes, normalization)

No functional changes. `AudioSettings.tsx` had no error handling to fix.

Closes #636

## Test plan
- [x] `npm run typecheck` passes
- [x] `npm run test` passes (231 tests)
- [ ] Verify settings panel loads without regressions
- [ ] Check DevTools console shows `[module-name]` prefixed warnings on IPC failures