### PR TITLE
#606 Reduce audio chunk default to 800ms with UI slider

### DIFF
--- a/src/main/store.ts
+++ b/src/main/store.ts
@@ -184,7 +184,7 @@ export const store = new Store<AppSettings>({
     targetLanguage: 'en',
     wsAudioPort: DEFAULT_WS_PORT,
     noiseSuppressionEnabled: false,
-    streamingIntervalMs: 1000,
+    streamingIntervalMs: 800,
     showConfidenceIndicator: true,
     audioSource: 'microphone',
     ttsEnabled: false,

--- a/src/renderer/components/SettingsPanel.tsx
+++ b/src/renderer/components/SettingsPanel.tsx
@@ -91,6 +91,11 @@ function SettingsPanel(): React.JSX.Element {
         noiseSuppressionEnabled={s.noiseSuppression.enabled}
         onNoiseSuppressionChange={s.noiseSuppression.setEnabled}
         platform={s.platform}
+        streamingIntervalMs={s.streamingIntervalMs}
+        onStreamingIntervalChange={(v) => {
+          s.setStreamingIntervalMs(v)
+          window.api.saveSettings({ streamingIntervalMs: v })
+        }}
       />
 
       {/* Current config summary — always visible */}

--- a/src/renderer/components/settings/AudioSettings.tsx
+++ b/src/renderer/components/settings/AudioSettings.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { Section } from './Section'
-import { selectStyle } from './shared'
+import { selectStyle, sliderLabelStyle } from './shared'
 import type { UseAudioCaptureReturn, AudioSource } from '../../hooks/useAudioCapture'
 
 /** Audio source display labels */
@@ -18,9 +18,12 @@ interface AudioSettingsProps {
   onNoiseSuppressionChange: (enabled: boolean) => void
   /** macOS requires Screen Recording permission for system audio (#501) */
   platform: string
+  /** #606: Streaming chunk interval in ms */
+  streamingIntervalMs: number
+  onStreamingIntervalChange: (ms: number) => void
 }
 
-export function AudioSettings({ audio, disabled, noiseSuppressionEnabled, onNoiseSuppressionChange, platform }: AudioSettingsProps): React.JSX.Element {
+export function AudioSettings({ audio, disabled, noiseSuppressionEnabled, onNoiseSuppressionChange, platform, streamingIntervalMs, onStreamingIntervalChange }: AudioSettingsProps): React.JSX.Element {
   const showMicSelector = audio.audioSource !== 'system'
 
   return (
@@ -113,6 +116,27 @@ export function AudioSettings({ audio, disabled, noiseSuppressionEnabled, onNois
           <span>Noise suppression (DeepFilterNet3)</span>
         </label>
       )}
+      {/* #606: Streaming interval slider */}
+      <div style={{ marginTop: '10px' }}>
+        <label style={sliderLabelStyle}>
+          Streaming Interval: {streamingIntervalMs}ms
+        </label>
+        <input
+          type="range"
+          min={500}
+          max={3000}
+          step={100}
+          value={streamingIntervalMs}
+          onChange={(e) => onStreamingIntervalChange(Number(e.target.value))}
+          disabled={disabled}
+          style={{ width: '100%' }}
+          aria-label="Streaming interval in milliseconds"
+        />
+        <div style={{ display: 'flex', justifyContent: 'space-between', fontSize: '10px', color: '#64748b' }}>
+          <span>500ms (lower latency)</span>
+          <span>3000ms (higher accuracy)</span>
+        </div>
+      </div>
       {audio.permissionError && (
         <div style={{ marginTop: '6px', fontSize: '12px', color: '#ef4444' }}>
           {audio.permissionError}

--- a/src/renderer/hooks/useAudioCapture.ts
+++ b/src/renderer/hooks/useAudioCapture.ts
@@ -35,7 +35,7 @@ export interface NoiseSuppressionProcessor {
   destroy: () => Promise<void>
 }
 
-const DEFAULT_STREAMING_INTERVAL_MS = 1000
+const DEFAULT_STREAMING_INTERVAL_MS = 800
 const SAMPLE_RATE = 16000
 const MAX_ROLLING_BUFFER_SECONDS = 3
 /** Overlap from previous chunk to prevent word boundary cutting (200ms at 16kHz) */

--- a/src/renderer/hooks/useSessionSettings.ts
+++ b/src/renderer/hooks/useSessionSettings.ts
@@ -30,6 +30,9 @@ export interface SessionSettingsState {
 
   audio: UseAudioCaptureReturn
   noiseSuppression: UseNoiseSuppressionReturn
+
+  streamingIntervalMs: number
+  setStreamingIntervalMs: (v: number) => void
 }
 
 export function useSessionSettings(): SessionSettingsState {
@@ -47,8 +50,8 @@ export function useSessionSettings(): SessionSettingsState {
 
   const [crashedSession, setCrashedSession] = useState<{ config: Record<string, unknown>; startedAt: number } | null>(null)
 
-  // Streaming interval from settings (#506)
-  const [streamingIntervalMs, setStreamingIntervalMs] = useState<number | undefined>(undefined)
+  // Streaming interval from settings (#506, #606: lowered default to 800ms)
+  const [streamingIntervalMs, setStreamingIntervalMs] = useState<number>(800)
 
   // Noise suppression + audio capture
   const noiseSuppression = useNoiseSuppression()
@@ -189,6 +192,7 @@ export function useSessionSettings(): SessionSettingsState {
     isSummarizing, setIsSummarizing,
     crashedSession, setCrashedSession,
     startSessionTimer, stopSessionTimer,
-    audio, noiseSuppression
+    audio, noiseSuppression,
+    streamingIntervalMs, setStreamingIntervalMs
   }
 }

--- a/src/renderer/hooks/useSettingsState.ts
+++ b/src/renderer/hooks/useSettingsState.ts
@@ -136,6 +136,8 @@ export interface SettingsState {
   // Audio + noise suppression
   audio: UseAudioCaptureReturn
   noiseSuppression: UseNoiseSuppressionReturn
+  streamingIntervalMs: number
+  setStreamingIntervalMs: (v: number) => void
 
   // Actions
   handleStart: () => Promise<void>
@@ -197,7 +199,8 @@ export function useSettingsState(): SettingsState {
         adaptiveRoutingEnabled: engine.adaptiveRoutingEnabled,
         adaptiveRoutingShortThreshold: engine.adaptiveRoutingShortThreshold,
         adaptiveRoutingLongThreshold: engine.adaptiveRoutingLongThreshold,
-        adaptiveRoutingQualityEngine: engine.adaptiveRoutingQualityEngine
+        adaptiveRoutingQualityEngine: engine.adaptiveRoutingQualityEngine,
+        streamingIntervalMs: session.streamingIntervalMs
       }), 10_000, 'saveSettings')
 
       const resolvedMode = resolveEngineMode(engine.engineMode, apiKeys, engine.gpuInfo)
@@ -341,6 +344,7 @@ export function useSettingsState(): SettingsState {
 
     // Audio + noise suppression
     audio: session.audio, noiseSuppression: session.noiseSuppression,
+    streamingIntervalMs: session.streamingIntervalMs, setStreamingIntervalMs: session.setStreamingIntervalMs,
 
     // UI state
     showAdvanced, setShowAdvanced,


### PR DESCRIPTION
## Summary
- Lower default streaming interval from 1000ms to 800ms for reduced latency
- Add "Streaming Interval" slider (500-3000ms) to Audio Settings UI
- Persist the setting via electron-store and save on pipeline start
- VAD-triggered speech-end submission was already implemented — no changes needed

## Test plan
- [ ] Verify slider appears in Audio Settings section (disabled while running)
- [ ] Confirm default shows 800ms for fresh installs
- [ ] Change slider value, restart app, confirm persisted
- [ ] Start pipeline at 500ms and 800ms, verify latency improvement
- [ ] Verify `npm run typecheck` and `npm run test` pass

Closes #606