### PR TITLE
Progressive model loading for instant offline start

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -39,7 +39,7 @@ import { TTSManager } from './tts-manager'
 import { VirtualMicManager } from './virtual-mic-manager'
 import { loadMdmConfig } from './mdm-config'
 import { trackTranslatedCharacters } from './ipc/pipeline-ipc'
-import { startOnboardingDownload, isOnboardingModelReady } from './onboarding-downloader'
+import { startOnboardingDownload, isTier1Ready, isTier2Ready } from './onboarding-downloader'
 import type { STTEngine, TranslatorEngine, E2ETranslationEngine, TranslationResult } from '../engines/types'
 import type { WhisperVariant } from '../engines/model-downloader'
 
@@ -349,22 +349,26 @@ app.whenReady().then(async () => {
   cleanupShortcuts = registerGlobalShortcuts(ctx)
   initAutoUpdater(ctx)
 
-  // #575: Start background model download for cloud-first onboarding
-  if (store.get('isFirstRun') && !isOnboardingModelReady()) {
+  // #694: Start progressive model download for instant offline start
+  // Tier 1 (fast-start ~371MB) downloads first, Tier 2 (full-quality) follows
+  if (store.get('isFirstRun') && !isTier1Ready()) {
     // Delay to avoid competing with app startup I/O
     setTimeout(() => {
       startOnboardingDownload(ctx.mainWindow).then((engineMode) => {
         if (engineMode) {
-          log.info(`Onboarding model ready: ${engineMode}`)
-          ctx.mainWindow?.webContents.send('onboarding-download-progress', {
-            status: 'completed',
-            progress: 100
-          })
+          log.info(`Tier 1 models ready: ${engineMode} — basic offline translation available`)
         }
       }).catch((err) => {
-        log.error('Onboarding background download failed:', err)
+        log.error('Progressive model download failed:', err)
       })
     }, 5000)
+  } else if (store.get('isFirstRun') && isTier1Ready() && !isTier2Ready()) {
+    // Tier 1 is ready but Tier 2 still needs downloading — resume in background
+    setTimeout(() => {
+      startOnboardingDownload(ctx.mainWindow).catch((err) => {
+        log.error('Tier 2 background download failed:', err)
+      })
+    }, 10000)
   }
 })
 

--- a/src/main/ipc/onboarding-ipc.ts
+++ b/src/main/ipc/onboarding-ipc.ts
@@ -3,21 +3,24 @@ import { store } from '../store'
 import {
   getOnboardingStatus,
   startOnboardingDownload,
-  isOnboardingModelReady
+  isTier1Ready,
+  isTier2Ready,
+  getTier1EngineConfig,
+  getTier2EngineConfig
 } from '../onboarding-downloader'
 import type { AppContext } from '../app-context'
 import { createLogger } from '../logger'
 
 const log = createLogger('ipc:onboarding')
 
-/** Register onboarding IPC handlers for cloud-first progressive download (#575) */
+/** Register onboarding IPC handlers for progressive model loading (#575, #694) */
 export function registerOnboardingIpc(ctx: AppContext): void {
-  // Get current onboarding download status
+  // Get current progressive download status
   ipcMain.handle('onboarding-get-status', () => {
     return getOnboardingStatus()
   })
 
-  // Start background model download
+  // Start progressive background download (Tier 1 → Tier 2)
   ipcMain.handle('onboarding-start-download', async () => {
     const engineMode = await startOnboardingDownload(ctx.mainWindow)
     if (engineMode) {
@@ -26,17 +29,44 @@ export function registerOnboardingIpc(ctx: AppContext): void {
     return { success: false }
   })
 
-  // Switch to local engine after download completes
+  // Switch to Tier 1 (basic offline) engine after Tier 1 download completes
   ipcMain.handle('onboarding-switch-to-local', async () => {
-    if (!isOnboardingModelReady()) {
-      return { error: 'Local model not yet downloaded' }
+    if (!isTier1Ready()) {
+      return { error: 'Tier 1 models not yet downloaded' }
     }
 
-    const preferred = store.get('preferredLocalEngine')
-    store.set('translationEngine', preferred)
+    const tier1Config = getTier1EngineConfig()
+    if (!tier1Config) {
+      return { error: 'Tier 1 engine configuration unavailable' }
+    }
+
+    store.set('translationEngine', tier1Config.engineMode)
+    store.set('sttEngine', tier1Config.sttEngineId)
+    store.set('whisperVariant', tier1Config.whisperVariant)
+    store.set('activeModelTier', 1)
+    // Don't set isFirstRun=false yet — Tier 2 may still need to download
+    log.info(`Onboarding: switched to Tier 1 (${tier1Config.engineMode}, STT: ${tier1Config.sttEngineId})`)
+    return { success: true, engine: tier1Config.engineMode, tier: 1 }
+  })
+
+  // Upgrade to Tier 2 (full-quality) engine after Tier 2 download completes
+  ipcMain.handle('onboarding-upgrade-to-tier2', async () => {
+    if (!isTier2Ready()) {
+      return { error: 'Tier 2 models not yet downloaded' }
+    }
+
+    const tier2Config = getTier2EngineConfig()
+    if (!tier2Config) {
+      return { error: 'Tier 2 engine configuration unavailable' }
+    }
+
+    store.set('translationEngine', tier2Config.engineMode)
+    store.set('sttEngine', tier2Config.sttEngineId)
+    store.set('whisperVariant', tier2Config.whisperVariant)
+    store.set('activeModelTier', 2)
     store.set('isFirstRun', false)
-    log.info(`Onboarding: switched to local engine ${preferred}`)
-    return { success: true, engine: preferred }
+    log.info(`Onboarding: upgraded to Tier 2 (${tier2Config.engineMode}, STT: ${tier2Config.sttEngineId})`)
+    return { success: true, engine: tier2Config.engineMode, tier: 2 }
   })
 
   // Dismiss onboarding (user wants to stay on current engine)

--- a/src/main/onboarding-downloader.ts
+++ b/src/main/onboarding-downloader.ts
@@ -3,149 +3,473 @@ import { createLogger } from './logger'
 import {
   isGGUFDownloaded,
   downloadGGUF,
+  isModelDownloaded,
+  downloadModel,
   getHunyuanMT15Variants,
-  getLFM2Variants
+  getLFM2Variants,
+  WHISPER_VARIANTS
 } from '../engines/model-downloader'
+import type { WhisperVariant } from '../engines/model-downloader'
 import type { BrowserWindow } from 'electron'
 
 const log = createLogger('onboarding-downloader')
 
-/** Model target configuration for onboarding download */
-interface OnboardingTarget {
-  engineId: string
-  engineMode: string
-  filename: string
-  url: string
-  sha256?: string
-  sizeMB: number
+// ---------------------------------------------------------------------------
+// Model tier system (#694)
+// Tier 1: smallest viable STT + translation pair for instant start (~371MB)
+// Tier 2: full-quality models downloaded in background after Tier 1 is ready
+// ---------------------------------------------------------------------------
+
+/** Model tier identifier */
+export type ModelTier = 1 | 2
+
+/** A single model to download as part of a tier */
+interface TierModel {
+  /** Which tier this model belongs to */
+  tier: ModelTier
+  /** Unique key for tracking download state */
+  key: string
+  /** Human-readable label */
   label: string
+  /** Approximate size in MB */
+  sizeMB: number
+  /** 'whisper' uses downloadModel(), 'gguf' uses downloadGGUF() */
+  type: 'whisper' | 'gguf'
+  /** For whisper models */
+  whisperVariant?: WhisperVariant
+  /** For gguf models */
+  ggufFilename?: string
+  ggufUrl?: string
+  ggufSha256?: string
+  /** Engine mode to use when this model is available */
+  sttEngineId?: string
+  translatorEngineId?: string
+  engineMode?: string
 }
 
-/** Get the target model for onboarding based on preferred engine */
-function getOnboardingTarget(): OnboardingTarget | null {
-  const preferred = store.get('preferredLocalEngine')
-
-  if (preferred === 'offline-lfm2') {
-    const variants = getLFM2Variants()
-    const v = variants['Q4_K_M']
-    if (!v) return null
-    return {
-      engineId: 'lfm2',
-      engineMode: 'offline-lfm2',
-      filename: v.filename,
-      url: v.url,
-      sizeMB: v.sizeMB,
-      label: 'LFM2-350M'
+/** Tier 1: Whisper base (142MB) + LFM2 Q4_K_M (229MB) = ~371MB total */
+function getTier1Models(): TierModel[] {
+  const lfm2 = getLFM2Variants()['Q4_K_M']
+  const models: TierModel[] = [
+    {
+      tier: 1,
+      key: 'tier1-stt',
+      label: 'Whisper Base (Fast STT)',
+      sizeMB: WHISPER_VARIANTS['base'].sizeMB,
+      type: 'whisper',
+      whisperVariant: 'base',
+      sttEngineId: 'whisper-local'
     }
+  ]
+  if (lfm2) {
+    models.push({
+      tier: 1,
+      key: 'tier1-translator',
+      label: 'LFM2-350M (Fast Translation)',
+      sizeMB: lfm2.sizeMB,
+      type: 'gguf',
+      ggufFilename: lfm2.filename,
+      ggufUrl: lfm2.url,
+      translatorEngineId: 'lfm2',
+      engineMode: 'offline-lfm2'
+    })
   }
-
-  // Default: HY-MT1.5-1.8B
-  const variants = getHunyuanMT15Variants()
-  const v = variants['Q4_K_M']
-  if (!v) return null
-  return {
-    engineId: 'hunyuan-mt-15',
-    engineMode: 'offline-hymt15',
-    filename: v.filename,
-    url: v.url,
-    sizeMB: v.sizeMB,
-    label: 'HY-MT1.5-1.8B'
-  }
+  return models
 }
 
-/** Check if the preferred local model is already downloaded */
+/** Tier 2: Full-quality models for upgrade after Tier 1 is usable */
+function getTier2Models(): TierModel[] {
+  const models: TierModel[] = [
+    // Full STT: Kotoba Whisper v2.0 (JA-optimized, 540MB)
+    {
+      tier: 2,
+      key: 'tier2-stt',
+      label: 'Whisper Kotoba v2.0 (JA-optimized)',
+      sizeMB: WHISPER_VARIANTS['kotoba-v2.0'].sizeMB,
+      type: 'whisper',
+      whisperVariant: 'kotoba-v2.0',
+      sttEngineId: 'whisper-local'
+    }
+  ]
+
+  // Full translator: HY-MT1.5-1.8B Q4_K_M (~1.1GB)
+  // Upgrades from LFM2 (Tier 1) for better translation quality
+  const hymt15 = getHunyuanMT15Variants()['Q4_K_M']
+  if (hymt15) {
+    models.push({
+      tier: 2,
+      key: 'tier2-translator',
+      label: 'HY-MT1.5-1.8B (Quality Translation)',
+      sizeMB: hymt15.sizeMB,
+      type: 'gguf',
+      ggufFilename: hymt15.filename,
+      ggufUrl: hymt15.url,
+      translatorEngineId: 'hunyuan-mt-15',
+      engineMode: 'offline-hymt15'
+    })
+  }
+
+  return models
+}
+
+/** Check if a specific model is already downloaded */
+function isModelReady(model: TierModel): boolean {
+  if (model.type === 'whisper' && model.whisperVariant) {
+    return isModelDownloaded(model.whisperVariant)
+  }
+  if (model.type === 'gguf' && model.ggufFilename) {
+    return isGGUFDownloaded(model.ggufFilename)
+  }
+  return false
+}
+
+/** Check if all Tier 1 models are downloaded and ready */
+export function isTier1Ready(): boolean {
+  return getTier1Models().every(isModelReady)
+}
+
+/** Check if all Tier 2 models are downloaded and ready */
+export function isTier2Ready(): boolean {
+  return getTier2Models().every(isModelReady)
+}
+
+/** Check if the preferred local model is already downloaded (legacy compat) */
 export function isOnboardingModelReady(): boolean {
-  const target = getOnboardingTarget()
-  if (!target) return false
-  return isGGUFDownloaded(target.filename)
+  return isTier1Ready()
 }
 
-/** Get onboarding download status for renderer */
-export function getOnboardingStatus(): {
-  status: string
-  progress: number
-  preferredEngine: string
-  modelReady: boolean
-  targetLabel: string
-  targetSizeMB: number
-} {
-  const target = getOnboardingTarget()
+/** Get the engine configuration for Tier 1 models */
+export function getTier1EngineConfig(): { sttEngineId: string; translatorEngineId: string; engineMode: string; whisperVariant: string } | null {
+  const models = getTier1Models()
+  const stt = models.find(m => m.sttEngineId)
+  const translator = models.find(m => m.translatorEngineId)
+  if (!stt || !translator) return null
   return {
-    status: store.get('onboardingModelStatus'),
-    progress: store.get('onboardingDownloadProgress'),
-    preferredEngine: store.get('preferredLocalEngine'),
-    modelReady: target ? isGGUFDownloaded(target.filename) : false,
-    targetLabel: target?.label ?? 'Unknown',
-    targetSizeMB: target?.sizeMB ?? 0
+    sttEngineId: stt.sttEngineId!,
+    translatorEngineId: translator.translatorEngineId!,
+    engineMode: translator.engineMode!,
+    whisperVariant: stt.whisperVariant || 'base'
+  }
+}
+
+/** Get the engine configuration for Tier 2 models */
+export function getTier2EngineConfig(): { sttEngineId: string; translatorEngineId: string; engineMode: string; whisperVariant: string } | null {
+  const models = getTier2Models()
+  const stt = models.find(m => m.sttEngineId)
+  const translator = models.find(m => m.translatorEngineId)
+  if (!stt || !translator) return null
+  return {
+    sttEngineId: stt.sttEngineId!,
+    translatorEngineId: translator.translatorEngineId!,
+    engineMode: translator.engineMode!,
+    whisperVariant: stt.whisperVariant || 'kotoba-v2.0'
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Progressive download status
+// ---------------------------------------------------------------------------
+
+export interface ProgressiveDownloadStatus {
+  /** Current download phase */
+  tier: ModelTier | null
+  /** Overall status */
+  status: 'idle' | 'downloading-tier1' | 'tier1-ready' | 'downloading-tier2' | 'all-ready' | 'failed'
+  /** Progress for current tier (0-100) */
+  progress: number
+  /** Whether Tier 1 models are downloaded */
+  tier1Ready: boolean
+  /** Whether Tier 2 models are downloaded */
+  tier2Ready: boolean
+  /** Current download label */
+  currentLabel: string
+  /** Total size of current tier */
+  currentTierSizeMB: number
+  /** Error message if failed */
+  error?: string
+}
+
+/** Get full progressive download status for renderer */
+export function getOnboardingStatus(): ProgressiveDownloadStatus {
+  const tier1Ready = isTier1Ready()
+  const tier2Ready = isTier2Ready()
+  const storedStatus = store.get('onboardingModelStatus')
+  const progress = store.get('onboardingDownloadProgress')
+
+  let status: ProgressiveDownloadStatus['status']
+  if (tier1Ready && tier2Ready) {
+    status = 'all-ready'
+  } else if (tier1Ready && storedStatus === 'downloading') {
+    status = 'downloading-tier2'
+  } else if (tier1Ready) {
+    status = 'tier1-ready'
+  } else if (storedStatus === 'downloading') {
+    status = 'downloading-tier1'
+  } else if (storedStatus === 'failed') {
+    status = 'failed'
+  } else {
+    status = 'idle'
+  }
+
+  const tier1Models = getTier1Models()
+  const tier2Models = getTier2Models()
+  const tier1Size = tier1Models.reduce((s, m) => s + m.sizeMB, 0)
+  const tier2Size = tier2Models.reduce((s, m) => s + m.sizeMB, 0)
+
+  return {
+    tier: tier1Ready ? 2 : 1,
+    status,
+    progress,
+    tier1Ready,
+    tier2Ready,
+    currentLabel: tier1Ready
+      ? tier2Models.map(m => m.label).join(' + ')
+      : tier1Models.map(m => m.label).join(' + '),
+    currentTierSizeMB: tier1Ready ? tier2Size : tier1Size
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Download orchestration
+// ---------------------------------------------------------------------------
+
+/** Download a single model with progress reporting */
+async function downloadTierModel(
+  model: TierModel,
+  mainWindow: BrowserWindow | null,
+  onProgress: (pct: number, message: string) => void
+): Promise<void> {
+  if (isModelReady(model)) {
+    log.info(`Model already downloaded: ${model.label}`)
+    return
+  }
+
+  if (model.type === 'whisper' && model.whisperVariant) {
+    await downloadModel((message) => {
+      const pctMatch = message.match(/(\d+)%/)
+      if (pctMatch) onProgress(parseInt(pctMatch[1], 10), message)
+      mainWindow?.webContents.send('status-update', message)
+    }, model.whisperVariant)
+  } else if (model.type === 'gguf' && model.ggufFilename && model.ggufUrl) {
+    await downloadGGUF(model.ggufFilename, model.ggufUrl, (message) => {
+      const pctMatch = message.match(/(\d+)%/)
+      if (pctMatch) onProgress(parseInt(pctMatch[1], 10), message)
+      mainWindow?.webContents.send('status-update', message)
+    }, model.ggufSha256)
   }
 }
 
 /**
- * Start background download of the preferred local translation model.
- * Sends progress updates to the renderer via IPC.
- * Returns the engine mode to switch to on completion.
+ * Start progressive download: Tier 1 first, then Tier 2 in background.
+ * Downloads models within each tier in parallel for maximum speed.
+ * Returns the engine mode available after Tier 1 completes.
  */
 export async function startOnboardingDownload(
   mainWindow: BrowserWindow | null
 ): Promise<string | null> {
-  const target = getOnboardingTarget()
-  if (!target) {
-    log.warn('No onboarding target configured')
-    return null
-  }
-
-  // Already downloaded
-  if (isGGUFDownloaded(target.filename)) {
-    store.set('onboardingModelStatus', 'completed')
-    store.set('onboardingDownloadProgress', 100)
-    sendProgress(mainWindow, { status: 'completed', progress: 100 })
-    return target.engineMode
-  }
-
   // Already downloading
   if (store.get('onboardingModelStatus') === 'downloading') {
     log.info('Onboarding download already in progress')
     return null
   }
 
+  // Phase 1: Tier 1 (instant-start models)
+  if (!isTier1Ready()) {
+    const tier1Models = getTier1Models()
+    const tier1Config = getTier1EngineConfig()
+    if (tier1Models.length === 0 || !tier1Config) {
+      log.warn('No Tier 1 models configured')
+      return null
+    }
+
+    store.set('onboardingModelStatus', 'downloading')
+    store.set('onboardingDownloadProgress', 0)
+    sendProgress(mainWindow, {
+      status: 'downloading-tier1',
+      progress: 0,
+      tier: 1,
+      tier1Ready: false,
+      tier2Ready: false
+    })
+
+    const totalSizeMB = tier1Models.reduce((s, m) => s + m.sizeMB, 0)
+    log.info(`Starting Tier 1 download: ${tier1Models.map(m => m.label).join(', ')} (${totalSizeMB}MB)`)
+
+    try {
+      // Track per-model progress for combined percentage
+      const modelProgress = new Map<string, number>()
+      for (const m of tier1Models) modelProgress.set(m.key, 0)
+
+      const updateCombinedProgress = (): void => {
+        // Weight progress by model size
+        let weightedDone = 0
+        for (const m of tier1Models) {
+          weightedDone += (modelProgress.get(m.key) || 0) * m.sizeMB
+        }
+        const pct = Math.round(weightedDone / totalSizeMB)
+        store.set('onboardingDownloadProgress', pct)
+        sendProgress(mainWindow, {
+          status: 'downloading-tier1',
+          progress: pct,
+          tier: 1,
+          tier1Ready: false,
+          tier2Ready: false
+        })
+      }
+
+      // Download Tier 1 models in parallel
+      await Promise.all(
+        tier1Models.map(model =>
+          downloadTierModel(model, mainWindow, (pct) => {
+            modelProgress.set(model.key, pct)
+            updateCombinedProgress()
+          })
+        )
+      )
+
+      store.set('onboardingDownloadProgress', 100)
+      sendProgress(mainWindow, {
+        status: 'tier1-ready',
+        progress: 100,
+        tier: 1,
+        tier1Ready: true,
+        tier2Ready: isTier2Ready()
+      })
+      log.info('Tier 1 download complete — basic offline translation ready')
+
+      // Start Tier 2 download in background (non-blocking)
+      startTier2Download(mainWindow).catch((err) => {
+        log.error('Tier 2 background download failed:', err)
+      })
+
+      return tier1Config.engineMode
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err)
+      store.set('onboardingModelStatus', 'failed')
+      sendProgress(mainWindow, {
+        status: 'failed',
+        progress: 0,
+        tier: 1,
+        tier1Ready: false,
+        tier2Ready: false,
+        error: message
+      })
+      log.error(`Tier 1 download failed: ${message}`)
+      return null
+    }
+  }
+
+  // Tier 1 already ready — just start Tier 2 if needed
+  const tier1Config = getTier1EngineConfig()
+  if (!isTier2Ready()) {
+    startTier2Download(mainWindow).catch((err) => {
+      log.error('Tier 2 background download failed:', err)
+    })
+  }
+  return tier1Config?.engineMode ?? null
+}
+
+/**
+ * Download Tier 2 (full-quality) models in background.
+ * Does not block the main onboarding flow.
+ */
+async function startTier2Download(mainWindow: BrowserWindow | null): Promise<void> {
+  if (isTier2Ready()) {
+    sendProgress(mainWindow, {
+      status: 'all-ready',
+      progress: 100,
+      tier: 2,
+      tier1Ready: true,
+      tier2Ready: true
+    })
+    return
+  }
+
+  const tier2Models = getTier2Models().filter(m => !isModelReady(m))
+  if (tier2Models.length === 0) return
+
   store.set('onboardingModelStatus', 'downloading')
   store.set('onboardingDownloadProgress', 0)
-  sendProgress(mainWindow, { status: 'downloading', progress: 0 })
+  const totalSizeMB = tier2Models.reduce((s, m) => s + m.sizeMB, 0)
 
-  log.info(`Starting onboarding download: ${target.label} (${target.sizeMB}MB)`)
+  log.info(`Starting Tier 2 download: ${tier2Models.map(m => m.label).join(', ')} (${totalSizeMB}MB)`)
+
+  sendProgress(mainWindow, {
+    status: 'downloading-tier2',
+    progress: 0,
+    tier: 2,
+    tier1Ready: true,
+    tier2Ready: false
+  })
 
   try {
-    await downloadGGUF(target.filename, target.url, (message) => {
-      // Parse progress percentage from download message
-      const pctMatch = message.match(/(\d+)%/)
-      if (pctMatch) {
-        const progress = parseInt(pctMatch[1], 10)
-        store.set('onboardingDownloadProgress', progress)
-        sendProgress(mainWindow, { status: 'downloading', progress, message })
+    const modelProgress = new Map<string, number>()
+    for (const m of tier2Models) modelProgress.set(m.key, 0)
+
+    const updateCombinedProgress = (): void => {
+      let weightedDone = 0
+      for (const m of tier2Models) {
+        weightedDone += (modelProgress.get(m.key) || 0) * m.sizeMB
       }
-      // Also forward to general status updates
-      mainWindow?.webContents.send('status-update', message)
-    }, target.sha256)
+      const pct = Math.round(weightedDone / totalSizeMB)
+      store.set('onboardingDownloadProgress', pct)
+      sendProgress(mainWindow, {
+        status: 'downloading-tier2',
+        progress: pct,
+        tier: 2,
+        tier1Ready: true,
+        tier2Ready: false
+      })
+    }
+
+    // Download Tier 2 models sequentially to avoid bandwidth contention
+    // with any active translation pipeline
+    for (const model of tier2Models) {
+      await downloadTierModel(model, mainWindow, (pct) => {
+        modelProgress.set(model.key, pct)
+        updateCombinedProgress()
+      })
+      modelProgress.set(model.key, 100)
+      updateCombinedProgress()
+    }
 
     store.set('onboardingModelStatus', 'completed')
     store.set('onboardingDownloadProgress', 100)
-    sendProgress(mainWindow, { status: 'completed', progress: 100 })
-    log.info(`Onboarding download complete: ${target.label}`)
-
-    return target.engineMode
+    sendProgress(mainWindow, {
+      status: 'all-ready',
+      progress: 100,
+      tier: 2,
+      tier1Ready: true,
+      tier2Ready: true
+    })
+    log.info('Tier 2 download complete — full quality models ready')
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err)
-    store.set('onboardingModelStatus', 'failed')
-    sendProgress(mainWindow, { status: 'failed', progress: 0, error: message })
-    log.error(`Onboarding download failed: ${message}`)
-    return null
+    // Don't set main status to failed — Tier 1 is still usable
+    log.error(`Tier 2 download failed: ${message}`)
+    sendProgress(mainWindow, {
+      status: 'tier1-ready',
+      progress: 0,
+      tier: 2,
+      tier1Ready: true,
+      tier2Ready: false,
+      error: `Tier 2 download failed: ${message}`
+    })
   }
 }
 
 /** Send download progress to renderer */
 function sendProgress(
   mainWindow: BrowserWindow | null,
-  data: { status: string; progress: number; message?: string; error?: string }
+  data: {
+    status: string
+    progress: number
+    tier?: ModelTier | null
+    tier1Ready?: boolean
+    tier2Ready?: boolean
+    message?: string
+    error?: string
+  }
 ): void {
   mainWindow?.webContents.send('onboarding-download-progress', data)
 }

--- a/src/main/store.ts
+++ b/src/main/store.ts
@@ -138,6 +138,8 @@ export interface AppSettings {
   onboardingDownloadProgress: number
   /** Preferred local translation engine to switch to after download (#575) */
   preferredLocalEngine: string
+  /** Current model quality tier in use: 1=basic (fast-start), 2=full-quality (#694) */
+  activeModelTier: 1 | 2 | null
 }
 
 export const store = new Store<AppSettings>({
@@ -205,6 +207,7 @@ export const store = new Store<AppSettings>({
     isFirstRun: true,
     onboardingModelStatus: 'idle',
     onboardingDownloadProgress: 0,
-    preferredLocalEngine: 'offline-hymt15'
+    preferredLocalEngine: 'offline-hymt15',
+    activeModelTier: null
   }
 })

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -163,21 +163,27 @@ export interface ElectronAPI {
 
   // Onboarding: cloud-first progressive download (#575)
   onboardingGetStatus: () => Promise<{
+    tier: number | null
     status: string
     progress: number
-    preferredEngine: string
-    modelReady: boolean
-    targetLabel: string
-    targetSizeMB: number
+    tier1Ready: boolean
+    tier2Ready: boolean
+    currentLabel: string
+    currentTierSizeMB: number
+    error?: string
   }>
   onboardingStartDownload: () => Promise<{ success: boolean; engineMode?: string }>
-  onboardingSwitchToLocal: () => Promise<{ success?: boolean; engine?: string; error?: string }>
+  onboardingSwitchToLocal: () => Promise<{ success?: boolean; engine?: string; tier?: number; error?: string }>
+  onboardingUpgradeToTier2: () => Promise<{ success?: boolean; engine?: string; tier?: number; error?: string }>
   onboardingDismiss: () => Promise<{ success: boolean }>
   onboardingSetPreferredEngine: (engine: string) => Promise<{ success?: boolean; error?: string }>
   onboardingIsFirstRun: () => Promise<boolean>
   onOnboardingDownloadProgress: (callback: (data: {
     status: string
     progress: number
+    tier?: number | null
+    tier1Ready?: boolean
+    tier2Ready?: boolean
     message?: string
     error?: string
   }) => void) => (() => void)

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -195,15 +195,16 @@ contextBridge.exposeInMainWorld('api', {
     return () => ipcRenderer.off('audio-port', handler)
   },
 
-  // Onboarding: cloud-first progressive download (#575)
+  // Onboarding: progressive model loading (#575, #694)
   onboardingGetStatus: () => ipcRenderer.invoke('onboarding-get-status'),
   onboardingStartDownload: () => ipcRenderer.invoke('onboarding-start-download'),
   onboardingSwitchToLocal: () => ipcRenderer.invoke('onboarding-switch-to-local'),
+  onboardingUpgradeToTier2: () => ipcRenderer.invoke('onboarding-upgrade-to-tier2'),
   onboardingDismiss: () => ipcRenderer.invoke('onboarding-dismiss'),
   onboardingSetPreferredEngine: (engine: string) => ipcRenderer.invoke('onboarding-set-preferred-engine', engine),
   onboardingIsFirstRun: () => ipcRenderer.invoke('onboarding-is-first-run'),
-  onOnboardingDownloadProgress: (callback: (data: { status: string; progress: number; message?: string; error?: string }) => void) => {
-    const handler = (_event: Electron.IpcRendererEvent, data: { status: string; progress: number; message?: string; error?: string }): void => callback(data)
+  onOnboardingDownloadProgress: (callback: (data: { status: string; progress: number; tier?: number | null; tier1Ready?: boolean; tier2Ready?: boolean; message?: string; error?: string }) => void) => {
+    const handler = (_event: Electron.IpcRendererEvent, data: { status: string; progress: number; tier?: number | null; tier1Ready?: boolean; tier2Ready?: boolean; message?: string; error?: string }): void => callback(data)
     ipcRenderer.on('onboarding-download-progress', handler)
     return () => ipcRenderer.off('onboarding-download-progress', handler)
   },

--- a/src/renderer/components/settings/ModelDownloadProgress.tsx
+++ b/src/renderer/components/settings/ModelDownloadProgress.tsx
@@ -1,12 +1,14 @@
 import React, { useEffect, useState, useCallback } from 'react'
 
-interface DownloadStatus {
+interface ProgressiveDownloadStatus {
+  tier: number | null
   status: string
   progress: number
-  preferredEngine: string
-  modelReady: boolean
-  targetLabel: string
-  targetSizeMB: number
+  tier1Ready: boolean
+  tier2Ready: boolean
+  currentLabel: string
+  currentTierSizeMB: number
+  error?: string
 }
 
 interface ModelDownloadProgressProps {
@@ -45,15 +47,28 @@ const buttonBaseStyle: React.CSSProperties = {
   cursor: 'pointer'
 }
 
+const tierBadgeStyle = (ready: boolean): React.CSSProperties => ({
+  display: 'inline-block',
+  padding: '2px 6px',
+  fontSize: '10px',
+  fontWeight: 700,
+  borderRadius: '4px',
+  background: ready ? '#166534' : '#1e293b',
+  color: ready ? '#4ade80' : '#64748b',
+  border: `1px solid ${ready ? '#22c55e' : '#475569'}`,
+  marginRight: '6px'
+})
+
 export function ModelDownloadProgress({
   onSwitchToLocal,
   onDismiss,
   disabled
 }: ModelDownloadProgressProps): React.JSX.Element | null {
-  const [downloadStatus, setDownloadStatus] = useState<DownloadStatus | null>(null)
+  const [downloadStatus, setDownloadStatus] = useState<ProgressiveDownloadStatus | null>(null)
   const [isFirstRun, setIsFirstRun] = useState(false)
   const [downloading, setDownloading] = useState(false)
   const [switchedToLocal, setSwitchedToLocal] = useState(false)
+  const [upgradedToTier2, setUpgradedToTier2] = useState(false)
 
   // Load initial status
   useEffect(() => {
@@ -61,9 +76,11 @@ export function ModelDownloadProgress({
       window.api.onboardingGetStatus(),
       window.api.onboardingIsFirstRun()
     ]).then(([status, firstRun]) => {
-      setDownloadStatus(status)
+      setDownloadStatus(status as ProgressiveDownloadStatus)
       setIsFirstRun(firstRun)
-      if (status.status === 'downloading') setDownloading(true)
+      if (status.status === 'downloading-tier1' || status.status === 'downloading-tier2') {
+        setDownloading(true)
+      }
     }).catch((err: unknown) => {
       const e = err instanceof Error ? err : new Error(String(err))
       console.warn('[model-download] Failed to load onboarding status:', e.message)
@@ -73,14 +90,24 @@ export function ModelDownloadProgress({
   // Listen for progress updates
   useEffect(() => {
     const unsub = window.api.onOnboardingDownloadProgress((data) => {
-      setDownloadStatus((prev) => prev ? {
-        ...prev,
-        status: data.status,
-        progress: data.progress,
-        modelReady: data.status === 'completed'
-      } : null)
+      setDownloadStatus((prev) => {
+        if (!prev) return null
+        return {
+          ...prev,
+          status: data.status,
+          progress: data.progress,
+          tier: data.tier ?? prev.tier,
+          tier1Ready: data.tier1Ready ?? prev.tier1Ready,
+          tier2Ready: data.tier2Ready ?? prev.tier2Ready,
+          error: data.error
+        }
+      })
 
-      if (data.status === 'completed' || data.status === 'failed') {
+      if (data.status === 'all-ready' || data.status === 'failed') {
+        setDownloading(false)
+      }
+      // Tier 1 just became ready — stop showing "downloading" spinner
+      if (data.status === 'tier1-ready') {
         setDownloading(false)
       }
     })
@@ -98,7 +125,7 @@ export function ModelDownloadProgress({
     }
   }, [])
 
-  const handleSwitchToLocal = useCallback(async () => {
+  const handleSwitchToTier1 = useCallback(async () => {
     try {
       const result = await window.api.onboardingSwitchToLocal()
       if (result.success && result.engine) {
@@ -107,7 +134,20 @@ export function ModelDownloadProgress({
       }
     } catch (err: unknown) {
       const e = err instanceof Error ? err : new Error(String(err))
-      console.warn('[model-download] Failed to switch to local engine:', e.message)
+      console.warn('[model-download] Failed to switch to Tier 1:', e.message)
+    }
+  }, [onSwitchToLocal])
+
+  const handleUpgradeToTier2 = useCallback(async () => {
+    try {
+      const result = await window.api.onboardingUpgradeToTier2()
+      if (result.success && result.engine) {
+        setUpgradedToTier2(true)
+        onSwitchToLocal(result.engine)
+      }
+    } catch (err: unknown) {
+      const e = err instanceof Error ? err : new Error(String(err))
+      console.warn('[model-download] Failed to upgrade to Tier 2:', e.message)
     }
   }, [onSwitchToLocal])
 
@@ -122,25 +162,70 @@ export function ModelDownloadProgress({
     }
   }, [onDismiss])
 
-  // Don't show if not first run or already switched
-  if (!isFirstRun || switchedToLocal) return null
+  // Don't show if not first run or fully dismissed
+  if (!isFirstRun || upgradedToTier2) return null
   if (!downloadStatus) return null
 
-  const { status, progress, targetLabel, targetSizeMB, modelReady } = downloadStatus
+  const { status, progress, tier1Ready, tier2Ready } = downloadStatus
 
-  // Model already ready — show switch prompt
-  if (modelReady && status === 'completed') {
+  // All models ready — show upgrade prompt
+  if (tier1Ready && tier2Ready && status === 'all-ready') {
+    if (switchedToLocal) {
+      // User is on Tier 1, Tier 2 is now ready — prompt upgrade
+      return (
+        <div style={bannerStyle} role="status" aria-live="polite">
+          <div style={{ display: 'flex', alignItems: 'center', marginBottom: '6px' }}>
+            <span style={tierBadgeStyle(true)}>Tier 1</span>
+            <span style={tierBadgeStyle(true)}>Tier 2</span>
+            <span style={{ fontSize: '13px', fontWeight: 600, color: '#4ade80' }}>
+              Full quality models ready
+            </span>
+          </div>
+          <div style={{ fontSize: '12px', color: '#94a3b8', marginBottom: '10px' }}>
+            Higher quality STT and translation models have finished downloading. Upgrade for better accuracy.
+          </div>
+          <div style={{ display: 'flex', gap: '8px' }}>
+            <button
+              onClick={handleUpgradeToTier2}
+              disabled={disabled}
+              style={{
+                ...buttonBaseStyle,
+                background: '#22c55e',
+                color: '#fff'
+              }}
+            >
+              Upgrade to full quality
+            </button>
+            <button
+              onClick={handleDismiss}
+              style={{
+                ...buttonBaseStyle,
+                background: '#334155',
+                color: '#94a3b8'
+              }}
+            >
+              Keep current
+            </button>
+          </div>
+        </div>
+      )
+    }
+
+    // User hasn't switched yet but all models are ready
     return (
       <div style={bannerStyle} role="status" aria-live="polite">
-        <div style={{ fontSize: '13px', fontWeight: 600, color: '#4ade80', marginBottom: '6px' }}>
-          Local model ready
+        <div style={{ display: 'flex', alignItems: 'center', marginBottom: '6px' }}>
+          <span style={tierBadgeStyle(true)}>Tier 2</span>
+          <span style={{ fontSize: '13px', fontWeight: 600, color: '#4ade80' }}>
+            Full quality offline models ready
+          </span>
         </div>
         <div style={{ fontSize: '12px', color: '#94a3b8', marginBottom: '10px' }}>
-          {targetLabel} has been downloaded. Switch to offline translation for faster, private results.
+          All models downloaded. Switch to offline translation for the best quality.
         </div>
         <div style={{ display: 'flex', gap: '8px' }}>
           <button
-            onClick={handleSwitchToLocal}
+            onClick={handleUpgradeToTier2}
             disabled={disabled}
             style={{
               ...buttonBaseStyle,
@@ -148,7 +233,7 @@ export function ModelDownloadProgress({
               color: '#fff'
             }}
           >
-            Switch to {targetLabel}
+            Switch to full quality
           </button>
           <button
             onClick={handleDismiss}
@@ -165,6 +250,105 @@ export function ModelDownloadProgress({
     )
   }
 
+  // Tier 1 ready, Tier 2 downloading — show basic mode active + upgrade progress
+  if (tier1Ready && !tier2Ready) {
+    if (status === 'downloading-tier2') {
+      return (
+        <div style={bannerStyle} role="status" aria-live="polite">
+          <div style={{ display: 'flex', alignItems: 'center', marginBottom: '6px' }}>
+            <span style={tierBadgeStyle(true)}>Tier 1</span>
+            <span style={tierBadgeStyle(false)}>Tier 2</span>
+            <span style={{ fontSize: '13px', fontWeight: 600, color: '#60a5fa' }}>
+              {switchedToLocal ? 'Basic mode active' : 'Basic offline ready'}
+            </span>
+          </div>
+          <div style={{ fontSize: '12px', color: '#94a3b8' }}>
+            {switchedToLocal
+              ? 'Translating with fast models. Downloading full quality models in background...'
+              : 'Basic offline models ready. Full quality models downloading in background...'}
+          </div>
+          <div style={progressBarContainerStyle}>
+            <div
+              style={{
+                width: `${Math.max(progress, 2)}%`,
+                height: '100%',
+                background: '#3b82f6',
+                borderRadius: '3px',
+                transition: 'width 0.3s ease'
+              }}
+              role="progressbar"
+              aria-valuenow={progress}
+              aria-valuemin={0}
+              aria-valuemax={100}
+            />
+          </div>
+          <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+            <span style={{ fontSize: '11px', color: '#94a3b8' }}>
+              Upgrading: {progress}%
+            </span>
+            {!switchedToLocal && (
+              <button
+                onClick={handleSwitchToTier1}
+                disabled={disabled}
+                style={{
+                  ...buttonBaseStyle,
+                  padding: '4px 12px',
+                  background: '#22c55e',
+                  color: '#fff'
+                }}
+              >
+                Use basic offline now
+              </button>
+            )}
+          </div>
+        </div>
+      )
+    }
+
+    // Tier 1 ready, Tier 2 not started or failed — prompt to use Tier 1
+    if (!switchedToLocal) {
+      return (
+        <div style={bannerStyle} role="status" aria-live="polite">
+          <div style={{ display: 'flex', alignItems: 'center', marginBottom: '6px' }}>
+            <span style={tierBadgeStyle(true)}>Tier 1</span>
+            <span style={{ fontSize: '13px', fontWeight: 600, color: '#4ade80' }}>
+              Basic offline models ready
+            </span>
+          </div>
+          <div style={{ fontSize: '12px', color: '#94a3b8', marginBottom: '10px' }}>
+            Fast STT and translation models are ready. Switch now for instant offline translation, or wait for full quality models.
+          </div>
+          <div style={{ display: 'flex', gap: '8px' }}>
+            <button
+              onClick={handleSwitchToTier1}
+              disabled={disabled}
+              style={{
+                ...buttonBaseStyle,
+                background: '#22c55e',
+                color: '#fff'
+              }}
+            >
+              Switch to basic offline
+            </button>
+            <button
+              onClick={handleDismiss}
+              style={{
+                ...buttonBaseStyle,
+                background: '#334155',
+                color: '#94a3b8'
+              }}
+            >
+              Keep cloud
+            </button>
+          </div>
+        </div>
+      )
+    }
+
+    // Switched to Tier 1 but Tier 2 download hasn't started/failed
+    return null
+  }
+
   // Download failed
   if (status === 'failed') {
     return (
@@ -173,7 +357,7 @@ export function ModelDownloadProgress({
           Model download failed
         </div>
         <div style={{ fontSize: '12px', color: '#94a3b8', marginBottom: '10px' }}>
-          Failed to download {targetLabel}. You can retry or continue with cloud translation.
+          Failed to download offline models. You can retry or continue with cloud translation.
         </div>
         <div style={{ display: 'flex', gap: '8px' }}>
           <button
@@ -202,15 +386,18 @@ export function ModelDownloadProgress({
     )
   }
 
-  // Downloading in progress
-  if (status === 'downloading' || downloading) {
+  // Downloading Tier 1
+  if (status === 'downloading-tier1' || (downloading && !tier1Ready)) {
     return (
       <div style={bannerStyle} role="status" aria-live="polite">
-        <div style={{ fontSize: '13px', fontWeight: 600, color: '#60a5fa', marginBottom: '4px' }}>
-          Downloading offline model...
+        <div style={{ display: 'flex', alignItems: 'center', marginBottom: '4px' }}>
+          <span style={tierBadgeStyle(false)}>Tier 1</span>
+          <span style={{ fontSize: '13px', fontWeight: 600, color: '#60a5fa' }}>
+            Downloading fast-start models...
+          </span>
         </div>
         <div style={{ fontSize: '12px', color: '#94a3b8' }}>
-          {targetLabel} (~{targetSizeMB}MB) — translation works via cloud while downloading
+          Small models (~371MB) for instant offline translation. Cloud translation works while downloading.
         </div>
         <div style={progressBarContainerStyle}>
           <div
@@ -241,7 +428,8 @@ export function ModelDownloadProgress({
         Offline translation available
       </div>
       <div style={{ fontSize: '12px', color: '#94a3b8', marginBottom: '10px' }}>
-        Download {targetLabel} (~{targetSizeMB}MB) for faster, private offline translation.
+        Download fast-start models (~371MB) for instant offline translation.
+        Full quality models download automatically in background.
         Cloud translation continues to work while downloading.
       </div>
       <div style={{ display: 'flex', gap: '8px', alignItems: 'center' }}>


### PR DESCRIPTION
## Summary

Implements a two-tier progressive model loading system so first-launch users can start translating within 2-3 minutes instead of waiting 10+ minutes for full model downloads.

**Tier 1 (~371MB, parallel download):**
- Whisper Base (142MB) — fast STT
- LFM2-350M Q4_K_M (229MB) — ultra-fast JA↔EN translation

**Tier 2 (~1.7GB, sequential background download after Tier 1):**
- Whisper Kotoba v2.0 (540MB) — JA-optimized STT
- HY-MT1.5-1.8B Q4_K_M (1.1GB) — quality translation

### Changes
- Rewrote `onboarding-downloader.ts` with a model tier system: Tier 1 downloads in parallel for speed, Tier 2 downloads sequentially in background to avoid bandwidth contention with active translation
- Added `onboarding-upgrade-to-tier2` IPC handler for seamless quality upgrade when Tier 2 completes
- Updated `ModelDownloadProgress.tsx` with tier-aware UI: shows tier badges, per-tier progress bars, and prompts for upgrade when Tier 2 is ready
- Added `activeModelTier` to store for tracking current quality level
- Modified app startup to resume Tier 2 download if Tier 1 was already completed in a previous session
- Tier 2 failure does not block Tier 1 usage — basic mode remains functional

Closes #694

## Test plan
- [ ] Fresh install: verify Tier 1 download starts automatically after 5s delay
- [ ] Verify Tier 1 models (Whisper Base + LFM2) download in parallel
- [ ] After Tier 1 completes, verify "Use basic offline now" button works and pipeline starts with Whisper Base + LFM2
- [ ] While translating with Tier 1, verify Tier 2 downloads in background without interrupting translation
- [ ] When Tier 2 completes, verify "Upgrade to full quality" notification appears
- [ ] Verify upgrading to Tier 2 switches to Kotoba Whisper + HY-MT1.5 without pipeline crash
- [ ] Kill app during Tier 2 download, restart — verify Tier 1 still works and Tier 2 resumes
- [ ] Verify first-launch-to-first-translation time < 3 min on 50Mbps connection (~371MB / 50Mbps ≈ 1 min)
- [ ] Verify "Dismiss" / "Keep cloud" buttons correctly end onboarding flow