### PR TITLE
Trim UI engine list to 5 options + migrate legacy translationEngine (#702)

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -26,6 +26,7 @@ import { HybridTranslator } from '../engines/translator/HybridTranslator'
 import { FluidAudioDiarizer } from '../engines/diarization/FluidAudioDiarizer'
 import { discoverPlugins, loadPluginEngine } from '../engines/plugin-loader'
 import { store } from './store'
+import { migrateLegacyTranslationEngine } from './store-migrations'
 import { sanitizeErrorMessage, getErrorHint } from './error-utils'
 import { createMainWindow, createSubtitleWindow, registerDisplayHandlers } from './window-manager'
 import { registerAudioHandlers } from './audio-handlers'
@@ -306,6 +307,12 @@ app.whenReady().then(async () => {
     // Existing users keep their current engine (don't override to 'online')
     log.info('Existing user detected — skipping cloud-first onboarding')
   }
+
+  // #702: Migrate legacy translationEngine IDs trimmed from the UI to 'auto'.
+  migrateLegacyTranslationEngine({
+    get: (key) => store.get(key),
+    set: (key, value) => store.set(key, value)
+  }, log)
 
   await initPipeline()
 

--- a/src/main/store-migrations.test.ts
+++ b/src/main/store-migrations.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect, vi } from 'vitest'
+import { migrateLegacyTranslationEngine, LEGACY_TRANSLATION_ENGINES } from './store-migrations'
+import type { MigratableStore } from './store-migrations'
+
+/** Build an in-memory mock store seeded with a translationEngine value */
+function mockStore(initial: unknown): { store: MigratableStore; getCurrent: () => unknown; setCalls: number } {
+  let value: unknown = initial
+  let setCalls = 0
+  return {
+    store: {
+      get: (_key) => value,
+      set: (_key, next) => {
+        value = next
+        setCalls++
+      }
+    },
+    getCurrent: () => value,
+    get setCalls() { return setCalls }
+  }
+}
+
+describe('migrateLegacyTranslationEngine (#702)', () => {
+  it.each(LEGACY_TRANSLATION_ENGINES)(
+    'rewrites legacy ID "%s" to "auto" and logs the migration',
+    (legacy) => {
+      const fixture = mockStore(legacy)
+      const logger = { info: vi.fn() }
+
+      const migrated = migrateLegacyTranslationEngine(fixture.store, logger)
+
+      expect(migrated).toBe(true)
+      expect(fixture.getCurrent()).toBe('auto')
+      expect(logger.info).toHaveBeenCalledOnce()
+      expect(logger.info).toHaveBeenCalledWith(
+        expect.stringContaining(`from "${legacy}" to "auto"`)
+      )
+    }
+  )
+
+  it('leaves supported engine IDs untouched', () => {
+    for (const supported of ['auto', 'offline-hymt15', 'offline-hunyuan-mt', 'offline-apple', 'rotation', 'online']) {
+      const fixture = mockStore(supported)
+      const migrated = migrateLegacyTranslationEngine(fixture.store)
+      expect(migrated).toBe(false)
+      expect(fixture.getCurrent()).toBe(supported)
+    }
+  })
+
+  it('does nothing when the stored value is missing or not a string', () => {
+    for (const empty of [undefined, null, 0, false, {}]) {
+      const fixture = mockStore(empty)
+      const migrated = migrateLegacyTranslationEngine(fixture.store)
+      expect(migrated).toBe(false)
+      expect(fixture.getCurrent()).toBe(empty)
+    }
+  })
+
+  it('does not call store.set when no migration is needed', () => {
+    const fixture = mockStore('offline-hymt15')
+    migrateLegacyTranslationEngine(fixture.store)
+    expect(fixture.setCalls).toBe(0)
+  })
+
+  it('works without a logger', () => {
+    const fixture = mockStore('offline-opus')
+    expect(() => migrateLegacyTranslationEngine(fixture.store)).not.toThrow()
+    expect(fixture.getCurrent()).toBe('auto')
+  })
+})

--- a/src/main/store-migrations.ts
+++ b/src/main/store-migrations.ts
@@ -1,0 +1,44 @@
+/**
+ * Persisted-store migrations applied at app startup.
+ *
+ * Migrations operate on a minimal `Store` shape so they remain unit-testable
+ * without booting electron-store or Electron itself.
+ */
+
+/** Subset of the electron-store API used by migrations */
+export interface MigratableStore {
+  get(key: 'translationEngine'): unknown
+  set(key: 'translationEngine', value: string): void
+}
+
+/** Minimal logger interface compatible with src/main/logger.ts */
+export interface MigrationLogger {
+  info: (message: string) => void
+}
+
+/**
+ * Legacy `translationEngine` IDs trimmed from the UI in #702.
+ * Mirrors LEGACY_TRANSLATION_ENGINES in src/renderer/components/settings/shared.ts.
+ */
+export const LEGACY_TRANSLATION_ENGINES: readonly string[] = [
+  'offline-lfm2',
+  'offline-plamo',
+  'offline-hybrid',
+  'offline-opus'
+] as const
+
+/**
+ * If the persisted `translationEngine` value is one of the removed legacy IDs,
+ * rewrite it to `'auto'` so the renderer never has to render an option that
+ * no longer exists in the UI.
+ *
+ * Returns true when a migration was applied, false otherwise.
+ */
+export function migrateLegacyTranslationEngine(store: MigratableStore, logger?: MigrationLogger): boolean {
+  const current = store.get('translationEngine')
+  if (typeof current !== 'string') return false
+  if (!LEGACY_TRANSLATION_ENGINES.includes(current)) return false
+  logger?.info(`Migrating translationEngine from "${current}" to "auto"`)
+  store.set('translationEngine', 'auto')
+  return true
+}

--- a/src/main/store.ts
+++ b/src/main/store.ts
@@ -146,7 +146,7 @@ export const store = new Store<AppSettings>({
   encryptionKey: 'live-translate-v1',
   defaults: {
     hasCompletedSetup: false,
-    translationEngine: 'online',
+    translationEngine: 'auto',
     googleApiKey: '',
     microsoftApiKey: '',
     microsoftRegion: '',

--- a/src/renderer/components/settings/TranslatorSettings.tsx
+++ b/src/renderer/components/settings/TranslatorSettings.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { GlossarySettings } from './GlossarySettings'
 import { Section } from './Section'
-import { API_ENGINE_MODES, LLM_ENGINE_MODES, disclosureArrowStyle, disclosureToggleStyle, inputStyle, radioLabelStyle, selectStyle } from './shared'
+import { LLM_ENGINE_MODES, disclosureArrowStyle, disclosureToggleStyle, inputStyle, radioLabelStyle, selectStyle } from './shared'
 import type { EngineMode } from './shared'
 
 interface TranslatorSettingsProps {
@@ -91,16 +91,28 @@ export function TranslatorSettings({
   onOrgGlossaryTermsChange
 }: TranslatorSettingsProps): React.JSX.Element {
   const showLlmOptions = LLM_ENGINE_MODES.includes(engineMode)
-  const isApiEngine = API_ENGINE_MODES.includes(engineMode)
+
+  // 'rotation' (API auto) requires at least one API key — disabled when none configured
+  const hasAnyApiKey = !!(apiKey || deeplApiKey || geminiApiKey || (microsoftApiKey && microsoftRegion))
 
   return (
     <>
-      <Section label="Translation Engine" helpText="HY-MT 1.5 is recommended for most users. Quality engines need more memory but produce better translations.">
+      <Section label="Translation Engine" helpText="Auto picks the best engine for your setup. HY-MT 1.5 is the recommended offline default.">
         <fieldset style={{ border: 'none', margin: 0, padding: 0 }}>
         <legend style={{ position: 'absolute', width: '1px', height: '1px', overflow: 'hidden', clip: 'rect(0,0,0,0)' }}>Translation Engine</legend>
-        <div style={{ fontSize: '11px', fontWeight: 600, color: '#94a3b8', textTransform: 'uppercase', letterSpacing: '0.05em', marginBottom: '4px' }}>
-          Offline
-        </div>
+        <label style={radioLabelStyle}>
+          <input
+            type="radio"
+            name="engine"
+            checked={engineMode === 'auto'}
+            onChange={() => onEngineModeChange('auto')}
+            disabled={disabled}
+          />
+          <div>
+            <div style={{ fontWeight: 500 }}>Auto (Recommended)</div>
+            <div style={{ fontSize: '12px', color: '#94a3b8' }}>Picks the best engine for your hardware and API keys</div>
+          </div>
+        </label>
         <label style={radioLabelStyle}>
           <input
             type="radio"
@@ -110,37 +122,8 @@ export function TranslatorSettings({
             disabled={disabled}
           />
           <div>
-            <div style={{ fontWeight: 500 }}>HY-MT 1.5 (Recommended)</div>
+            <div style={{ fontWeight: 500 }}>HY-MT 1.5 (Offline default)</div>
             <div style={{ fontSize: '12px', color: '#94a3b8' }}>Fast + high quality, 36 languages, ~1GB — surpasses Google/DeepL</div>
-          </div>
-        </label>
-        <label style={radioLabelStyle}>
-          <input
-            type="radio"
-            name="engine"
-            checked={engineMode === 'offline-lfm2'}
-            onChange={() => onEngineModeChange('offline-lfm2')}
-            disabled={disabled}
-          />
-          <div>
-            <div style={{ fontWeight: 500 }}>LFM2 (Ultra-fast, JA↔EN)</div>
-            <div style={{ fontSize: '12px', color: '#94a3b8' }}>350M params, ~230MB — GPT-4o-class quality at minimal cost</div>
-          </div>
-        </label>
-        <div style={{ fontSize: '10px', fontWeight: 600, color: '#64748b', textTransform: 'uppercase', letterSpacing: '0.05em', marginTop: '8px', marginBottom: '4px', paddingTop: '8px', borderTop: '1px solid #1e293b' }}>
-          Quality
-        </div>
-        <label style={radioLabelStyle}>
-          <input
-            type="radio"
-            name="engine"
-            checked={engineMode === 'offline-plamo'}
-            onChange={() => onEngineModeChange('offline-plamo')}
-            disabled={disabled}
-          />
-          <div>
-            <div style={{ fontWeight: 500 }}>PLaMo-2 10B (Quality, JA↔EN)</div>
-            <div style={{ fontSize: '12px', color: '#94a3b8' }}>Japan Gov "Gennai" adopted, style-aware, ~5.5GB</div>
           </div>
         </label>
         <label style={radioLabelStyle}>
@@ -152,13 +135,10 @@ export function TranslatorSettings({
             disabled={disabled}
           />
           <div>
-            <div style={{ fontWeight: 500 }}>Hunyuan-MT 7B (High Quality)</div>
+            <div style={{ fontWeight: 500 }}>Hunyuan-MT 7B (High Quality, GPU recommended)</div>
             <div style={{ fontSize: '12px', color: '#94a3b8' }}>WMT25 winner, 33 languages, ~4GB — slower but higher quality</div>
           </div>
         </label>
-        <div style={{ fontSize: '10px', fontWeight: 600, color: '#64748b', textTransform: 'uppercase', letterSpacing: '0.05em', marginTop: '8px', marginBottom: '4px', paddingTop: '8px', borderTop: '1px solid #1e293b' }}>
-          Other
-        </div>
         {platform === 'darwin' && (
           <label style={radioLabelStyle}>
             <input
@@ -169,39 +149,30 @@ export function TranslatorSettings({
               disabled={disabled}
             />
             <div>
-              <div style={{ fontWeight: 500 }}>Apple Translate (Built-in)</div>
-              <div style={{ fontSize: '12px', color: '#94a3b8' }}>macOS 15+, zero config, on-device, ANE-optimized — no model download</div>
+              <div style={{ fontWeight: 500 }}>Apple Translate (Built-in, macOS 15+)</div>
+              <div style={{ fontSize: '12px', color: '#94a3b8' }}>Zero config, on-device, ANE-optimized — no model download</div>
             </div>
           </label>
         )}
-        <label style={radioLabelStyle}>
+        <label style={{ ...radioLabelStyle, opacity: hasAnyApiKey ? 1 : 0.5 }}>
           <input
             type="radio"
             name="engine"
-            checked={engineMode === 'offline-hybrid'}
-            onChange={() => onEngineModeChange('offline-hybrid')}
-            disabled={disabled}
+            checked={engineMode === 'rotation'}
+            onChange={() => onEngineModeChange('rotation')}
+            disabled={disabled || !hasAnyApiKey}
           />
           <div>
-            <div style={{ fontWeight: 500 }}>Hybrid (OPUS-MT + TranslateGemma)</div>
-            <div style={{ fontSize: '12px', color: '#94a3b8' }}>Instant draft + LLM refinement — best offline quality</div>
-          </div>
-        </label>
-        <label style={radioLabelStyle}>
-          <input
-            type="radio"
-            name="engine"
-            checked={engineMode === 'offline-opus'}
-            onChange={() => onEngineModeChange('offline-opus')}
-            disabled={disabled}
-          />
-          <div>
-            <div style={{ fontWeight: 500 }}>OPUS-MT (Legacy Fallback)</div>
-            <div style={{ fontSize: '12px', color: '#94a3b8' }}>~200ms latency, ONNX accelerated — used as fallback while LLM models download</div>
+            <div style={{ fontWeight: 500 }}>Online API (Auto Rotation)</div>
+            <div style={{ fontSize: '12px', color: '#94a3b8' }}>
+              {hasAnyApiKey
+                ? 'Azure → Google → DeepL → Gemini — up to 4M+ chars/month free'
+                : 'Configure an API key below to enable cloud translation'}
+            </div>
           </div>
         </label>
 
-        {/* LLM sub-options for Hunyuan-MT and Hybrid */}
+        {/* LLM sub-options for HY-MT 1.5 and Hunyuan-MT 7B */}
         {showLlmOptions && (
           <>
             {gpuInfo && !gpuInfo.hasGpu && (
@@ -345,7 +316,7 @@ export function TranslatorSettings({
           </div>
         )}
 
-        {/* API Translation — collapsed by default */}
+        {/* API Keys — collapsed by default. Enables 'Online API' option above. */}
         <div style={{ marginTop: '12px' }}>
           <button
             onClick={() => onShowApiOptionsChange(!showApiOptions)}
@@ -355,115 +326,56 @@ export function TranslatorSettings({
             <span style={disclosureArrowStyle(showApiOptions)}>
               ▶
             </span>
-            API Translation (requires internet)
+            API Keys (optional — enables online translation)
           </button>
 
           {showApiOptions && (
-            <div style={{ marginTop: '4px' }}>
-              <label style={radioLabelStyle}>
-                <input
-                  type="radio"
-                  name="engine"
-                  checked={engineMode === 'rotation'}
-                  onChange={() => onEngineModeChange('rotation')}
-                  disabled={disabled}
-                />
-                <div>
-                  <div style={{ fontWeight: 500 }}>Auto Rotation — up to 4M+ chars/month free</div>
-                  <div style={{ fontSize: '12px', color: '#94a3b8' }}>Azure → Google → DeepL → Gemini</div>
-                </div>
-              </label>
-              <label style={radioLabelStyle}>
-                <input
-                  type="radio"
-                  name="engine"
-                  checked={engineMode === 'online'}
-                  onChange={() => onEngineModeChange('online')}
-                  disabled={disabled}
-                />
-                <div style={{ fontWeight: 500 }}>Google Translation</div>
-              </label>
-              <label style={radioLabelStyle}>
-                <input
-                  type="radio"
-                  name="engine"
-                  checked={engineMode === 'online-deepl'}
-                  onChange={() => onEngineModeChange('online-deepl')}
-                  disabled={disabled}
-                />
-                <div style={{ fontWeight: 500 }}>DeepL</div>
-              </label>
-              <label style={radioLabelStyle}>
-                <input
-                  type="radio"
-                  name="engine"
-                  checked={engineMode === 'online-gemini'}
-                  onChange={() => onEngineModeChange('online-gemini')}
-                  disabled={disabled}
-                />
-                <div style={{ fontWeight: 500 }}>Gemini 2.5 Flash</div>
-              </label>
-
-              {/* API Keys */}
-              {isApiEngine && (
-                <div style={{ marginTop: '8px', display: 'flex', flexDirection: 'column', gap: '6px' }}>
-                  {(engineMode === 'rotation' || engineMode === 'online') && (
-                    <input
-                      type="password"
-                      value={apiKey}
-                      onChange={(e) => onApiKeyChange(e.target.value)}
-                      placeholder="Google Cloud Translation key"
-                      aria-label="Google Cloud Translation API key"
-                      style={inputStyle}
-                      disabled={disabled}
-                    />
-                  )}
-                  {(engineMode === 'rotation' || engineMode === 'online-deepl') && (
-                    <input
-                      type="password"
-                      value={deeplApiKey}
-                      onChange={(e) => onDeeplApiKeyChange(e.target.value)}
-                      placeholder="DeepL API key"
-                      aria-label="DeepL API key"
-                      style={inputStyle}
-                      disabled={disabled}
-                    />
-                  )}
-                  {(engineMode === 'rotation' || engineMode === 'online-gemini') && (
-                    <input
-                      type="password"
-                      value={geminiApiKey}
-                      onChange={(e) => onGeminiApiKeyChange(e.target.value)}
-                      placeholder="Gemini API key"
-                      aria-label="Gemini API key"
-                      style={inputStyle}
-                      disabled={disabled}
-                    />
-                  )}
-                  {engineMode === 'rotation' && (
-                    <>
-                      <input
-                        type="password"
-                        value={microsoftApiKey}
-                        onChange={(e) => onMicrosoftApiKeyChange(e.target.value)}
-                        placeholder="Azure Microsoft Translator key"
-                        aria-label="Azure Microsoft Translator key"
-                        style={inputStyle}
-                        disabled={disabled}
-                      />
-                      <input
-                        type="text"
-                        value={microsoftRegion}
-                        onChange={(e) => onMicrosoftRegionChange(e.target.value)}
-                        placeholder="Azure region (e.g. eastus)"
-                        aria-label="Azure region"
-                        style={inputStyle}
-                        disabled={disabled}
-                      />
-                    </>
-                  )}
-                </div>
-              )}
+            <div style={{ marginTop: '4px', display: 'flex', flexDirection: 'column', gap: '6px' }}>
+              <input
+                type="password"
+                value={apiKey}
+                onChange={(e) => onApiKeyChange(e.target.value)}
+                placeholder="Google Cloud Translation key"
+                aria-label="Google Cloud Translation API key"
+                style={inputStyle}
+                disabled={disabled}
+              />
+              <input
+                type="password"
+                value={deeplApiKey}
+                onChange={(e) => onDeeplApiKeyChange(e.target.value)}
+                placeholder="DeepL API key"
+                aria-label="DeepL API key"
+                style={inputStyle}
+                disabled={disabled}
+              />
+              <input
+                type="password"
+                value={geminiApiKey}
+                onChange={(e) => onGeminiApiKeyChange(e.target.value)}
+                placeholder="Gemini API key"
+                aria-label="Gemini API key"
+                style={inputStyle}
+                disabled={disabled}
+              />
+              <input
+                type="password"
+                value={microsoftApiKey}
+                onChange={(e) => onMicrosoftApiKeyChange(e.target.value)}
+                placeholder="Azure Microsoft Translator key"
+                aria-label="Azure Microsoft Translator key"
+                style={inputStyle}
+                disabled={disabled}
+              />
+              <input
+                type="text"
+                value={microsoftRegion}
+                onChange={(e) => onMicrosoftRegionChange(e.target.value)}
+                placeholder="Azure region (e.g. eastus)"
+                aria-label="Azure region"
+                style={inputStyle}
+                disabled={disabled}
+              />
             </div>
           )}
         </div>

--- a/src/renderer/components/settings/shared.test.ts
+++ b/src/renderer/components/settings/shared.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect } from 'vitest'
+import { buildEngineConfig, resolveEngineMode, getEngineDisplayName, LEGACY_TRANSLATION_ENGINES, LLM_ENGINE_MODES, API_ENGINE_MODES } from './shared'
+import type { EngineMode, SttEngineType } from './shared'
+
+const STT: SttEngineType = 'mlx-whisper'
+const NO_KEYS = { apiKey: '', deeplApiKey: '', geminiApiKey: '', microsoftApiKey: '', microsoftRegion: '' }
+const ALL_KEYS = { apiKey: 'g', deeplApiKey: 'd', geminiApiKey: 'gem', microsoftApiKey: 'm', microsoftRegion: 'eastus' }
+
+describe('EngineMode catalog (#702)', () => {
+  it('LEGACY_TRANSLATION_ENGINES lists the four IDs removed from the UI', () => {
+    expect(LEGACY_TRANSLATION_ENGINES).toEqual(
+      expect.arrayContaining(['offline-lfm2', 'offline-plamo', 'offline-hybrid', 'offline-opus'])
+    )
+    expect(LEGACY_TRANSLATION_ENGINES).toHaveLength(4)
+  })
+
+  it('LLM_ENGINE_MODES only retains the two supported LLM engines', () => {
+    expect(LLM_ENGINE_MODES).toEqual(['offline-hymt15', 'offline-hunyuan-mt'])
+  })
+
+  it('API_ENGINE_MODES still lists every online provider mode', () => {
+    expect(API_ENGINE_MODES).toEqual(['rotation', 'online', 'online-deepl', 'online-gemini'])
+  })
+
+  it('getEngineDisplayName returns the raw mode string for unknown legacy IDs', () => {
+    // Legacy IDs are no longer in the union, so callers casting through `as EngineMode`
+    // should fall through the switch default and receive the raw string.
+    for (const legacy of LEGACY_TRANSLATION_ENGINES) {
+      expect(getEngineDisplayName(legacy as EngineMode)).toBe(legacy)
+    }
+  })
+})
+
+describe('buildEngineConfig (#702)', () => {
+  it('returns HY-MT 1.5 config for the default offline mode', () => {
+    expect(buildEngineConfig('offline-hymt15', STT, NO_KEYS)).toEqual({
+      mode: 'cascade',
+      sttEngineId: STT,
+      translatorEngineId: 'hunyuan-mt-15'
+    })
+  })
+
+  it('returns Hunyuan-MT 7B config for offline-hunyuan-mt', () => {
+    expect(buildEngineConfig('offline-hunyuan-mt', STT, NO_KEYS)).toEqual({
+      mode: 'cascade',
+      sttEngineId: STT,
+      translatorEngineId: 'hunyuan-mt'
+    })
+  })
+
+  it('returns Apple Translate config for offline-apple', () => {
+    expect(buildEngineConfig('offline-apple', STT, NO_KEYS)).toEqual({
+      mode: 'cascade',
+      sttEngineId: STT,
+      translatorEngineId: 'apple-translate'
+    })
+  })
+
+  it('returns rotation controller with all configured API keys for rotation mode', () => {
+    expect(buildEngineConfig('rotation', STT, ALL_KEYS)).toEqual({
+      mode: 'cascade',
+      sttEngineId: STT,
+      translatorEngineId: 'rotation-controller',
+      apiKey: 'g',
+      deeplApiKey: 'd',
+      geminiApiKey: 'gem',
+      microsoftApiKey: 'm',
+      microsoftRegion: 'eastus'
+    })
+  })
+
+  it('omits absent API keys from the rotation config', () => {
+    const partial = { apiKey: 'g', deeplApiKey: '', geminiApiKey: '', microsoftApiKey: '', microsoftRegion: '' }
+    expect(buildEngineConfig('rotation', STT, partial)).toEqual({
+      mode: 'cascade',
+      sttEngineId: STT,
+      translatorEngineId: 'rotation-controller',
+      apiKey: 'g'
+    })
+  })
+
+  it.each(['offline-lfm2', 'offline-plamo', 'offline-hybrid', 'offline-opus'])(
+    'falls back to HY-MT 1.5 for removed legacy engine "%s"',
+    (legacy) => {
+      // Callers may still hold a stale EngineMode string before migration runs;
+      // buildEngineConfig must safely fall through to the default case.
+      const cfg = buildEngineConfig(legacy as EngineMode, STT, NO_KEYS)
+      expect(cfg).toEqual({
+        mode: 'cascade',
+        sttEngineId: STT,
+        translatorEngineId: 'hunyuan-mt-15'
+      })
+    }
+  )
+})
+
+describe('resolveEngineMode (#702)', () => {
+  it('resolves auto → rotation when at least one API key is configured', () => {
+    expect(resolveEngineMode('auto', ALL_KEYS, { hasGpu: false })).toBe('rotation')
+  })
+
+  it('resolves auto → offline-hunyuan-mt when GPU is present and no API keys', () => {
+    expect(resolveEngineMode('auto', NO_KEYS, { hasGpu: true })).toBe('offline-hunyuan-mt')
+  })
+
+  it('resolves auto → offline-hymt15 when no GPU and no API keys', () => {
+    expect(resolveEngineMode('auto', NO_KEYS, { hasGpu: false })).toBe('offline-hymt15')
+  })
+
+  it('returns the mode unchanged when not auto', () => {
+    expect(resolveEngineMode('offline-hymt15', NO_KEYS, null)).toBe('offline-hymt15')
+    expect(resolveEngineMode('offline-apple', NO_KEYS, null)).toBe('offline-apple')
+  })
+
+  it('treats Azure as a valid key only when both key and region are present', () => {
+    const onlyKey = { ...NO_KEYS, microsoftApiKey: 'm' }
+    expect(resolveEngineMode('auto', onlyKey, { hasGpu: false })).toBe('offline-hymt15')
+    const withRegion = { ...NO_KEYS, microsoftApiKey: 'm', microsoftRegion: 'eastus' }
+    expect(resolveEngineMode('auto', withRegion, { hasGpu: false })).toBe('rotation')
+  })
+})

--- a/src/renderer/components/settings/shared.ts
+++ b/src/renderer/components/settings/shared.ts
@@ -26,7 +26,16 @@ export const LANGUAGE_LABELS: Record<Language, string> = {
 
 export const ALL_LANGUAGES = Object.keys(LANGUAGE_LABELS) as Language[]
 
-export type EngineMode = 'auto' | 'rotation' | 'online' | 'online-deepl' | 'online-gemini' | 'offline-opus' | 'offline-hymt15' | 'offline-hunyuan-mt' | 'offline-hybrid' | 'offline-lfm2' | 'offline-plamo' | 'offline-apple'
+export type EngineMode = 'auto' | 'rotation' | 'online' | 'online-deepl' | 'online-gemini' | 'offline-hymt15' | 'offline-hunyuan-mt' | 'offline-apple'
+
+/** Legacy engine mode IDs removed from the UI in #702.
+ *  Persisted store values matching these IDs are migrated to 'auto' on startup. */
+export const LEGACY_TRANSLATION_ENGINES: readonly string[] = [
+  'offline-lfm2',
+  'offline-plamo',
+  'offline-hybrid',
+  'offline-opus'
+] as const
 
 export type SttEngineType = 'whisper-local' | 'mlx-whisper' | 'kotoba-whisper' | 'qwen3-asr' | 'sensevoice-sherpa' | 'apple-speech-transcriber'
 export type WhisperVariantType = 'kotoba-v2.0' | 'large-v3-turbo' | 'distil-large-v3' | 'base' | 'small'
@@ -148,18 +157,14 @@ export const disclosureArrowStyle = (isOpen: boolean): React.CSSProperties => ({
 export const API_ENGINE_MODES: EngineMode[] = ['rotation', 'online', 'online-deepl', 'online-gemini']
 
 /** LLM-based engine modes that support KV cache / SimulMT options */
-export const LLM_ENGINE_MODES: EngineMode[] = ['offline-hymt15', 'offline-hunyuan-mt', 'offline-hybrid', 'offline-lfm2', 'offline-plamo']
+export const LLM_ENGINE_MODES: EngineMode[] = ['offline-hymt15', 'offline-hunyuan-mt']
 
 /** Display name for each engine mode */
 export function getEngineDisplayName(mode: EngineMode): string {
   switch (mode) {
     case 'offline-apple': return 'Apple Translate (Built-in)'
-    case 'offline-opus': return 'OPUS-MT (Legacy Fallback)'
     case 'offline-hymt15': return 'HY-MT 1.5 (Recommended)'
     case 'offline-hunyuan-mt': return 'Hunyuan-MT 7B (High Quality)'
-    case 'offline-lfm2': return 'LFM2 (Ultra-fast)'
-    case 'offline-plamo': return 'PLaMo-2 10B (Quality)'
-    case 'offline-hybrid': return 'Hybrid (OPUS-MT + TranslateGemma)'
     case 'rotation': return 'API Auto Rotation'
     case 'online': return 'Google Translation'
     case 'online-deepl': return 'DeepL'
@@ -228,20 +233,13 @@ export function buildEngineConfig(
       return { ...base, translatorEngineId: 'deepl-translate', deeplApiKey: apiKeys.deeplApiKey }
     case 'online-gemini':
       return { ...base, translatorEngineId: 'gemini-translate', geminiApiKey: apiKeys.geminiApiKey }
-    case 'offline-lfm2':
-      return { ...base, translatorEngineId: 'lfm2' }
-    case 'offline-plamo':
-      return { ...base, translatorEngineId: 'plamo' }
-    case 'offline-hymt15':
-      return { ...base, translatorEngineId: 'hunyuan-mt-15' }
     case 'offline-hunyuan-mt':
       return { ...base, translatorEngineId: 'hunyuan-mt' }
-    case 'offline-hybrid':
-      return { ...base, translatorEngineId: 'hybrid' }
     case 'offline-apple':
       return { ...base, translatorEngineId: 'apple-translate' }
-    case 'offline-opus':
+    case 'offline-hymt15':
     default:
-      return { ...base, translatorEngineId: 'opus-mt' }
+      // 'offline-hymt15' is the fast offline default; any unknown legacy ID falls back here.
+      return { ...base, translatorEngineId: 'hunyuan-mt-15' }
   }
 }

--- a/src/renderer/hooks/useEngineSettings.ts
+++ b/src/renderer/hooks/useEngineSettings.ts
@@ -50,7 +50,7 @@ export interface EngineSettingsInit {
 }
 
 export function useEngineSettings(init: EngineSettingsInit): EngineSettingsState {
-  const [engineMode, setEngineMode] = useState<EngineMode>('online')
+  const [engineMode, setEngineMode] = useState<EngineMode>('auto')
   const [gpuInfo, setGpuInfo] = useState<{ hasGpu: boolean; gpuNames: string[] } | null>(null)
   const [apiKey, setApiKey] = useState('')
   const [deeplApiKey, setDeeplApiKey] = useState('')
@@ -71,7 +71,13 @@ export function useEngineSettings(init: EngineSettingsInit): EngineSettingsState
   // Load engine-related settings on mount
   useEffect(() => {
     window.api.getSettings().then((s) => {
-      if (s.translationEngine) setEngineMode(str(s.translationEngine, 'offline-hymt15') as EngineMode)
+      // #702: Coerce legacy/unknown engine IDs to 'auto' so the UI never displays a removed option.
+      // The main process also migrates the persisted value on startup.
+      if (s.translationEngine) {
+        const raw = str(s.translationEngine, 'auto')
+        const valid: EngineMode[] = ['auto', 'rotation', 'online', 'online-deepl', 'online-gemini', 'offline-hymt15', 'offline-hunyuan-mt', 'offline-apple']
+        setEngineMode((valid.includes(raw as EngineMode) ? raw : 'auto') as EngineMode)
+      }
       if (s.googleApiKey) setApiKey(str(s.googleApiKey, ''))
       if (s.deeplApiKey) setDeeplApiKey(str(s.deeplApiKey, ''))
       if (s.geminiApiKey) setGeminiApiKey(str(s.geminiApiKey, ''))


### PR DESCRIPTION
## Description

Trim the Translator engine select down to the 5 supported options (auto, HY-MT 1.5, Hunyuan-MT 7B, Apple Translate, Online API) and add a startup migration that rewrites any previously persisted legacy ID to ``auto``.

- ``EngineMode`` (``src/renderer/components/settings/shared.ts``) drops ``offline-lfm2`` / ``offline-plamo`` / ``offline-hybrid`` / ``offline-opus``. A new ``LEGACY_TRANSLATION_ENGINES`` constant tracks the removed IDs.
- ``buildEngineConfig`` falls back to ``hunyuan-mt-15`` for any unknown (including legacy) mode so stale callers do not crash before migration runs.
- Store default ``translationEngine`` flips from ``'online'`` to ``'auto'`` (``src/main/store.ts``), and ``useEngineSettings.ts`` coerces unrecognised persisted values to ``'auto'`` on load.
- Startup migration extracted to ``src/main/store-migrations.ts`` (``migrateLegacyTranslationEngine``) and wired into ``src/main/index.ts`` after the existing first-run migration.
- ``TranslatorSettings.tsx`` is rebuilt around the 5-option order (auto / HY-MT 1.5 / Hunyuan-MT 7B / Apple Translate / Online Rotation). ``rotation`` is grayed out and disabled until at least one API key is configured. Individual single-provider radios (Google / DeepL / Gemini) are removed from the API disclosure; API key inputs remain in a collapsed ``API Keys`` panel.

## Related Issue

Closes #702

## Tests

- New ``src/renderer/components/settings/shared.test.ts`` — 13 cases covering ``buildEngineConfig`` (including legacy fall-through), ``resolveEngineMode`` auto resolution and Azure key+region pairing, ``getEngineDisplayName`` legacy passthrough, and catalog invariants.
- New ``src/main/store-migrations.test.ts`` — 13 cases covering migration of every legacy ID, no-op for supported IDs, defensive handling of non-string values, and logger optionality.
- Full ``npm test`` summary: 247 passing / 10 pre-existing failures in ``virtual-mic-manager.test.ts`` (PortAudio/naudiodon absent in the dev container — unchanged on ``main``).
- ``npm run typecheck`` clean. ``npm run build`` succeeds. ``npm run lint`` shows only the same 1 error + 3 warnings that exist on ``main``.

## Notes

- ``src/engines/hardware-recommender.ts`` still emits ``offline-opus`` / ``offline-lfm2`` for Quick Start because retiring those engine registrations is explicitly out of scope (Phase 1.5 / ``register削除``). Any legacy value that route writes is converted back to ``auto`` on next startup by the new migration.
- ``ModelDownloadProgress`` (``SettingsPanel.tsx``) and ``onboarding-ipc.ts`` continue to call ``setEngineMode`` / ``store.set('translationEngine', ...)`` with the old onboarding IDs; the renderer coercer + main migration absorb that until the onboarding copy is updated in #708.