### PR TITLE
Add STT benchmark infrastructure for primary promotion (#692)

### DIFF
--- a/.claude/rules/engines.md
+++ b/.claude/rules/engines.md
@@ -7,21 +7,23 @@ globs: src/engines/**/*.ts, src/pipeline/**/*.ts
 
 ## Current Engine Landscape
 
-### STT Engines (3 primary + 7 experimental)
+### STT Engines (6 primary + 5 experimental)
 
 **Primary (shown in UI):**
 | Engine | File | Notes |
 |--------|------|-------|
 | Apple SpeechTranscriber | `AppleSpeechTranscriberEngine.ts` | macOS 26+ only, zero setup, ANE-native, 2.2x faster than Whisper Turbo |
-| Whisper Local | `WhisperLocalEngine.ts` | Native whisper.cpp, primary default |
+| SenseVoice Small (sherpa-onnx) | `SenseVoiceSherpaEngine.ts` | ~70ms/10s audio, 229MB int8, cross-platform, benchmark pending (#692) |
+| Kotoba-Whisper | `KotobaWhisperEngine.ts` | JA-optimized, JA CER 5.6%, Apple Silicon, JA-only output |
+| Qwen3-ASR 0.6B | `Qwen3ASREngine.ts` | Best JA+EN accuracy (CER 6.8%, WER 1.9%), Apple Silicon, ~2.2s |
 | MLX Whisper | `MlxWhisperEngine.ts` | Apple Silicon, JA CER 8.1%, EN WER 3.8%, 2.9s |
+| Whisper Local | `WhisperLocalEngine.ts` | Native whisper.cpp, cross-platform default |
 
 **Experimental (hidden from UI):**
 - Moonshine Tiny JA (`MoonshineTinyJaEngine.ts`) — ultra-fast draft STT, JA CER 10.1%, 845ms latency
-- Kotoba-Whisper (`KotobaWhisperEngine.ts`) — JA-optimized Whisper variant
 - SpeechSwift (`SpeechSwiftEngine.ts`) — speech-swift CLI bridge
 - Qwen3-ASR Native (`QwenAsrNativeEngine.ts`) — antirez/qwen-asr pure C, cross-platform, under evaluation
-- SenseVoice, Qwen3-ASR, Qwen ASR, Sherpa-ONNX — under evaluation
+- SenseVoice FunASR (`SenseVoiceEngine.ts`), Qwen ASR (`QwenASREngine.ts`), Sherpa-ONNX (`SherpaOnnxEngine.ts`) — under evaluation
 
 **Removed (benchmark failures):**
 - Lightning Whisper MLX — JA CER 162%

--- a/benchmark/package.json
+++ b/benchmark/package.json
@@ -29,9 +29,14 @@
     "stt:moonshine": "tsx --expose-gc run.ts --stt --engines moonshine",
     "stt:sensevoice": "tsx --expose-gc run.ts --stt --engines sensevoice",
     "stt:qwen": "tsx --expose-gc run.ts --stt --engines qwen-asr",
+    "stt:qwen3-swift-06b": "tsx --expose-gc run.ts --stt --engines qwen3-asr-swift-06b",
+    "stt:qwen3-swift-17b": "tsx --expose-gc run.ts --stt --engines qwen3-asr-swift-17b",
+    "stt:qwen3-native-06b": "tsx --expose-gc run.ts --stt --engines qwen3-asr-native-06b",
+    "stt:qwen3-native-17b": "tsx --expose-gc run.ts --stt --engines qwen3-asr-native-17b",
     "stt:sherpa": "tsx --expose-gc run.ts --stt --engines sherpa-onnx",
     "stt:sherpa-sensevoice": "tsx --expose-gc run.ts --stt --engines sherpa-sensevoice",
-    "stt:all": "tsx --expose-gc run.ts --stt --engines whisper-local,mlx-whisper,lightning-whisper,moonshine,sensevoice,qwen-asr,sherpa-onnx,sherpa-sensevoice",
+    "stt:promotion-candidates": "tsx --expose-gc run.ts --stt --engines whisper-local,mlx-whisper,sherpa-sensevoice,qwen3-asr-swift-06b,qwen3-asr-native-06b",
+    "stt:all": "tsx --expose-gc run.ts --stt --engines whisper-local,mlx-whisper,lightning-whisper,moonshine,sensevoice,qwen-asr,qwen3-asr-swift-06b,qwen3-asr-swift-17b,qwen3-asr-native-06b,qwen3-asr-native-17b,sherpa-onnx,sherpa-sensevoice",
     "stt:generate-testset": "bash scripts/generate-stt-testset.sh"
   },
   "dependencies": {

--- a/benchmark/run.ts
+++ b/benchmark/run.ts
@@ -43,6 +43,8 @@ const AVAILABLE_STT_ENGINES = [
   'qwen-asr',
   'qwen3-asr-swift-06b',
   'qwen3-asr-swift-17b',
+  'qwen3-asr-native-06b',
+  'qwen3-asr-native-17b',
   'sherpa-onnx',
   'sherpa-sensevoice'
 ] as const
@@ -255,6 +257,14 @@ async function createSTTEngine(id: STTEngineId): Promise<STTBenchmarkEngine> {
     case 'qwen3-asr-swift-17b': {
       const { Qwen3ASRSwiftBench } = await import('./src/stt-engines/qwen3-asr-swift.js')
       return new Qwen3ASRSwiftBench({ variant: '1.7b' })
+    }
+    case 'qwen3-asr-native-06b': {
+      const { Qwen3ASRNativeBench } = await import('./src/stt-engines/qwen3-asr-native.js')
+      return new Qwen3ASRNativeBench({ variant: '0.6b' })
+    }
+    case 'qwen3-asr-native-17b': {
+      const { Qwen3ASRNativeBench } = await import('./src/stt-engines/qwen3-asr-native.js')
+      return new Qwen3ASRNativeBench({ variant: '1.7b' })
     }
     case 'sherpa-onnx': {
       const { SherpaOnnxBench } = await import('./src/stt-engines/sherpa-onnx.js')

--- a/benchmark/src/stt-engines/qwen3-asr-native.ts
+++ b/benchmark/src/stt-engines/qwen3-asr-native.ts
@@ -1,0 +1,169 @@
+import { execFile, execSync } from 'child_process'
+import { existsSync, readdirSync } from 'fs'
+import { join, dirname } from 'path'
+import { homedir } from 'os'
+import type { STTBenchmarkEngine } from '../stt-types.js'
+
+/** Well-known paths where the qwen_asr binary may be installed */
+const QWEN_ASR_BINARY_PATHS = [
+  '/opt/homebrew/bin/qwen_asr',
+  '/usr/local/bin/qwen_asr',
+  join(homedir(), 'qwen-asr', 'qwen_asr')
+]
+
+/**
+ * Qwen3-ASR STT benchmark engine via antirez/qwen-asr pure C implementation.
+ *
+ * Uses the `qwen_asr` CLI binary compiled from https://github.com/antirez/qwen-asr.
+ * Pure C with only BLAS dependency (Accelerate on macOS, OpenBLAS on Linux).
+ * Models use safetensors format with memory-mapped loading for near-instant startup.
+ *
+ * Cross-platform (macOS + Linux), no Python/Swift dependency.
+ *
+ * Install:
+ *   git clone https://github.com/antirez/qwen-asr
+ *   cd qwen-asr && make blas
+ *   ./download_model.sh   # Select 0.6B or 1.7B
+ */
+export class Qwen3ASRNativeBench implements STTBenchmarkEngine {
+  readonly id: string
+  readonly label: string
+
+  private binaryPath: string | null = null
+  private modelDir: string | null = null
+  private variant: '0.6b' | '1.7b'
+  private timeoutMs: number
+
+  constructor(options?: { variant?: '0.6b' | '1.7b'; timeoutMs?: number }) {
+    this.variant = options?.variant ?? '0.6b'
+    this.id = `qwen3-asr-native-${this.variant}`
+    this.label = `Qwen3-ASR Native ${this.variant.toUpperCase()}`
+    this.timeoutMs = options?.timeoutMs ?? 60_000
+  }
+
+  async initialize(): Promise<void> {
+    this.binaryPath = findQwenAsrBinary()
+    if (!this.binaryPath) {
+      throw new Error(
+        'qwen_asr binary not found. Build from source:\n' +
+        '  git clone https://github.com/antirez/qwen-asr\n' +
+        '  cd qwen-asr && make blas\n' +
+        '  ./download_model.sh'
+      )
+    }
+    console.log(`[qwen3-asr-native] Using binary: ${this.binaryPath}`)
+
+    const dirName = this.variant === '1.7b' ? 'qwen3-asr-1.7b' : 'qwen3-asr-0.6b'
+    this.modelDir = findModelDir(this.binaryPath, dirName)
+    if (!this.modelDir) {
+      throw new Error(
+        `Model directory '${dirName}' not found. Download the model:\n` +
+        `  cd ${getDirname(this.binaryPath)} && ./download_model.sh`
+      )
+    }
+    console.log(`[qwen3-asr-native] Model directory: ${this.modelDir}`)
+  }
+
+  async transcribe(audioPath: string): Promise<{ text: string; language?: string }> {
+    if (!this.binaryPath || !this.modelDir) {
+      throw new Error('Engine not initialized')
+    }
+
+    const text = await runTranscribe(
+      this.binaryPath,
+      this.modelDir,
+      audioPath,
+      this.timeoutMs
+    )
+
+    return {
+      text: text.trim(),
+      language: undefined // qwen_asr CLI does not output language info
+    }
+  }
+
+  async dispose(): Promise<void> {
+    this.binaryPath = null
+    this.modelDir = null
+  }
+}
+
+/** Find the qwen_asr binary in well-known locations or PATH */
+function findQwenAsrBinary(): string | null {
+  for (const p of QWEN_ASR_BINARY_PATHS) {
+    if (existsSync(p)) {
+      try {
+        execSync(`"${p}" --help`, { stdio: 'ignore', timeout: 5000 })
+        return p
+      } catch {
+        // Binary exists but not usable
+      }
+    }
+  }
+
+  // Try PATH lookup
+  try {
+    const which = execSync('which qwen_asr', { encoding: 'utf-8', timeout: 3000 }).trim()
+    if (which && existsSync(which)) return which
+  } catch { /* not in PATH */ }
+
+  return null
+}
+
+/**
+ * Find the model directory relative to the binary or in common locations.
+ * antirez/qwen-asr expects the model dir to contain safetensors files.
+ */
+function findModelDir(binaryPath: string, dirName: string): string | null {
+  const candidates = [
+    join(getDirname(binaryPath), dirName),
+    join(homedir(), 'qwen-asr', dirName),
+    join(homedir(), '.cache', 'qwen-asr', dirName),
+    join('/opt/homebrew/share/qwen-asr', dirName),
+    join('/usr/local/share/qwen-asr', dirName)
+  ]
+
+  for (const dir of candidates) {
+    if (existsSync(dir)) {
+      try {
+        const files = readdirSync(dir)
+        const hasModel = files.some(
+          (f) => f.endsWith('.safetensors') || f.endsWith('.bin') || f === 'config.json'
+        )
+        if (hasModel) return dir
+      } catch { /* ignore read errors */ }
+    }
+  }
+
+  return null
+}
+
+/** Get directory name from a file path */
+function getDirname(p: string): string {
+  const parts = p.split('/')
+  parts.pop()
+  return parts.join('/') || '/'
+}
+
+/** Run `qwen_asr -d <model_dir> -i <wav_file> --silent` and return transcribed text */
+function runTranscribe(
+  binaryPath: string,
+  modelDir: string,
+  audioPath: string,
+  timeoutMs: number
+): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const args = ['-d', modelDir, '-i', audioPath, '--silent']
+
+    execFile(binaryPath, args, { timeout: timeoutMs }, (err, stdout, stderr) => {
+      if (err) {
+        const msg = stderr?.trim() || err.message
+        reject(new Error(`qwen_asr error: ${msg}`))
+        return
+      }
+
+      // Output is the transcribed text on stdout
+      resolve(stdout.trim())
+    })
+  })
+}

--- a/benchmark/src/stt-report.ts
+++ b/benchmark/src/stt-report.ts
@@ -62,8 +62,11 @@ function buildAccuracyBreakdown(summaries: STTEngineSummary[]): string {
 }
 
 function buildGoNoGoTable(summaries: STTEngineSummary[]): string {
-  const LATENCY_THRESHOLD = 3000 // 3s for STT (longer than translation)
-  const ERROR_RATE_THRESHOLD = 0.25 // 25% WER/CER
+  // Promotion criteria from issue #692:
+  //   JA CER < 15%, EN WER < 10%, latency < 3s, memory < 4GB
+  const LATENCY_THRESHOLD = 3000 // 3s for STT
+  const JA_CER_THRESHOLD = 0.15 // 15% CER for Japanese
+  const EN_WER_THRESHOLD = 0.10 // 10% WER for English
   const MEMORY_THRESHOLD_MB = 4 * 1024
 
   // Aggregate per-engine across languages
@@ -74,30 +77,35 @@ function buildGoNoGoTable(summaries: STTEngineSummary[]): string {
 
     // Use "all" language if available, otherwise average across languages
     const allRun = runs.find((r) => r.language === 'all')
+    const jaRun = runs.find((r) => r.language === 'ja')
+    const enRun = runs.find((r) => r.language === 'en')
+
     const avgLatency = allRun
       ? allRun.latency.avg
       : runs.reduce((acc, r) => acc + r.latency.avg, 0) / runs.length
-    const avgErrorRate = allRun
-      ? allRun.accuracy.errorRate
-      : runs.reduce((acc, r) => acc + r.accuracy.errorRate, 0) / runs.length
     const peakRss = Math.max(...runs.map((r) => r.peakRssMB))
 
+    const jaCer = jaRun?.accuracy.errorRate ?? (allRun?.accuracy.errorRate ?? 1)
+    const enWer = enRun?.accuracy.errorRate ?? (allRun?.accuracy.errorRate ?? 1)
+
     const latencyOk = avgLatency < LATENCY_THRESHOLD
-    const accuracyOk = avgErrorRate < ERROR_RATE_THRESHOLD
+    const jaCerOk = jaCer < JA_CER_THRESHOLD
+    const enWerOk = enWer < EN_WER_THRESHOLD
     const memoryOk = peakRss < MEMORY_THRESHOLD_MB
 
-    return { id, label, avgLatency, avgErrorRate, peakRss, latencyOk, accuracyOk, memoryOk }
+    return { id, label, avgLatency, jaCer, enWer, peakRss, latencyOk, jaCerOk, enWerOk, memoryOk }
   })
 
   const header = `| Criteria | ${engineMetrics.map((e) => e.label).join(' | ')} |`
   const sep = `|---|${engineMetrics.map(() => '---').join('|')}|`
 
   const latencyRow = `| Latency (<3s) | ${engineMetrics.map((e) => (e.latencyOk ? `Yes (${fmt(e.avgLatency)}ms)` : `No (${fmt(e.avgLatency)}ms)`)).join(' | ')} |`
-  const accuracyRow = `| Error rate (<25%) | ${engineMetrics.map((e) => (e.accuracyOk ? `Yes (${pct(e.avgErrorRate)})` : `No (${pct(e.avgErrorRate)})`)).join(' | ')} |`
+  const jaCerRow = `| JA CER (<15%) | ${engineMetrics.map((e) => (e.jaCerOk ? `Yes (${pct(e.jaCer)})` : `No (${pct(e.jaCer)})`)).join(' | ')} |`
+  const enWerRow = `| EN WER (<10%) | ${engineMetrics.map((e) => (e.enWerOk ? `Yes (${pct(e.enWer)})` : `No (${pct(e.enWer)})`)).join(' | ')} |`
   const memoryRow = `| Memory (<4GB) | ${engineMetrics.map((e) => (e.memoryOk ? `Yes (${fmt(e.peakRss / 1024, 2)}GB)` : `No (${fmt(e.peakRss / 1024, 2)}GB)`)).join(' | ')} |`
-  const recRow = `| Recommendation | ${engineMetrics.map((e) => (e.latencyOk && e.accuracyOk && e.memoryOk ? 'Go' : 'No-Go')).join(' | ')} |`
+  const recRow = `| Recommendation | ${engineMetrics.map((e) => (e.latencyOk && e.jaCerOk && e.enWerOk && e.memoryOk ? 'Promote' : 'No-Go')).join(' | ')} |`
 
-  return [header, sep, latencyRow, accuracyRow, memoryRow, recRow].join('\n')
+  return [header, sep, latencyRow, jaCerRow, enWerRow, memoryRow, recRow].join('\n')
 }
 
 function buildMarkdown(result: STTBenchmarkResult): string {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -83,7 +83,8 @@ async function initPipeline(): Promise<void> {
     onProgress: (msg) => ctx.mainWindow?.webContents.send('status-update', msg),
     modelKey: (store.get('sherpaOnnxModel') as string) || undefined
   }))
-  // Experimental: SenseVoice Small via sherpa-onnx — ultra-fast CJK STT, no Python (#554)
+  // SenseVoice Small via sherpa-onnx — ultra-fast CJK STT, no Python (#554, #692)
+  // Primary candidate: ~70ms for 10s audio, 229MB int8 model, pending benchmark validation
   ctx.pipeline.registerSTT('sensevoice-sherpa', () => new SenseVoiceSherpaEngine({
     onProgress: (msg) => ctx.mainWindow?.webContents.send('status-update', msg)
   }))

--- a/src/renderer/components/settings/STTSettings.tsx
+++ b/src/renderer/components/settings/STTSettings.tsx
@@ -46,6 +46,7 @@ export function STTSettings({
         {showKotobaWhisper && (
           <option value="kotoba-whisper">Kotoba-Whisper v2.0 (JA-optimized, Apple Silicon)</option>
         )}
+        <option value="sensevoice-sherpa">SenseVoice Small (Ultra-fast, ~70ms, Offline)</option>
         {platform === 'darwin' && (
           <option value="qwen3-asr">Qwen3-ASR 0.6B (Best accuracy, Apple Silicon)</option>
         )}
@@ -102,6 +103,18 @@ export function STTSettings({
               {' '}Warning: this model only outputs Japanese. Set source language to JA for best results.
             </span>
           )}
+        </div>
+      )}
+      {sttEngine === 'sensevoice-sherpa' && (
+        <div style={{ marginTop: '4px', fontSize: '11px', color: '#94a3b8' }}>
+          SenseVoice Small: non-autoregressive, ~70ms for 10s audio (15x faster than Whisper-Large).
+          229MB int8 model, supports JA/EN/ZH/KO with auto language detection.
+          Requires{' '}
+          <span style={{ fontFamily: 'monospace', fontSize: '10px' }}>sherpa-onnx-node</span>
+          . Model (~229MB) auto-downloads on first use.
+          <div style={{ marginTop: '2px', color: '#22c55e' }}>
+            Benchmark pending — accuracy to be validated against Whisper baselines (#692).
+          </div>
         </div>
       )}
       {sttEngine === 'qwen3-asr' && (

--- a/src/renderer/components/settings/shared.ts
+++ b/src/renderer/components/settings/shared.ts
@@ -28,7 +28,7 @@ export const ALL_LANGUAGES = Object.keys(LANGUAGE_LABELS) as Language[]
 
 export type EngineMode = 'auto' | 'rotation' | 'online' | 'online-deepl' | 'online-gemini' | 'offline-opus' | 'offline-hymt15' | 'offline-hunyuan-mt' | 'offline-hybrid' | 'offline-lfm2' | 'offline-plamo' | 'offline-apple'
 
-export type SttEngineType = 'whisper-local' | 'mlx-whisper' | 'kotoba-whisper' | 'qwen3-asr' | 'apple-speech-transcriber'
+export type SttEngineType = 'whisper-local' | 'mlx-whisper' | 'kotoba-whisper' | 'qwen3-asr' | 'sensevoice-sherpa' | 'apple-speech-transcriber'
 export type WhisperVariantType = 'kotoba-v2.0' | 'large-v3-turbo' | 'distil-large-v3' | 'base' | 'small'
 export type SubtitlePositionType = 'top' | 'bottom'
 
@@ -173,6 +173,7 @@ export function getEngineDisplayName(mode: EngineMode): string {
 export function getSttDisplayName(sttEngine: SttEngineType, whisperVariant: WhisperVariantType): string {
   switch (sttEngine) {
     case 'apple-speech-transcriber': return 'Apple Speech (Zero Setup)'
+    case 'sensevoice-sherpa': return 'SenseVoice Small (Ultra-fast, Offline)'
     case 'qwen3-asr': return 'Qwen3-ASR 0.6B (Apple Silicon)'
     case 'kotoba-whisper': return 'Kotoba-Whisper v2.0 (JA-optimized)'
     case 'mlx-whisper': return 'mlx-whisper (Apple Silicon)'


### PR DESCRIPTION
## Summary

Prepares benchmark infrastructure and UI to evaluate SenseVoice-Sherpa and Qwen3-ASR for promotion to primary STT engines, targeting a 10-28x latency improvement over current Whisper baselines.

Closes #692

### Changes

**Benchmark infrastructure:**
- Add `Qwen3ASRNativeBench` benchmark engine for antirez/qwen-asr pure C implementation (0.6B and 1.7B variants)
- Register `qwen3-asr-native-06b` and `qwen3-asr-native-17b` in the benchmark runner
- Add convenience scripts: `stt:qwen3-swift-06b`, `stt:qwen3-swift-17b`, `stt:qwen3-native-06b`, `stt:qwen3-native-17b`
- Add `stt:promotion-candidates` script to run all promotion candidates (whisper-local, mlx-whisper, sherpa-sensevoice, qwen3-asr-swift-06b, qwen3-asr-native-06b) in one command
- Update `stt:all` to include new engine variants

**Go/No-Go criteria tightened (stt-report.ts):**
- Split single error rate threshold (25%) into per-language criteria: JA CER < 15%, EN WER < 10%
- Recommendation label changed from "Go" to "Promote" when all criteria pass
- Matches promotion criteria defined in issue #692

**UI: SenseVoice-Sherpa exposed as primary STT option:**
- Add `sensevoice-sherpa` to `SttEngineType` union
- Add dropdown option in `STTSettings.tsx` with description (cross-platform, not gated on `darwin`)
- Add display name in `getSttDisplayName()`
- Engine registration comment updated from "Experimental" to "Primary candidate"

**Engine landscape doc updated:**
- `.claude/rules/engines.md` updated to reflect 6 primary + 5 experimental STT engines
- Kotoba-Whisper and Qwen3-ASR promoted to primary (already in UI), SenseVoice-Sherpa added

### What still needs manual execution
- Run `npm run stt:promotion-candidates` on a machine with models installed
- Review benchmark results and decide on default engine change
- If promoted, update store default from `mlx-whisper` to winning engine

## Test plan
- [ ] `npm run typecheck` passes
- [ ] `npm run lint` passes (no new issues)
- [ ] Verify SenseVoice-Sherpa appears in STT engine dropdown
- [ ] Run `npm run stt:promotion-candidates` and review Go/No-Go report
- [ ] Verify new Go/No-Go criteria show JA CER and EN WER separately