### PR TITLE
#703 Inject local fallback into ApiRotationController + classify 429 errors

### DIFF
--- a/src/engines/translator/ApiRotationController.test.ts
+++ b/src/engines/translator/ApiRotationController.test.ts
@@ -90,6 +90,198 @@ describe('ApiRotationController', () => {
     await expect(controller.translate('hello', 'en', 'ja')).rejects.toThrow('All translation providers exhausted')
   })
 
+  describe('#703 fallbackEngine', () => {
+    it('falls back to local engine when all providers are exhausted', async () => {
+      const fallback = createMockEngine('local-fallback', 'local-result')
+      ;(fallback as { isOffline: boolean }).isOffline = true
+      vi.mocked(engine1.translate).mockRejectedValue(new Error('fail-a'))
+      vi.mocked(engine2.translate).mockRejectedValue(new Error('fail-b'))
+
+      const c = new ApiRotationController(
+        [
+          { engine: engine1, monthlyCharLimit: 100 },
+          { engine: engine2, monthlyCharLimit: 200 }
+        ],
+        persistence,
+        undefined,
+        { fallbackEngine: fallback }
+      )
+      await c.initialize()
+
+      const result = await c.translate('hello', 'en', 'ja')
+      expect(result).toBe('local-result')
+      expect(fallback.initialize).toHaveBeenCalledTimes(1)
+      expect(fallback.translate).toHaveBeenCalledWith('hello', 'en', 'ja', undefined)
+    })
+
+    it('lazy-initializes fallback engine only once across multiple exhaustions', async () => {
+      const fallback = createMockEngine('local-fallback', 'local-result')
+      vi.mocked(engine1.translate).mockRejectedValue(new Error('Quota exceeded'))
+      vi.mocked(engine2.translate).mockRejectedValue(new Error('Quota exceeded'))
+
+      const c = new ApiRotationController(
+        [
+          { engine: engine1, monthlyCharLimit: 100 },
+          { engine: engine2, monthlyCharLimit: 200 }
+        ],
+        persistence,
+        undefined,
+        { fallbackEngine: fallback }
+      )
+      await c.initialize()
+
+      await c.translate('hello', 'en', 'ja')
+      await c.translate('world', 'en', 'ja')
+
+      expect(fallback.initialize).toHaveBeenCalledTimes(1)
+      expect(fallback.translate).toHaveBeenCalledTimes(2)
+    })
+
+    it('still throws when no fallbackEngine is configured (backward-compat)', async () => {
+      vi.mocked(engine1.translate).mockRejectedValue(new Error('fail-a'))
+      vi.mocked(engine2.translate).mockRejectedValue(new Error('fail-b'))
+
+      const c = new ApiRotationController(
+        [
+          { engine: engine1, monthlyCharLimit: 100 },
+          { engine: engine2, monthlyCharLimit: 200 }
+        ],
+        persistence
+      )
+      await c.initialize()
+
+      await expect(c.translate('hello', 'en', 'ja')).rejects.toThrow(
+        'All translation providers exhausted'
+      )
+    })
+
+    it('disposes fallbackEngine when initialized', async () => {
+      const fallback = createMockEngine('local-fallback', 'local-result')
+      vi.mocked(engine1.translate).mockRejectedValue(new Error('fail-a'))
+      vi.mocked(engine2.translate).mockRejectedValue(new Error('fail-b'))
+
+      const c = new ApiRotationController(
+        [
+          { engine: engine1, monthlyCharLimit: 100 },
+          { engine: engine2, monthlyCharLimit: 200 }
+        ],
+        persistence,
+        undefined,
+        { fallbackEngine: fallback }
+      )
+      await c.initialize()
+      await c.translate('hello', 'en', 'ja')
+      await c.dispose()
+
+      expect(fallback.dispose).toHaveBeenCalledTimes(1)
+    })
+
+    it('does NOT dispose fallbackEngine if it was never initialized', async () => {
+      const fallback = createMockEngine('local-fallback', 'local-result')
+
+      const c = new ApiRotationController(
+        [
+          { engine: engine1, monthlyCharLimit: 100 },
+          { engine: engine2, monthlyCharLimit: 200 }
+        ],
+        persistence,
+        undefined,
+        { fallbackEngine: fallback }
+      )
+      await c.initialize()
+      await c.translate('hello', 'en', 'ja') // succeeds via engine1
+      await c.dispose()
+
+      expect(fallback.initialize).not.toHaveBeenCalled()
+      expect(fallback.dispose).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('#703 429 classification', () => {
+    it('applies short cooldown on Rate limit (default 60s)', async () => {
+      vi.useFakeTimers()
+      try {
+        vi.mocked(engine1.translate)
+          .mockRejectedValueOnce(new Error('Rate limit - retry after short cooldown'))
+          .mockResolvedValueOnce('result-a')
+        await controller.initialize()
+
+        const result1 = await controller.translate('hello', 'en', 'ja')
+        expect(result1).toBe('result-b') // falls through to engine2
+        expect(engine1.translate).toHaveBeenCalledTimes(1)
+
+        // Within cooldown — engine1 must be skipped
+        const result2 = await controller.translate('world', 'en', 'ja')
+        expect(result2).toBe('result-b')
+        expect(engine1.translate).toHaveBeenCalledTimes(1)
+
+        // After cooldown — engine1 retried
+        vi.advanceTimersByTime(61_000)
+        const result3 = await controller.translate('again', 'en', 'ja')
+        expect(result3).toBe('result-a')
+        expect(engine1.translate).toHaveBeenCalledTimes(2)
+      } finally {
+        vi.useRealTimers()
+      }
+    })
+
+    it('honors shortFailureCooldownMs override', async () => {
+      vi.useFakeTimers()
+      try {
+        const c = new ApiRotationController(
+          [
+            { engine: engine1, monthlyCharLimit: 100 },
+            { engine: engine2, monthlyCharLimit: 200 }
+          ],
+          persistence,
+          undefined,
+          { shortFailureCooldownMs: 5_000 }
+        )
+        vi.mocked(engine1.translate)
+          .mockRejectedValueOnce(new Error('Rate limit'))
+          .mockResolvedValueOnce('result-a')
+        await c.initialize()
+
+        await c.translate('hello', 'en', 'ja')
+        vi.advanceTimersByTime(4_000)
+        await c.translate('world', 'en', 'ja') // still cooled
+        expect(engine1.translate).toHaveBeenCalledTimes(1)
+
+        vi.advanceTimersByTime(2_000)
+        await c.translate('again', 'en', 'ja') // 6s elapsed → retried
+        expect(engine1.translate).toHaveBeenCalledTimes(2)
+      } finally {
+        vi.useRealTimers()
+      }
+    })
+
+    it('marks provider exhausted on Quota exceeded', async () => {
+      vi.mocked(engine1.translate).mockRejectedValueOnce(
+        new Error('Quota exceeded - monthly limit reached')
+      )
+      await controller.initialize()
+
+      await controller.translate('hello', 'en', 'ja') // falls through to engine2
+
+      const summary = controller.getQuotaSummary()
+      const a = summary.find((s) => s.id === 'provider-a')!
+      expect(a.exhausted).toBe(true)
+      expect(a.used).toBe(100)
+    })
+
+    it('rate-limit errors do NOT count toward MAX_CONSECUTIVE_FAILURES budget', async () => {
+      // 5 rate-limit failures should not trigger the 5-minute disable
+      vi.mocked(engine1.translate).mockRejectedValue(new Error('Rate limit'))
+      await controller.initialize()
+
+      for (let i = 0; i < 5; i++) {
+        await controller.translate(`text-${i}`, 'en', 'ja') // falls through
+      }
+      // engine1 was called once (subsequent attempts skipped by rate-limit cooldown)
+      expect(engine1.translate).toHaveBeenCalledTimes(1)
+    })
+  })
+
   it('tracks character usage', async () => {
     await controller.initialize()
     await controller.translate('hello', 'en', 'ja') // 5 chars

--- a/src/engines/translator/ApiRotationController.ts
+++ b/src/engines/translator/ApiRotationController.ts
@@ -22,6 +22,20 @@ export interface QuotaPersistence {
   save(quota: QuotaStore): void
 }
 
+/** Optional rotation behavior knobs (#703) */
+export interface ApiRotationOptions {
+  /**
+   * Engine used when every cloud provider has been exhausted or is on
+   * cooldown. When omitted, exhaustion throws (backward-compatible).
+   */
+  fallbackEngine?: TranslatorEngine
+  /**
+   * Cooldown applied to a provider that emitted a short-window rate-limit
+   * (429 Rate limit). Defaults to 60_000 ms.
+   */
+  shortFailureCooldownMs?: number
+}
+
 /**
  * Wraps multiple TranslatorEngine instances with automatic fallback.
  * Tracks character usage per provider per month and skips exhausted providers.
@@ -37,20 +51,29 @@ export class ApiRotationController implements TranslatorEngine {
   private onStatusUpdate?: (message: string) => void
   private failureCount = new Map<string, number>() // #40: track transient failures
   private failureDisabledAt = new Map<string, number>() // #94: cooldown tracking
+  private rateLimitedUntil = new Map<string, number>() // #703: short cooldown for 429 rate-limit
   private static readonly MAX_CONSECUTIVE_FAILURES = 5
   private static readonly FAILURE_COOLDOWN_MS = 5 * 60_000 // 5 minutes
+  private static readonly DEFAULT_SHORT_FAILURE_COOLDOWN_MS = 60_000 // #703: 60s default
   private initialized = false
   private initializedProviders = new Set<string>()
+  private fallbackEngine?: TranslatorEngine
+  private fallbackInitialized = false
+  private shortFailureCooldownMs: number
 
   constructor(
     providers: ProviderConfig[],
     persistence: QuotaPersistence,
-    onStatusUpdate?: (message: string) => void
+    onStatusUpdate?: (message: string) => void,
+    options?: ApiRotationOptions
   ) {
     this.providers = providers
     this.persistence = persistence
     this.onStatusUpdate = onStatusUpdate
     this.quota = persistence.load() || {}
+    this.fallbackEngine = options?.fallbackEngine
+    this.shortFailureCooldownMs =
+      options?.shortFailureCooldownMs ?? ApiRotationController.DEFAULT_SHORT_FAILURE_COOLDOWN_MS
   }
 
   async initialize(): Promise<void> {
@@ -113,6 +136,15 @@ export class ApiRotationController implements TranslatorEngine {
         log.info(`${providerId}: cooldown elapsed, re-enabling`)
       }
 
+      // #703: skip if currently rate-limited (short cooldown for 429 rate-limit)
+      const rateLimitedUntil = this.rateLimitedUntil.get(providerId) ?? 0
+      if (rateLimitedUntil > Date.now()) {
+        continue
+      } else if (rateLimitedUntil > 0) {
+        // Rate-limit cooldown elapsed — clear it
+        this.rateLimitedUntil.delete(providerId)
+      }
+
       // Warn if approaching limit (90%)
       const usageRatio = record.charCount / provider.monthlyCharLimit
       if (usageRatio >= 0.9 && usageRatio < 1) {
@@ -136,24 +168,47 @@ export class ApiRotationController implements TranslatorEngine {
         errors.push(`${providerId}: ${message}`)
         log.error(`${providerId} failed:`, message)
 
+        // #703: classify into quota / rate-limit / generic transient failure
+        const isQuotaError =
+          message.includes('Quota exceeded') || message.includes('456')
+        const isRateLimitError = message.includes('Rate limit')
+
         // Mark as exhausted on quota errors
-        if (message.includes('Quota exceeded') || message.includes('456')) {
+        if (isQuotaError) {
           record.charCount = provider.monthlyCharLimit
           this.quota[providerId] = record
           this.persistence.save(this.quota)
-        }
-
-        // #40: track consecutive failures for transient errors
-        const currentFailures = (this.failureCount.get(providerId) ?? 0) + 1
-        this.failureCount.set(providerId, currentFailures)
-        if (currentFailures >= ApiRotationController.MAX_CONSECUTIVE_FAILURES) {
-          this.failureDisabledAt.set(providerId, Date.now())
-          log.warn(`${providerId}: disabled after ${currentFailures} consecutive failures (cooldown 5min)`)
-          this.onStatusUpdate?.(`${provider.engine.name} temporarily disabled after repeated failures`)
+          // Quota errors do not count toward transient failure budget.
+          this.failureCount.set(providerId, 0)
+        } else if (isRateLimitError) {
+          // Short cooldown; do not count toward transient failure budget.
+          this.rateLimitedUntil.set(providerId, Date.now() + this.shortFailureCooldownMs)
+          log.warn(`${providerId}: rate-limited, cooldown ${this.shortFailureCooldownMs}ms`)
+          this.failureCount.set(providerId, 0)
+        } else {
+          // #40: track consecutive failures for generic transient errors
+          const currentFailures = (this.failureCount.get(providerId) ?? 0) + 1
+          this.failureCount.set(providerId, currentFailures)
+          if (currentFailures >= ApiRotationController.MAX_CONSECUTIVE_FAILURES) {
+            this.failureDisabledAt.set(providerId, Date.now())
+            log.warn(`${providerId}: disabled after ${currentFailures} consecutive failures (cooldown 5min)`)
+            this.onStatusUpdate?.(`${provider.engine.name} temporarily disabled after repeated failures`)
+          }
         }
 
         // Continue to next provider
       }
+    }
+
+    // #703: fall back to local engine when all cloud providers are exhausted
+    if (this.fallbackEngine) {
+      this.onStatusUpdate?.('All cloud providers exhausted, using local fallback')
+      log.info(`Falling back to ${this.fallbackEngine.id}. Errors: ${errors.join('; ')}`)
+      if (!this.fallbackInitialized) {
+        await this.fallbackEngine.initialize()
+        this.fallbackInitialized = true
+      }
+      return await this.fallbackEngine.translate(text, from, to, context)
     }
 
     this.onStatusUpdate?.('Translation quota exhausted — all providers used up')
@@ -166,6 +221,13 @@ export class ApiRotationController implements TranslatorEngine {
       await provider.engine.dispose().catch((err) => {
         log.warn(`Error disposing ${provider.engine.id}:`, err)
       })
+    }
+    // #703: dispose the lazily-initialized fallback engine too
+    if (this.fallbackEngine && this.fallbackInitialized) {
+      await this.fallbackEngine.dispose().catch((err) => {
+        log.warn(`Error disposing fallback ${this.fallbackEngine?.id}:`, err)
+      })
+      this.fallbackInitialized = false
     }
   }
 

--- a/src/engines/translator/DeepLTranslator.test.ts
+++ b/src/engines/translator/DeepLTranslator.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { DeepLTranslator } from './DeepLTranslator'
+
+function makeResponse(status: number, body: string, ok = status < 400): Response {
+  return {
+    ok,
+    status,
+    text: async () => body,
+    json: async () => JSON.parse(body)
+  } as Response
+}
+
+describe('DeepLTranslator 429 / 456 classification (#703)', () => {
+  let fetchMock: ReturnType<typeof vi.fn>
+
+  beforeEach(() => {
+    fetchMock = vi.fn()
+    vi.stubGlobal('fetch', fetchMock)
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('classifies 456 as Quota exceeded', async () => {
+    fetchMock.mockResolvedValue(makeResponse(456, '{"message":"Quota for this billing period has been exceeded."}'))
+    const t = new DeepLTranslator('key:fx')
+    await expect(t.translate('hi', 'en', 'ja')).rejects.toThrow(/Quota exceeded/)
+  })
+
+  it('classifies 429 with quota body as Quota exceeded', async () => {
+    fetchMock.mockResolvedValue(
+      makeResponse(429, '{"message":"Character limit reached for the current billing period"}')
+    )
+    const t = new DeepLTranslator('key:fx')
+    await expect(t.translate('hi', 'en', 'ja')).rejects.toThrow(/Quota exceeded/)
+  })
+
+  it('classifies generic 429 as Rate limit', async () => {
+    fetchMock.mockResolvedValue(makeResponse(429, '{"message":"Too many requests"}'))
+    const t = new DeepLTranslator('key:fx')
+    await expect(t.translate('hi', 'en', 'ja')).rejects.toThrow(/Rate limit/)
+  })
+
+  it('passes through 401 as invalid key', async () => {
+    fetchMock.mockResolvedValue(makeResponse(401, ''))
+    const t = new DeepLTranslator('bad:fx')
+    await expect(t.translate('hi', 'en', 'ja')).rejects.toThrow(/Invalid or expired API key/)
+  })
+})

--- a/src/engines/translator/DeepLTranslator.ts
+++ b/src/engines/translator/DeepLTranslator.ts
@@ -29,9 +29,27 @@ const LANG_MAP: Record<Language, { source: string; target: string }> = {
 
 const ERROR_MAPPINGS = [
   { statuses: [401, 403], message: 'Invalid or expired API key' },
-  { statuses: [429], message: 'Rate limit exceeded' },
-  { statuses: [456], message: 'Quota exceeded' }
+  { statuses: [429], message: 'Rate limit - retry after short cooldown' },
+  { statuses: [456], message: 'Quota exceeded - monthly limit reached' }
 ]
+
+/**
+ * Classify DeepL 429 responses. DeepL primarily signals monthly quota
+ * exhaustion with HTTP 456 (handled by errorMappings), but very high
+ * request volume can also return 429 with a quota-related message body.
+ * Reference: https://developers.deepl.com/api-reference/troubleshooting
+ */
+function classifyDeepLError(status: number, body: string): string | null {
+  if (status === 456) {
+    return 'Quota exceeded - monthly limit reached'
+  }
+  if (status !== 429) return null
+  const lower = body.toLowerCase()
+  if (lower.includes('quota') || lower.includes('character limit')) {
+    return 'Quota exceeded - monthly limit reached'
+  }
+  return 'Rate limit - retry after short cooldown'
+}
 
 export class DeepLTranslator implements TranslatorEngine {
   readonly id = 'deepl-translate'
@@ -89,7 +107,8 @@ export class DeepLTranslator implements TranslatorEngine {
       },
       timeoutMs: this.timeoutMs,
       serviceName: 'DeepL API',
-      errorMappings: ERROR_MAPPINGS
+      errorMappings: ERROR_MAPPINGS,
+      classifyErrorBody: classifyDeepLError
     })
 
     return data.translations[0]?.text || ''

--- a/src/engines/translator/GeminiTranslator.test.ts
+++ b/src/engines/translator/GeminiTranslator.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { GeminiTranslator } from './GeminiTranslator'
+
+function makeResponse(status: number, body: string, ok = status < 400): Response {
+  return {
+    ok,
+    status,
+    text: async () => body,
+    json: async () => JSON.parse(body)
+  } as Response
+}
+
+describe('GeminiTranslator 429 classification (#703)', () => {
+  let fetchMock: ReturnType<typeof vi.fn>
+
+  beforeEach(() => {
+    fetchMock = vi.fn()
+    vi.stubGlobal('fetch', fetchMock)
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('classifies 429 daily quota exceeded as Quota exceeded', async () => {
+    fetchMock.mockResolvedValue(
+      makeResponse(
+        429,
+        JSON.stringify({
+          error: {
+            message: 'Quota exceeded for quota metric "GenerateContent requests per day"',
+            details: [{ '@type': 'type.googleapis.com/google.rpc.QuotaFailure' }]
+          }
+        })
+      )
+    )
+    const t = new GeminiTranslator('key')
+    await t.initialize()
+    await expect(t.translate('hi', 'en', 'ja')).rejects.toThrow(/Quota exceeded/)
+  })
+
+  it('classifies generic per-minute 429 as Rate limit', async () => {
+    fetchMock.mockResolvedValue(
+      makeResponse(429, JSON.stringify({ error: { message: 'Too many requests' } }))
+    )
+    const t = new GeminiTranslator('key')
+    await t.initialize()
+    await expect(t.translate('hi', 'en', 'ja')).rejects.toThrow(/Rate limit/)
+  })
+
+  it('passes through 400 as invalid key', async () => {
+    fetchMock.mockResolvedValue(makeResponse(400, ''))
+    const t = new GeminiTranslator('bad')
+    await t.initialize()
+    await expect(t.translate('hi', 'en', 'ja')).rejects.toThrow(/Invalid API key/)
+  })
+})

--- a/src/engines/translator/GeminiTranslator.ts
+++ b/src/engines/translator/GeminiTranslator.ts
@@ -11,8 +11,26 @@ const GEMINI_API_URL =
 
 const ERROR_MAPPINGS = [
   { statuses: [400, 403], message: 'Invalid API key' },
-  { statuses: [429], message: 'Rate limit exceeded' }
+  { statuses: [429], message: 'Rate limit - retry after short cooldown' }
 ]
+
+/**
+ * Classify Gemini API 429 responses. The Gemini API returns 429 for both
+ * per-minute rate-limit and daily/monthly quota exhaustion. The error body
+ * typically contains a quotaId or "quota" mention for monthly exhaustion.
+ * Reference: https://ai.google.dev/gemini-api/docs/troubleshooting
+ */
+function classifyGeminiError(status: number, body: string): string | null {
+  if (status !== 429) return null
+  const lower = body.toLowerCase()
+  if (
+    lower.includes('quota') &&
+    (lower.includes('day') || lower.includes('month') || lower.includes('exceeded'))
+  ) {
+    return 'Quota exceeded - monthly limit reached'
+  }
+  return 'Rate limit - retry after short cooldown'
+}
 
 export class GeminiTranslator implements TranslatorEngine {
   readonly id = 'gemini-translate'
@@ -79,7 +97,8 @@ export class GeminiTranslator implements TranslatorEngine {
       },
       timeoutMs: this.timeoutMs,
       serviceName: 'Gemini API',
-      errorMappings: ERROR_MAPPINGS
+      errorMappings: ERROR_MAPPINGS,
+      classifyErrorBody: classifyGeminiError
     })
 
     return data.candidates?.[0]?.content?.parts?.[0]?.text?.trim() || ''

--- a/src/engines/translator/GoogleTranslator.test.ts
+++ b/src/engines/translator/GoogleTranslator.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { GoogleTranslator } from './GoogleTranslator'
+
+function makeResponse(status: number, body: string, ok = status < 400): Response {
+  return {
+    ok,
+    status,
+    text: async () => body,
+    json: async () => JSON.parse(body)
+  } as Response
+}
+
+describe('GoogleTranslator 429 classification (#703)', () => {
+  let fetchMock: ReturnType<typeof vi.fn>
+
+  beforeEach(() => {
+    fetchMock = vi.fn()
+    vi.stubGlobal('fetch', fetchMock)
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('classifies 429 dailyLimitExceeded as Quota exceeded', async () => {
+    fetchMock.mockResolvedValue(
+      makeResponse(
+        429,
+        JSON.stringify({ error: { errors: [{ reason: 'dailyLimitExceeded' }] } })
+      )
+    )
+    const t = new GoogleTranslator('key')
+    await expect(t.translate('hi', 'en', 'ja')).rejects.toThrow(/Quota exceeded/)
+  })
+
+  it('classifies 429 quotaExceeded as Quota exceeded', async () => {
+    fetchMock.mockResolvedValue(
+      makeResponse(429, JSON.stringify({ error: { errors: [{ reason: 'quotaExceeded' }] } }))
+    )
+    const t = new GoogleTranslator('key')
+    await expect(t.translate('hi', 'en', 'ja')).rejects.toThrow(/Quota exceeded/)
+  })
+
+  it('classifies generic 429 as Rate limit', async () => {
+    fetchMock.mockResolvedValue(
+      makeResponse(429, JSON.stringify({ error: { errors: [{ reason: 'rateLimitExceeded' }] } }))
+    )
+    const t = new GoogleTranslator('key')
+    await expect(t.translate('hi', 'en', 'ja')).rejects.toThrow(/Rate limit/)
+  })
+
+  it('passes through 403 as invalid key', async () => {
+    fetchMock.mockResolvedValue(makeResponse(403, ''))
+    const t = new GoogleTranslator('bad')
+    await expect(t.translate('hi', 'en', 'ja')).rejects.toThrow(/Invalid or expired API key/)
+  })
+})

--- a/src/engines/translator/GoogleTranslator.ts
+++ b/src/engines/translator/GoogleTranslator.ts
@@ -8,8 +8,28 @@ const GOOGLE_TRANSLATE_URL = 'https://translation.googleapis.com/language/transl
 
 const ERROR_MAPPINGS = [
   { statuses: [403], message: 'Invalid or expired API key' },
-  { statuses: [429], message: 'Rate limit exceeded' }
+  { statuses: [429], message: 'Rate limit - retry after short cooldown' }
 ]
+
+/**
+ * Classify Google Cloud Translation 429 responses. Daily/monthly quota
+ * exhaustion is reported with reason "quotaExceeded" / "userRateLimitExceeded"
+ * / "dailyLimitExceeded" inside the JSON error body, while transient per-second
+ * limits surface as plain rateLimitExceeded.
+ * Reference: https://cloud.google.com/translate/quotas
+ */
+function classifyGoogleError(status: number, body: string): string | null {
+  if (status !== 429) return null
+  const lower = body.toLowerCase()
+  if (
+    lower.includes('dailylimitexceeded') ||
+    lower.includes('quotaexceeded') ||
+    lower.includes('userratelimitexceeded')
+  ) {
+    return 'Quota exceeded - monthly limit reached'
+  }
+  return 'Rate limit - retry after short cooldown'
+}
 
 export class GoogleTranslator implements TranslatorEngine {
   readonly id = 'google-translate'
@@ -53,7 +73,8 @@ export class GoogleTranslator implements TranslatorEngine {
       init: { method: 'POST' },
       timeoutMs: this.timeoutMs,
       serviceName: 'Google Translation API',
-      errorMappings: ERROR_MAPPINGS
+      errorMappings: ERROR_MAPPINGS,
+      classifyErrorBody: classifyGoogleError
     })
 
     return data.data.translations[0]?.translatedText || ''

--- a/src/engines/translator/MicrosoftTranslator.test.ts
+++ b/src/engines/translator/MicrosoftTranslator.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { MicrosoftTranslator } from './MicrosoftTranslator'
+
+/**
+ * Build a Response-like object that fetch() can return. The body is consumed
+ * via .text() (used by api-utils' classifyErrorBody) or .json() on success.
+ */
+function makeResponse(status: number, body: string, ok = status < 400): Response {
+  return {
+    ok,
+    status,
+    text: async () => body,
+    json: async () => JSON.parse(body)
+  } as Response
+}
+
+describe('MicrosoftTranslator 429 classification (#703)', () => {
+  let fetchMock: ReturnType<typeof vi.fn>
+
+  beforeEach(() => {
+    fetchMock = vi.fn()
+    vi.stubGlobal('fetch', fetchMock)
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('classifies 429 with outOfQuota body as Quota exceeded', async () => {
+    fetchMock.mockResolvedValue(
+      makeResponse(429, JSON.stringify({ error: { code: 403001, message: 'outOfQuota' } }))
+    )
+    const t = new MicrosoftTranslator('key', 'global')
+    await expect(t.translate('hi', 'en', 'ja')).rejects.toThrow(/Quota exceeded/)
+  })
+
+  it('classifies 429 with quotaExceeded body as Quota exceeded', async () => {
+    fetchMock.mockResolvedValue(
+      makeResponse(429, JSON.stringify({ error: { message: 'quotaExceeded' } }))
+    )
+    const t = new MicrosoftTranslator('key', 'global')
+    await expect(t.translate('hi', 'en', 'ja')).rejects.toThrow(/Quota exceeded/)
+  })
+
+  it('classifies generic 429 as Rate limit', async () => {
+    fetchMock.mockResolvedValue(
+      makeResponse(429, JSON.stringify({ error: { message: 'Too many requests' } }))
+    )
+    const t = new MicrosoftTranslator('key', 'global')
+    await expect(t.translate('hi', 'en', 'ja')).rejects.toThrow(/Rate limit/)
+  })
+
+  it('passes through 401 as invalid key', async () => {
+    fetchMock.mockResolvedValue(makeResponse(401, ''))
+    const t = new MicrosoftTranslator('bad', 'global')
+    await expect(t.translate('hi', 'en', 'ja')).rejects.toThrow(/Invalid API key/)
+  })
+})

--- a/src/engines/translator/MicrosoftTranslator.ts
+++ b/src/engines/translator/MicrosoftTranslator.ts
@@ -9,8 +9,23 @@ const API_VERSION = '3.0'
 
 const ERROR_MAPPINGS = [
   { statuses: [401], message: 'Invalid API key or region' },
-  { statuses: [429], message: 'Rate limit exceeded' }
+  { statuses: [429], message: 'Rate limit - retry after short cooldown' }
 ]
+
+/**
+ * Classify Microsoft Translator 429 responses into either monthly quota
+ * exhaustion or short-window rate-limit. The Microsoft API surfaces both
+ * conditions via HTTP 429; only the response body distinguishes them.
+ * Reference: https://learn.microsoft.com/en-us/azure/ai-services/translator/reference/v3-0-reference#errors
+ */
+function classifyMicrosoftError(status: number, body: string): string | null {
+  if (status !== 429) return null
+  const lower = body.toLowerCase()
+  if (lower.includes('outofquota') || lower.includes('quotaexceeded')) {
+    return 'Quota exceeded - monthly limit reached'
+  }
+  return 'Rate limit - retry after short cooldown'
+}
 
 export class MicrosoftTranslator implements TranslatorEngine {
   readonly id = 'microsoft-translate'
@@ -65,7 +80,8 @@ export class MicrosoftTranslator implements TranslatorEngine {
       },
       timeoutMs: this.timeoutMs,
       serviceName: 'Microsoft Translator',
-      errorMappings: ERROR_MAPPINGS
+      errorMappings: ERROR_MAPPINGS,
+      classifyErrorBody: classifyMicrosoftError
     })
 
     return data[0]?.translations[0]?.text || ''

--- a/src/engines/translator/api-utils.ts
+++ b/src/engines/translator/api-utils.ts
@@ -12,6 +12,13 @@ export interface HttpErrorMapping {
   message: string
 }
 
+/**
+ * Body-aware error classifier. Called for non-OK HTTP statuses with the raw
+ * response body. Return a string message to throw, or null to fall through to
+ * the standard errorMappings / generic message.
+ */
+export type ErrorBodyClassifier = (status: number, body: string) => string | null
+
 /** Options for fetchWithTimeout */
 export interface ApiFetchOptions {
   url: string
@@ -21,6 +28,12 @@ export interface ApiFetchOptions {
   serviceName: string
   /** Custom status-to-message mappings, checked before the generic fallback */
   errorMappings?: HttpErrorMapping[]
+  /**
+   * Optional body-aware classifier evaluated before errorMappings. Useful when
+   * a single status code (e.g. 429) needs to be split into multiple semantic
+   * errors based on the response body (e.g. monthly quota vs short rate-limit).
+   */
+  classifyErrorBody?: ErrorBodyClassifier
 }
 
 /**
@@ -28,7 +41,7 @@ export interface ApiFetchOptions {
  * Returns the parsed JSON response body.
  */
 export async function apiFetch<T>(options: ApiFetchOptions): Promise<T> {
-  const { url, init, timeoutMs, serviceName, errorMappings } = options
+  const { url, init, timeoutMs, serviceName, errorMappings, classifyErrorBody } = options
 
   const controller = new AbortController()
   const timeout = setTimeout(() => controller.abort(), timeoutMs)
@@ -40,6 +53,18 @@ export async function apiFetch<T>(options: ApiFetchOptions): Promise<T> {
     })
 
     if (!response.ok) {
+      let body = ''
+      if (classifyErrorBody) {
+        try {
+          body = await response.text()
+        } catch {
+          // ignore — fall through to status-only handling
+        }
+        const classified = classifyErrorBody(response.status, body)
+        if (classified) {
+          throw new Error(`${serviceName}: ${classified}`)
+        }
+      }
       throwHttpError(response.status, serviceName, errorMappings)
     }
 

--- a/src/main/ipc/pipeline-ipc.ts
+++ b/src/main/ipc/pipeline-ipc.ts
@@ -5,6 +5,7 @@ import { GeminiTranslator } from '../../engines/translator/GeminiTranslator'
 import { MicrosoftTranslator } from '../../engines/translator/MicrosoftTranslator'
 import { ApiRotationController } from '../../engines/translator/ApiRotationController'
 import type { ProviderConfig, QuotaStore } from '../../engines/translator/ApiRotationController'
+import { HunyuanMT15Translator } from '../../engines/translator/HunyuanMT15Translator'
 import { TranscriptLogger } from '../../logger/TranscriptLogger'
 import { store } from '../store'
 import type { AppContext } from '../app-context'
@@ -134,7 +135,15 @@ export function registerPipelineIpc(ctx: AppContext): void {
         }
 
         ctx.pipeline.registerTranslator('rotation-controller', () =>
-          new ApiRotationController(rotationProviders!, persistence, statusFn)
+          new ApiRotationController(rotationProviders!, persistence, statusFn, {
+            // #703: local fallback so exhausted cloud quotas never silently
+            // stop the subtitle stream. HunyuanMT15 is lazy-initialized inside
+            // the controller (only loaded on first exhaustion).
+            fallbackEngine: new HunyuanMT15Translator({
+              onProgress: (msg) =>
+                ctx.mainWindow?.webContents.send('status-update', msg)
+            })
+          })
         )
       }
 


### PR DESCRIPTION
## Description

Extends `ApiRotationController` so that exhausting every cloud provider transparently falls back to a local engine instead of throwing, and disambiguates 429 responses across Microsoft / Google / DeepL / Gemini into short rate-limit vs monthly quota.

**ApiRotationController**
- New `ApiRotationOptions` interface with `fallbackEngine` and `shortFailureCooldownMs` (default 60_000 ms)
- Constructor accepts an optional 4th `options` arg; absent `fallbackEngine` keeps the legacy throw-on-exhaustion behavior
- Lazy-initializes the fallback engine on first exhaustion to avoid double-loading HY-MT1.5 when it is also the primary engine
- Rate-limit (429-rate) and quota errors no longer consume the 5-failure transient budget that triggers the 5-minute disable
- New `rateLimitedUntil` short-cooldown map skips providers for `shortFailureCooldownMs` instead of treating them as dead

**Per-translator 429 classification (via new `classifyErrorBody` callback in `api-utils.ts`)**
- Microsoft: body `outOfQuota` / `quotaExceeded` → Quota; everything else → Rate limit
- Google: body `dailyLimitExceeded` / `quotaExceeded` / `userRateLimitExceeded` → Quota; else Rate limit
- DeepL: 456 → Quota; 429 with `quota` / `character limit` body → Quota; else Rate limit
- Gemini: body contains `quota` + (`day` / `month` / `exceeded`) → Quota; else Rate limit

**Pipeline wiring**
- `pipeline-ipc.ts` injects `HunyuanMT15Translator` as the rotation fallback so subtitles keep flowing after cloud quotas are exhausted

**Tests (32 added/updated, all passing)**
- `ApiRotationController.test.ts`: fallback success, lazy init, backward-compat throw, fallback disposal (only when initialized), rate-limit cooldown + override, quota-marks-exhausted, rate-limit does not count toward failure budget
- New per-translator tests covering Quota vs Rate limit classification + invalid-key passthrough for each of the four cloud translators

## Related Issue

Closes #703

## Test Checklist
- [x] Unit tests added/updated (32 new/updated tests, all passing)
- [ ] Tested in Chrome
- [ ] Tested in Firefox or Safari
- [ ] Responsive: mobile (375px) and desktop (1280px+)
- [ ] Keyboard navigation works
- [ ] Dark mode verified (if supported)

## Checklist
- [x] CLAUDE.md rules followed
- [x] No hardcoded strings (all externalized)
- [x] Error handling complete
- [x] No console.log left in production code