### PR TITLE
Add speculative decoding to Hunyuan-MT 7B quality mode

### DIFF
--- a/src/engines/translator/HunyuanMTTranslator.ts
+++ b/src/engines/translator/HunyuanMTTranslator.ts
@@ -1,4 +1,6 @@
-import { getHunyuanMTVariants } from '../model-downloader'
+import { join } from 'path'
+import { getHunyuanMTVariants, getLFM2Variants, isGGUFDownloaded, getGGUFDir } from '../model-downloader'
+import type { WorkerInitOptions } from '../../main/worker-pool'
 import { LlamaWorkerTranslator } from './LlamaWorkerTranslator'
 import type { GGUFVariantConfig } from './LlamaWorkerTranslator'
 
@@ -7,10 +9,30 @@ import type { GGUFVariantConfig } from './LlamaWorkerTranslator'
  * Uses the shared worker pool instead of spawning its own process.
  * WMT25 winner: 30/31 categories, 33 languages, 15-65% improvement over Google Translate.
  * License: Tencent Hunyuan Community License (Apache 2.0 based, commercial OK < 100M MAU).
+ *
+ * Optionally supports speculative decoding with LFM2-350M as draft model (#693).
+ * LFM2 generates draft tokens at ~200+ tok/s, Hunyuan-MT 7B verifies/corrects them,
+ * reducing quality-mode latency from ~3.7s to an estimated ~1.2-1.8s.
  */
 export class HunyuanMTTranslator extends LlamaWorkerTranslator {
   readonly id = 'hunyuan-mt'
-  readonly name = 'Hunyuan-MT 7B (Offline)'
+  readonly name: string
+
+  private speculativeDecoding: boolean
+  private draftModelPath: string | undefined
+
+  constructor(options?: {
+    onProgress?: (message: string) => void
+    variant?: string
+    kvCacheQuant?: boolean
+    speculativeDecoding?: boolean
+  }) {
+    super(options)
+    this.speculativeDecoding = options?.speculativeDecoding ?? false
+    this.name = this.speculativeDecoding
+      ? 'Hunyuan-MT 7B + LFM2 Speculative (Offline)'
+      : 'Hunyuan-MT 7B (Offline)'
+  }
 
   protected getVariants(): Record<string, GGUFVariantConfig> {
     return getHunyuanMTVariants()
@@ -20,7 +42,28 @@ export class HunyuanMTTranslator extends LlamaWorkerTranslator {
     return 'Hunyuan-MT 7B'
   }
 
-  protected getExtraInitOptions() {
-    return { modelType: 'hunyuan-mt' as const }
+  protected async afterDownload(): Promise<void> {
+    if (!this.speculativeDecoding) return
+
+    // Resolve LFM2-350M draft model path for speculative decoding
+    const lfm2Variants = getLFM2Variants()
+    const draftVariantConfig = lfm2Variants['Q4_K_M']!
+    if (isGGUFDownloaded(draftVariantConfig.filename)) {
+      this.draftModelPath = join(getGGUFDir(), draftVariantConfig.filename)
+      this.onProgress?.('Speculative decoding enabled: LFM2-350M draft + Hunyuan-MT 7B verifier')
+    } else {
+      this.onProgress?.('Speculative decoding skipped: LFM2-350M draft model not downloaded')
+    }
+  }
+
+  protected getExtraInitOptions(): Partial<WorkerInitOptions> {
+    return {
+      modelType: 'hunyuan-mt' as const,
+      ...(this.draftModelPath && { draftModelPath: this.draftModelPath })
+    }
+  }
+
+  protected getLoadedSuffix(): string {
+    return this.draftModelPath ? ' (speculative decoding: LFM2 draft)' : ''
   }
 }

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -135,7 +135,8 @@ async function initPipeline(): Promise<void> {
   }))
   ctx.pipeline.registerTranslator('hunyuan-mt', () => new HunyuanMTTranslator({
     onProgress: (msg) => ctx.mainWindow?.webContents.send('status-update', msg),
-    kvCacheQuant: store.get('slmKvCacheQuant')
+    kvCacheQuant: store.get('slmKvCacheQuant'),
+    speculativeDecoding: store.get('slmSpeculativeDecoding')
   }))
   // LFM2-350M ultra-fast JA↔EN translator — 350M params, ~230MB
   ctx.pipeline.registerTranslator('lfm2', () => new LFM2Translator({

--- a/src/renderer/components/SettingsPanel.tsx
+++ b/src/renderer/components/SettingsPanel.tsx
@@ -171,6 +171,8 @@ function SettingsPanel(): React.JSX.Element {
             gpuInfo={s.gpuInfo}
             slmKvCacheQuant={s.slmKvCacheQuant}
             onSlmKvCacheQuantChange={s.setSlmKvCacheQuant}
+            slmSpeculativeDecoding={s.slmSpeculativeDecoding}
+            onSlmSpeculativeDecodingChange={s.setSlmSpeculativeDecoding}
             simulMtEnabled={s.simulMtEnabled}
             onSimulMtEnabledChange={s.setSimulMtEnabled}
             simulMtWaitK={s.simulMtWaitK}

--- a/src/renderer/components/settings/TranslatorSettings.tsx
+++ b/src/renderer/components/settings/TranslatorSettings.tsx
@@ -14,6 +14,8 @@ interface TranslatorSettingsProps {
   // SLM options (for Hunyuan-MT)
   slmKvCacheQuant: boolean
   onSlmKvCacheQuantChange: (v: boolean) => void
+  slmSpeculativeDecoding: boolean
+  onSlmSpeculativeDecodingChange: (v: boolean) => void
   simulMtEnabled: boolean
   onSimulMtEnabledChange: (v: boolean) => void
   simulMtWaitK: number
@@ -57,6 +59,8 @@ export function TranslatorSettings({
   gpuInfo,
   slmKvCacheQuant,
   onSlmKvCacheQuantChange,
+  slmSpeculativeDecoding,
+  onSlmSpeculativeDecodingChange,
   simulMtEnabled,
   onSimulMtEnabledChange,
   simulMtWaitK,
@@ -217,6 +221,25 @@ export function TranslatorSettings({
                 <div style={{ fontSize: '11px', color: '#94a3b8' }}>Reduces VRAM ~50%</div>
               </div>
             </label>
+            {(engineMode === 'offline-hymt15' || engineMode === 'offline-hunyuan-mt') && (
+              <label style={{ ...radioLabelStyle, paddingLeft: '24px' }}>
+                <input
+                  type="checkbox"
+                  checked={slmSpeculativeDecoding}
+                  onChange={(e) => onSlmSpeculativeDecodingChange(e.target.checked)}
+                  disabled={disabled}
+                />
+                <div>
+                  <div style={{ fontWeight: 500, fontSize: '12px' }}>Speculative decoding (LFM2 draft)</div>
+                  <div style={{ fontSize: '11px', color: '#94a3b8' }}>
+                    LFM2-350M generates draft tokens, verified by the main model — 1.5-2x faster
+                  </div>
+                  <div style={{ fontSize: '10px', color: '#64748b' }}>
+                    Requires LFM2 model (~230MB). Extra memory: ~230MB on top of the main model.
+                  </div>
+                </div>
+              </label>
+            )}
             <label style={{ ...radioLabelStyle, paddingLeft: '24px' }}>
               <input
                 type="checkbox"

--- a/src/renderer/hooks/useEngineSettings.ts
+++ b/src/renderer/hooks/useEngineSettings.ts
@@ -21,6 +21,8 @@ export interface EngineSettingsState {
 
   slmKvCacheQuant: boolean
   setSlmKvCacheQuant: (v: boolean) => void
+  slmSpeculativeDecoding: boolean
+  setSlmSpeculativeDecoding: (v: boolean) => void
   simulMtEnabled: boolean
   setSimulMtEnabled: (v: boolean) => void
   simulMtWaitK: number
@@ -56,6 +58,7 @@ export function useEngineSettings(init: EngineSettingsInit): EngineSettingsState
   const [microsoftApiKey, setMicrosoftApiKey] = useState('')
   const [microsoftRegion, setMicrosoftRegion] = useState('')
   const [slmKvCacheQuant, setSlmKvCacheQuant] = useState(true)
+  const [slmSpeculativeDecoding, setSlmSpeculativeDecoding] = useState(false)
   const [simulMtEnabled, setSimulMtEnabled] = useState(false)
   const [simulMtWaitK, setSimulMtWaitK] = useState(3)
   const [glossaryTerms, setGlossaryTerms] = useState<Array<{ source: string; target: string }>>([])
@@ -75,6 +78,7 @@ export function useEngineSettings(init: EngineSettingsInit): EngineSettingsState
       if (s.microsoftApiKey) setMicrosoftApiKey(str(s.microsoftApiKey, ''))
       if (s.microsoftRegion) setMicrosoftRegion(str(s.microsoftRegion, ''))
       if (s.slmKvCacheQuant !== undefined) setSlmKvCacheQuant(bool(s.slmKvCacheQuant, true))
+      if (s.slmSpeculativeDecoding !== undefined) setSlmSpeculativeDecoding(bool(s.slmSpeculativeDecoding, false))
       if (s.glossaryTerms) setGlossaryTerms(arr<{ source: string; target: string }>(s.glossaryTerms, []))
       if (s.orgGlossaryTerms) setOrgGlossaryTerms(arr<{ source: string; target: string }>(s.orgGlossaryTerms, []))
       if (s.simulMtEnabled !== undefined) setSimulMtEnabled(bool(s.simulMtEnabled, false))
@@ -116,6 +120,7 @@ export function useEngineSettings(init: EngineSettingsInit): EngineSettingsState
     microsoftApiKey, setMicrosoftApiKey,
     microsoftRegion, setMicrosoftRegion,
     slmKvCacheQuant, setSlmKvCacheQuant,
+    slmSpeculativeDecoding, setSlmSpeculativeDecoding,
     simulMtEnabled, setSimulMtEnabled,
     simulMtWaitK, setSimulMtWaitK,
     glossaryTerms, setGlossaryTerms,

--- a/src/renderer/hooks/useSettingsState.ts
+++ b/src/renderer/hooks/useSettingsState.ts
@@ -102,6 +102,8 @@ export interface SettingsState {
   // SLM options
   slmKvCacheQuant: boolean
   setSlmKvCacheQuant: (v: boolean) => void
+  slmSpeculativeDecoding: boolean
+  setSlmSpeculativeDecoding: (v: boolean) => void
   simulMtEnabled: boolean
   setSimulMtEnabled: (v: boolean) => void
   simulMtWaitK: number
@@ -197,6 +199,7 @@ export function useSettingsState(): SettingsState {
         sttEngine: language.sttEngine,
         whisperVariant: language.whisperVariant,
         slmKvCacheQuant: engine.slmKvCacheQuant,
+        slmSpeculativeDecoding: engine.slmSpeculativeDecoding,
         simulMtEnabled: engine.simulMtEnabled,
         simulMtWaitK: engine.simulMtWaitK,
         sourceLanguage: language.sourceLanguage,
@@ -310,6 +313,7 @@ export function useSettingsState(): SettingsState {
     microsoftApiKey: engine.microsoftApiKey, setMicrosoftApiKey: engine.setMicrosoftApiKey,
     microsoftRegion: engine.microsoftRegion, setMicrosoftRegion: engine.setMicrosoftRegion,
     slmKvCacheQuant: engine.slmKvCacheQuant, setSlmKvCacheQuant: engine.setSlmKvCacheQuant,
+    slmSpeculativeDecoding: engine.slmSpeculativeDecoding, setSlmSpeculativeDecoding: engine.setSlmSpeculativeDecoding,
     simulMtEnabled: engine.simulMtEnabled, setSimulMtEnabled: engine.setSimulMtEnabled,
     simulMtWaitK: engine.simulMtWaitK, setSimulMtWaitK: engine.setSimulMtWaitK,
     glossaryTerms: engine.glossaryTerms, setGlossaryTerms: engine.setGlossaryTerms,


### PR DESCRIPTION
## Summary

Extends speculative decoding (LFM2-350M draft model) to Hunyuan-MT 7B quality mode, reducing quality-mode latency from ~3.7s to an estimated ~1.2-1.8s.

- Add `speculativeDecoding` option to `HunyuanMTTranslator` (same pattern as `HunyuanMT15Translator`)
- Pass `slmSpeculativeDecoding` store setting to Hunyuan-MT 7B engine registration
- Add speculative decoding toggle in TranslatorSettings UI for HY-MT1.5 and Hunyuan-MT 7B modes
- Wire `slmSpeculativeDecoding` state through `useEngineSettings` -> `useSettingsState` -> `SettingsPanel` -> `TranslatorSettings`

All infrastructure already exists (`slm-worker.ts` with `DraftSequenceTokenPredictor`, `worker-pool.ts` with `draftModelPath`). This change only enables the existing path for the 7B model.

Closes #693

## Remaining tasks from the issue (require runtime testing)

- [ ] Benchmark: measure latency reduction for JA->EN and EN->JA with speculative decoding
- [ ] Benchmark: measure translation quality (BLEU/COMET) to confirm no degradation
- [ ] Measure memory usage with both models loaded (~4GB + ~230MB expected)
- [ ] Monitor EAGLE-3 support in llama.cpp (Discussion #15902) for future 3-6x speedup

## Test plan

- [ ] Verify typecheck passes (`npm run typecheck`)
- [ ] Verify lint has no new errors (`npm run lint`)
- [ ] Verify existing tests pass (`npm test`)
- [ ] Enable speculative decoding in settings, select Hunyuan-MT 7B, start pipeline -> verify LFM2 draft model loads and status shows "speculative decoding"
- [ ] Compare translation latency with and without speculative decoding
- [ ] Verify speculative decoding toggle only appears for HY-MT1.5 and Hunyuan-MT 7B engine modes