### PR TITLE
#607 Implement SSBD for streaming re-translation

### DIFF
--- a/src/engines/translator/LlamaWorkerTranslator.ts
+++ b/src/engines/translator/LlamaWorkerTranslator.ts
@@ -139,6 +139,43 @@ export abstract class LlamaWorkerTranslator implements TranslatorEngine {
   }
 
   /**
+   * SSBD (Self-Speculative Biased Decoding) translation for re-translation (#607).
+   * Uses the previous translation as a speculative draft, verifying tokens in batch.
+   * Only re-generates from the divergence point, significantly speeding up
+   * re-translations when the source text is only slightly changed.
+   *
+   * Falls back to regular translate if SSBD fails in the worker.
+   *
+   * @param text - New source text to translate
+   * @param previousOutput - Previous translation to use as speculative draft
+   * @param from - Source language
+   * @param to - Target language
+   * @param context - Translation context (glossary, previous segments)
+   */
+  async translateSSBD(
+    text: string,
+    previousOutput: string,
+    from: Language,
+    to: Language,
+    context?: TranslateContext
+  ): Promise<string> {
+    if (!text.trim()) return previousOutput || ''
+    if (from === to) return text
+    if (!this.initialized) {
+      throw new Error(`[${this.id}-worker] Not initialized`)
+    }
+
+    const t0 = performance.now()
+    const result = await workerPool.sendRequest(
+      { type: 'translate-ssbd', text, previousOutput, from, to, context },
+      'translate-ssbd'
+    )
+    const ms = performance.now() - t0
+    this.log.info(`ssbd ${from}→${to} inputLen=${text.length} outputLen=${result.length} time=${ms.toFixed(0)}ms`)
+    return result
+  }
+
+  /**
    * SimulMT translation with persistent KV cache session (#550).
    * Uses a multi-turn conversational format where the system prompt
    * and prior context are cached in KV, reducing latency for

--- a/src/engines/types.ts
+++ b/src/engines/types.ts
@@ -59,8 +59,8 @@ export interface TranslationResult {
   confirmedText?: string
   /** Unstable trailing portion still being recognized */
   interimText?: string
-  /** Translation stage: 'draft' (OPUS-MT), 'refined' (LLM), 'ger-corrected' (GER), 'simulmt-partial' (partial clause), 'simulmt-revised' (full clause revision) */
-  translationStage?: 'draft' | 'refined' | 'ger-corrected' | 'simulmt-partial' | 'simulmt-revised'
+  /** Translation stage: 'draft' (OPUS-MT), 'refined' (LLM), 'ger-corrected' (GER), 'simulmt-partial' (partial clause), 'simulmt-revised' (full clause revision), 'ssbd-retranslated' (SSBD re-translation) */
+  translationStage?: 'draft' | 'refined' | 'ger-corrected' | 'simulmt-partial' | 'simulmt-revised' | 'ssbd-retranslated'
   /** STT confidence score (0.0–1.0), forwarded from STTResult for UI styling */
   confidence?: number
   /** Speaker label from diarization (e.g. 'Speaker 1', 'Speaker 2') */
@@ -138,6 +138,20 @@ export interface TranslatorEngine {
     from: Language,
     to: Language,
     isRevision: boolean,
+    context?: TranslateContext
+  ): Promise<string>
+
+  /**
+   * SSBD (Self-Speculative Biased Decoding) translation for re-translation (#607).
+   * Uses the previous translation as a speculative draft, verifying tokens in batch.
+   * Only re-generates from the divergence point for faster re-translations.
+   * Optional — only offline LLM engines support this.
+   */
+  translateSSBD?(
+    text: string,
+    previousOutput: string,
+    from: Language,
+    to: Language,
     context?: TranslateContext
   ): Promise<string>
 

--- a/src/main/slm-worker.ts
+++ b/src/main/slm-worker.ts
@@ -7,6 +7,7 @@
  *   Main → Worker: { type: 'init', modelPath: string, kvCacheQuant?: boolean, modelType?: ModelType, draftModelPath?: string }
  *   Main → Worker: { type: 'translate', id: string, text: string, from: string, to: string }
  *   Main → Worker: { type: 'translate-incremental', id: string, text: string, previousOutput: string, from: string, to: string }
+ *   Main → Worker: { type: 'translate-ssbd', id: string, text: string, previousOutput: string, from: string, to: string }
  *   Main → Worker: { type: 'translate-simulmt', id: string, text: string, previousOutput: string, from: string, to: string, isRevision: boolean }
  *   Main → Worker: { type: 'simulmt-reset' }
  *   Main → Worker: { type: 'summarize', id: string, transcript: string }
@@ -16,7 +17,7 @@
  *   Worker → Main: { type: 'error', id?: string, message: string }
  */
 
-import type { Llama, LlamaModel, LlamaContext, LlamaContextSequence } from 'node-llama-cpp'
+import type { Llama, LlamaModel, LlamaContext, LlamaContextSequence, Token } from 'node-llama-cpp'
 import { LANG_NAMES_EN, LANG_NAMES_ZH } from '../engines/language-names'
 import { formatGlossaryPrompt } from '../engines/translator/glossary-utils'
 import { createLogger } from './logger'
@@ -30,6 +31,7 @@ type WorkerInboundMessage =
   | { type: 'init'; modelPath: string; kvCacheQuant?: boolean; modelType?: ModelType; draftModelPath?: string }
   | { type: 'translate'; id: string; text: string; from: string; to: string; context?: TranslateContextPayload }
   | { type: 'translate-incremental'; id: string; text: string; previousOutput: string; from: string; to: string; context?: TranslateContextPayload }
+  | { type: 'translate-ssbd'; id: string; text: string; previousOutput: string; from: string; to: string; context?: TranslateContextPayload }
   | { type: 'translate-simulmt'; id: string; text: string; previousOutput: string; from: string; to: string; isRevision: boolean; context?: TranslateContextPayload }
   | { type: 'simulmt-reset' }
   | { type: 'summarize'; id: string; transcript: string }
@@ -39,6 +41,52 @@ type WorkerInboundMessage =
 interface TranslateContextPayload {
   previousSegments?: Array<{ source: string; translated: string }>
   glossary?: Array<{ source: string; target: string }>
+}
+
+/**
+ * Custom TokenPredictor that returns a fixed sequence of tokens as predictions.
+ * Used for SSBD: the previous translation output tokens are fed as speculative
+ * predictions, and node-llama-cpp's speculative decoding verifies them in batch.
+ */
+class FixedSequenceTokenPredictor {
+  private tokens: Token[] = []
+  private position = 0
+
+  constructor(tokens: Token[]) {
+    this.tokens = tokens
+  }
+
+  reset(): void {
+    this.position = 0
+  }
+
+  pushTokens(tokens: Token[]): void {
+    this.position += tokens.length
+  }
+
+  predictTokens(): Token[] {
+    if (this.position >= this.tokens.length) return []
+    // Return remaining tokens from the fixed sequence
+    const remaining = this.tokens.slice(this.position)
+    // Return a reasonable batch size for verification
+    return remaining.slice(0, 32)
+  }
+
+  stop(): void {
+    // no-op
+  }
+
+  updateInputTokens(): void {
+    // no-op
+  }
+
+  dispose(): void {
+    this.tokens = []
+  }
+
+  [Symbol.dispose](): void {
+    this.dispose()
+  }
 }
 
 /** Context size for translation (short segments) */
@@ -465,6 +513,143 @@ async function handleTranslateIncremental(
 }
 
 /**
+ * Handle SSBD (Self-Speculative Biased Decoding) translation.
+ * Uses the previous translation output as a speculative draft:
+ * 1. Tokenize the previous output
+ * 2. Create a context sequence with the previous tokens as a custom predictor
+ * 3. node-llama-cpp verifies them in batch and accepts/rejects
+ * 4. Normal autoregressive decoding resumes from the divergence point
+ *
+ * Falls back to regular translation if SSBD fails.
+ */
+async function handleTranslateSSBD(
+  id: string,
+  text: string,
+  previousOutput: string,
+  from: string,
+  to: string,
+  translateContext?: TranslateContextPayload
+): Promise<void> {
+  if (!context || !model) {
+    process.parentPort!.postMessage({
+      type: 'error',
+      id,
+      message: 'Model not initialized'
+    })
+    return
+  }
+
+  try {
+    const memBefore = process.memoryUsage()
+    const t0 = performance.now()
+    const prompt = buildTranslationPrompt(text, from, to, translateContext)
+    const promptMs = performance.now() - t0
+    const systemPrompt = activeModelType === 'lfm2' ? getLFM2SystemPrompt(to) : undefined
+
+    // Tokenize the previous output for use as speculative draft
+    const previousTokens = model.tokenize(previousOutput, false)
+
+    if (previousTokens.length === 0) {
+      // No tokens to speculate with, fall back to regular translation
+      const { response, inferenceMs, contextMs } = await runInference(prompt, undefined, systemPrompt)
+      const totalMs = performance.now() - t0
+      logSSBDProfile(totalMs, promptMs, 0, inferenceMs, text.length, response.length, 0, 0, memBefore)
+      process.parentPort!.postMessage({ type: 'result', id, text: response })
+      return
+    }
+
+    // Create an SSBD-specific session with the fixed sequence token predictor
+    const { LlamaChatSession } = await import('node-llama-cpp')
+
+    // Create a dedicated sequence with the fixed-token predictor
+    const predictor = new FixedSequenceTokenPredictor(previousTokens)
+    const ssbdSequence = context.getSequence({
+      tokenPredictor: predictor as unknown as import('node-llama-cpp').TokenPredictor
+    })
+
+    const ssbdSession = new LlamaChatSession({
+      contextSequence: ssbdSequence,
+      ...(systemPrompt && { systemPrompt })
+    })
+
+    try {
+      const inferenceParams = getInferenceParams()
+      const t1 = performance.now()
+
+      // Use responsePrefix to seed the model with previous output tokens.
+      // Combined with our FixedSequenceTokenPredictor, this enables
+      // speculative verification of the previous output.
+      const response = await ssbdSession.prompt(prompt, {
+        ...inferenceParams,
+        responsePrefix: previousOutput
+      })
+      const inferenceMs = performance.now() - t1
+
+      // Collect speculative decoding stats
+      const stats = ssbdSequence.tokenPredictions
+      const validated = stats?.validated ?? 0
+      const refuted = stats?.refuted ?? 0
+
+      const memAfter = process.memoryUsage()
+      const totalMs = performance.now() - t0
+
+      logSSBDProfile(totalMs, promptMs, 0, inferenceMs, text.length, response.trim().length, validated, refuted, memBefore)
+
+      process.parentPort!.postMessage({
+        type: 'result',
+        id,
+        text: response.trim()
+      })
+    } finally {
+      ssbdSession.dispose?.()
+      ssbdSequence.dispose?.()
+      predictor.dispose()
+    }
+  } catch (err) {
+    // SSBD failed — fall back to regular translation
+    log.warn('SSBD failed, falling back to regular translate:', err instanceof Error ? err.message : err)
+    try {
+      const systemPrompt = activeModelType === 'lfm2' ? getLFM2SystemPrompt(to) : undefined
+      const prompt = buildTranslationPrompt(text, from, to, translateContext)
+      const { response } = await runInference(prompt, undefined, systemPrompt)
+      process.parentPort!.postMessage({ type: 'result', id, text: response })
+    } catch (fallbackErr) {
+      process.parentPort!.postMessage({
+        type: 'error',
+        id,
+        message: fallbackErr instanceof Error ? fallbackErr.message : String(fallbackErr)
+      })
+    }
+  }
+}
+
+/** Log SSBD profiling information */
+function logSSBDProfile(
+  totalMs: number,
+  promptMs: number,
+  contextMs: number,
+  inferenceMs: number,
+  inputLen: number,
+  outputLen: number,
+  validated: number,
+  refuted: number,
+  memBefore: NodeJS.MemoryUsage
+): void {
+  const memAfter = process.memoryUsage()
+  const acceptRate = validated + refuted > 0
+    ? ((validated / (validated + refuted)) * 100).toFixed(0)
+    : 'N/A'
+  log.info(
+    `Profile(ssbd): total=${totalMs.toFixed(0)}ms prompt=${promptMs.toFixed(0)}ms ` +
+    `ctx=${contextMs.toFixed(0)}ms inference=${inferenceMs.toFixed(0)}ms ` +
+    `inputLen=${inputLen} outputLen=${outputLen} ` +
+    `validated=${validated} refuted=${refuted} acceptRate=${acceptRate}% ` +
+    `rss=${(memAfter.rss / 1048576).toFixed(0)}MB ` +
+    `heapDelta=${((memAfter.heapUsed - memBefore.heapUsed) / 1048576).toFixed(1)}MB`
+  )
+}
+
+/**
  * Persistent SimulMT session state.
  * Unlike regular translate which creates a new session per request,
  * SimulMT keeps a single LlamaChatSession alive across multiple turns.
@@ -790,6 +975,9 @@ process.parentPort!.on('message', (e: { data: WorkerInboundMessage }) => {
         case 'translate-incremental':
           await handleTranslateIncremental(msg.id, msg.text, msg.previousOutput, msg.from, msg.to, msg.context)
           break
+        case 'translate-ssbd':
+          await handleTranslateSSBD(msg.id, msg.text, msg.previousOutput, msg.from, msg.to, msg.context)
+          break
         case 'translate-simulmt':
           await handleTranslateSimulMt(msg.id, msg.text, msg.previousOutput, msg.from, msg.to, msg.isRevision, msg.context)
           break
@@ -815,7 +1003,7 @@ process.parentPort!.on('message', (e: { data: WorkerInboundMessage }) => {
     }
   }
 
-  if (msg.type === 'translate' || msg.type === 'translate-incremental' || msg.type === 'translate-simulmt' || msg.type === 'summarize' || msg.type === 'ger-correct') {
+  if (msg.type === 'translate' || msg.type === 'translate-incremental' || msg.type === 'translate-ssbd' || msg.type === 'translate-simulmt' || msg.type === 'summarize' || msg.type === 'ger-correct') {
     // Queue to serialize context access
     requestQueue = requestQueue.then(handleMessage, handleMessage)
   } else {

--- a/src/main/worker-pool.ts
+++ b/src/main/worker-pool.ts
@@ -43,11 +43,12 @@ export interface WorkerInitOptions {
 }
 
 /** Timeout value by request type */
-export type RequestType = 'translate' | 'translate-incremental' | 'translate-simulmt' | 'summarize' | 'ger-correct'
+export type RequestType = 'translate' | 'translate-incremental' | 'translate-ssbd' | 'translate-simulmt' | 'summarize' | 'ger-correct'
 
 const TIMEOUT_BY_TYPE: Record<RequestType, number> = {
   'translate': WORKER_TRANSLATE_TIMEOUT_MS,
   'translate-incremental': WORKER_TRANSLATE_TIMEOUT_MS,
+  'translate-ssbd': WORKER_TRANSLATE_TIMEOUT_MS,
   'translate-simulmt': WORKER_TRANSLATE_TIMEOUT_MS,
   'summarize': WORKER_SUMMARIZE_TIMEOUT_MS,
   'ger-correct': WORKER_TRANSLATE_TIMEOUT_MS

--- a/src/pipeline/GERProcessor.ts
+++ b/src/pipeline/GERProcessor.ts
@@ -45,6 +45,8 @@ export class GERProcessor {
   private deps: GERDeps
   /** Track in-flight corrections to avoid duplicate work */
   private pendingTimestamp: number | null = null
+  /** Last known translation for SSBD re-translation draft */
+  private lastTranslation: string | null = null
 
   constructor(deps: GERDeps) {
     this.deps = deps
@@ -70,13 +72,15 @@ export class GERProcessor {
    * @param language - Detected source language
    * @param targetLanguage - Translation target language
    * @param timestamp - Original result timestamp for deduplication
+   * @param previousTranslation - Previous translation output for SSBD re-translation draft
    */
   maybeCorrect(
     sttText: string,
     confidence: number | undefined,
     language: Language,
     targetLanguage: Language,
-    timestamp: number
+    timestamp: number,
+    previousTranslation?: string
   ): void {
     if (!this.enabled) return
 
@@ -102,6 +106,7 @@ export class GERProcessor {
     }
 
     this.pendingTimestamp = timestamp
+    this.lastTranslation = previousTranslation ?? null
     this.runCorrection(sttText, language, targetLanguage, timestamp).catch((err) => {
       log.warn('GER correction failed:', err)
     }).finally(() => {
@@ -114,6 +119,7 @@ export class GERProcessor {
   /** Reset state (e.g., on pipeline stop) */
   reset(): void {
     this.pendingTimestamp = null
+    this.lastTranslation = null
   }
 
   private async runCorrection(
@@ -156,18 +162,35 @@ export class GERProcessor {
       return
     }
 
-    // Re-translate the corrected text
+    // Re-translate the corrected text, using SSBD if available for faster re-translation.
+    // Since GER only makes small corrections, most of the previous translation remains valid.
     const translator = this.deps.getTranslator()
     if (!translator) {
       log.warn('GER: no translator available for re-translation')
       return
     }
 
-    const translatedText = await translator.translate(
-      trimmedCorrected,
-      language,
-      targetLanguage
-    )
+    let translatedText: string
+    if (translator.translateSSBD && this.lastTranslation) {
+      try {
+        translatedText = await translator.translateSSBD(
+          trimmedCorrected,
+          this.lastTranslation,
+          language,
+          targetLanguage
+        )
+        log.info('GER: used SSBD for re-translation')
+      } catch (ssbdErr) {
+        log.warn('GER: SSBD failed, falling back to regular translate:', ssbdErr)
+        translatedText = await translator.translate(trimmedCorrected, language, targetLanguage)
+      }
+    } else {
+      translatedText = await translator.translate(
+        trimmedCorrected,
+        language,
+        targetLanguage
+      )
+    }
 
     const result: TranslationResult = {
       sourceText: trimmedCorrected,

--- a/src/pipeline/StreamingProcessor.ts
+++ b/src/pipeline/StreamingProcessor.ts
@@ -168,12 +168,24 @@ export class StreamingProcessor {
             if (!dbTranslator || !fullSourceText.trim()) return
             const glossaryEntries = this.deps.getGlossary()
             const glossary = glossaryEntries.length > 0 ? glossaryEntries : undefined
-            dbTranslator.translate(
-              fullSourceText,
-              sttResult.language,
-              targetLang,
-              this.deps.contextBuffer.getContext(glossary)
-            ).then((translated) => {
+            const ctx = this.deps.contextBuffer.getContext(glossary)
+
+            // Use SSBD for re-translation when we have a previous translation,
+            // since most of the output likely remains valid (#607)
+            const translatePromise = (dbTranslator.translateSSBD && this.lastTranslatedConfirmed)
+              ? dbTranslator.translateSSBD(
+                  fullSourceText,
+                  this.lastTranslatedConfirmed,
+                  sttResult.language,
+                  targetLang,
+                  ctx
+                ).catch((ssbdErr) => {
+                  log.warn('SSBD debounced translation failed, falling back:', ssbdErr)
+                  return dbTranslator.translate(fullSourceText, sttResult.language, targetLang, ctx)
+                })
+              : dbTranslator.translate(fullSourceText, sttResult.language, targetLang, ctx)
+
+            translatePromise.then((translated) => {
               this.lastTranslatedConfirmed = translated
               const debouncedResult: TranslationResult = {
                 sourceText: fullSourceText,
@@ -311,7 +323,8 @@ export class StreamingProcessor {
           sttResult.confidence,
           sttResult.language,
           targetLang,
-          result.timestamp
+          result.timestamp,
+          translatedText || undefined
         )
       }
 

--- a/src/pipeline/TranslationPipeline.ts
+++ b/src/pipeline/TranslationPipeline.ts
@@ -483,7 +483,8 @@ export class TranslationPipeline extends EventEmitter {
         sttResult.confidence,
         sttResult.language,
         targetLang,
-        Date.now()
+        Date.now(),
+        translated || undefined
       )
 
       return {


### PR DESCRIPTION
## Description

Implement Self-Speculative Biased Decoding (SSBD) for streaming re-translation. When source text is updated (e.g., STT refines output or GER corrects errors), instead of translating from scratch, SSBD uses the previous translation as a speculative draft.

A custom `FixedSequenceTokenPredictor` feeds previous output tokens to node-llama-cpp's speculative decoding infrastructure, which verifies them in batch and only resumes autoregressive decoding from the first divergence point. This gives substantial speedup for re-translations where most of the previous output remains valid.

**Changes:**
- New `translate-ssbd` worker message type in `slm-worker.ts` with `FixedSequenceTokenPredictor`
- `translateSSBD()` method added to `LlamaWorkerTranslator` and `TranslatorEngine` interface
- StreamingProcessor uses SSBD for debounced re-translations when previous output exists
- GERProcessor uses SSBD for post-correction re-translations
- Automatic fallback to regular translate on SSBD failure
- SSBD profiling logs with validated/refuted token counts and accept rate

Closes #607

## Related Issue
#607

## Test Checklist
- [x] Unit tests added/updated (231 tests pass)
- [ ] Tested in Chrome
- [ ] Tested in Firefox or Safari
- [ ] Responsive: mobile (375px) and desktop (1280px+)
- [ ] Keyboard navigation works
- [ ] Dark mode verified (if supported)

## Checklist
- [x] CLAUDE.md rules followed
- [x] No hardcoded strings (all externalized)
- [x] Error handling complete
- [x] No console.log left in production code