### PR TITLE
MDM config: add managedMicrosoftApiKey + managedMicrosoftRegion (#704)

### DIFF
--- a/docs/mdm-config.md
+++ b/docs/mdm-config.md
@@ -1,0 +1,90 @@
+# MDM Configuration Reference
+
+Live Translate reads MDM-managed configuration on macOS from
+`/Library/Managed Preferences/com.live-translate.app.plist`. The plist is
+written by an MDM-deployed configuration profile (PayloadType
+`com.live-translate.app`).
+
+On non-macOS platforms there is currently no MDM enforcement and every value
+defaults to `null` / `false`.
+
+## Supported keys
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `lockedEngine` | string | `null` | Force the translator engine ID. Overrides user selection. |
+| `lockedSttEngine` | string | `null` | Force the STT engine ID. Overrides user selection. |
+| `telemetryDisabled` | boolean (`<true/>` / `<false/>`) | `false` | When `true`, blocks the user from enabling telemetry. |
+| `managedApiKey` | string | `null` | Google Cloud Translation API key injected when the user has not set one. |
+| `managedDeeplApiKey` | string | `null` | DeepL API key injected when the user has not set one. |
+| `managedGeminiApiKey` | string | `null` | Gemini API key injected when the user has not set one. |
+| `managedMicrosoftApiKey` | string | `null` | **(#704)** Microsoft (Azure) Translator API key injected when the user has not set one. |
+| `managedMicrosoftRegion` | string | `null` | **(#704)** Microsoft (Azure) Translator region (e.g. `japaneast`, `eastus`). Required together with `managedMicrosoftApiKey` for the engine to start. |
+| `organizationName` | string | `null` | Organization label shown in the Enterprise settings panel. |
+| `autoUpdateDisabled` | boolean | `false` | When `true`, suppresses in-app auto-update (admin manages updates via MDM). |
+
+## Injection behaviour
+
+When the user starts a pipeline, the main process merges MDM-managed API keys
+into the runtime config in `src/main/ipc/pipeline-ipc.ts`:
+
+1. MDM keys are only applied when the user has **not** set a key of their own.
+2. `managedMicrosoftApiKey` is only effective when `managedMicrosoftRegion` is
+   also provided — Azure Translator requires both.
+3. The MDM `lockedEngine` / `lockedSttEngine` values override the user's
+   engine selection unconditionally.
+
+## Renderer exposure
+
+`src/main/ipc/enterprise-ipc.ts` strips secret values before sending the MDM
+config to the renderer. The renderer receives only boolean presence flags for
+each API key. The region (a non-secret identifier) is sent as-is so the UI can
+display it.
+
+Renderer-visible shape:
+
+```ts
+interface MdmConfig {
+  lockedEngine: string | null
+  lockedSttEngine: string | null
+  telemetryDisabled: boolean
+  hasManagedApiKey: boolean
+  hasManagedDeeplApiKey: boolean
+  hasManagedGeminiApiKey: boolean
+  hasManagedMicrosoftApiKey: boolean
+  managedMicrosoftRegion: string | null
+  organizationName: string | null
+  autoUpdateDisabled: boolean
+}
+```
+
+## Example configuration profile
+
+```xml
+<dict>
+  <key>PayloadType</key>
+  <string>com.live-translate.app</string>
+
+  <key>organizationName</key>
+  <string>Acme Corp</string>
+
+  <key>lockedEngine</key>
+  <string>rotation-controller</string>
+
+  <key>managedMicrosoftApiKey</key>
+  <string>YOUR-AZURE-TRANSLATOR-KEY</string>
+  <key>managedMicrosoftRegion</key>
+  <string>japaneast</string>
+
+  <key>telemetryDisabled</key>
+  <true/>
+  <key>autoUpdateDisabled</key>
+  <true/>
+</dict>
+```
+
+## Out of scope
+
+- Region string validation (Azure publishes a finite list of regions). Tracked
+  for Phase 2 once the broader managed-policy spec lands.
+- Windows registry / Group Policy support for managed preferences.

--- a/src/main/ipc/enterprise-ipc.ts
+++ b/src/main/ipc/enterprise-ipc.ts
@@ -42,6 +42,11 @@ export function registerEnterpriseIpc(_ctx: AppContext): void {
       hasManagedApiKey: config.managedApiKey !== null,
       hasManagedDeeplApiKey: config.managedDeeplApiKey !== null,
       hasManagedGeminiApiKey: config.managedGeminiApiKey !== null,
+      // #704: expose Microsoft (Azure) Translator managed state to renderer.
+      // Key is hidden (boolean only) but region is sent as a non-secret value
+      // so the UI can display the configured Azure region.
+      hasManagedMicrosoftApiKey: config.managedMicrosoftApiKey !== null,
+      managedMicrosoftRegion: config.managedMicrosoftRegion,
       organizationName: config.organizationName,
       autoUpdateDisabled: config.autoUpdateDisabled
     }

--- a/src/main/ipc/pipeline-ipc.ts
+++ b/src/main/ipc/pipeline-ipc.ts
@@ -74,6 +74,13 @@ export function registerPipelineIpc(ctx: AppContext): void {
       if (mdm.managedGeminiApiKey && !config.geminiApiKey) {
         config.geminiApiKey = mdm.managedGeminiApiKey
       }
+      // #704: inject managed Microsoft (Azure) Translator key+region when present
+      if (mdm.managedMicrosoftApiKey && !config.microsoftApiKey) {
+        config.microsoftApiKey = mdm.managedMicrosoftApiKey
+      }
+      if (mdm.managedMicrosoftRegion && !config.microsoftRegion) {
+        config.microsoftRegion = mdm.managedMicrosoftRegion
+      }
 
       // Register online translators with provided API keys
       if (config.apiKey) {

--- a/src/main/mdm-config.test.ts
+++ b/src/main/mdm-config.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+/**
+ * Mock child_process.execSync so we can simulate macOS `defaults read` output
+ * for managed preferences without touching the real filesystem.
+ *
+ * The real `readManagedPref` builds a command of the form
+ *   defaults read "/Library/Managed Preferences/<bundle>" <key> 2>/dev/null
+ * We capture the requested key from the command string and return a value
+ * from the configured fixture map. Missing keys throw, matching the real
+ * `defaults` behavior (which exits non-zero when a key is absent).
+ */
+let prefFixture: Record<string, string> = {}
+
+vi.mock('child_process', () => ({
+  execSync: vi.fn((cmd: string) => {
+    // Extract the trailing key argument (after the quoted path).
+    // Format: defaults read "<path>" <key> 2>/dev/null
+    const match = cmd.match(/" ([A-Za-z0-9_]+) 2>\/dev\/null$/)
+    const key = match?.[1]
+    if (!key || !(key in prefFixture)) {
+      throw new Error(`defaults: key "${key}" not found`)
+    }
+    return prefFixture[key]
+  })
+}))
+
+vi.mock('./logger', () => ({
+  createLogger: () => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn()
+  })
+}))
+
+const originalPlatform = process.platform
+
+function setPlatform(platform: NodeJS.Platform): void {
+  Object.defineProperty(process, 'platform', { value: platform, configurable: true })
+}
+
+describe('mdm-config', () => {
+  beforeEach(async () => {
+    prefFixture = {}
+    const mod = await import('./mdm-config')
+    mod.clearMdmConfigCache()
+  })
+
+  afterEach(() => {
+    setPlatform(originalPlatform)
+  })
+
+  describe('on non-macOS platforms', () => {
+    beforeEach(() => {
+      setPlatform('linux')
+    })
+
+    it('returns null for all managed Microsoft fields', async () => {
+      const { loadMdmConfig } = await import('./mdm-config')
+      const cfg = loadMdmConfig()
+      expect(cfg.managedMicrosoftApiKey).toBeNull()
+      expect(cfg.managedMicrosoftRegion).toBeNull()
+    })
+  })
+
+  describe('on macOS', () => {
+    beforeEach(() => {
+      setPlatform('darwin')
+    })
+
+    it('#704: loads managedMicrosoftApiKey + managedMicrosoftRegion from managed prefs', async () => {
+      prefFixture = {
+        managedMicrosoftApiKey: 'azure-secret-key-abc123',
+        managedMicrosoftRegion: 'japaneast'
+      }
+
+      const { loadMdmConfig } = await import('./mdm-config')
+      const cfg = loadMdmConfig()
+
+      expect(cfg.managedMicrosoftApiKey).toBe('azure-secret-key-abc123')
+      expect(cfg.managedMicrosoftRegion).toBe('japaneast')
+    })
+
+    it('#704: leaves Microsoft fields null when MDM does not set them', async () => {
+      prefFixture = {
+        managedApiKey: 'google-key',
+        managedDeeplApiKey: 'deepl-key'
+      }
+
+      const { loadMdmConfig } = await import('./mdm-config')
+      const cfg = loadMdmConfig()
+
+      expect(cfg.managedApiKey).toBe('google-key')
+      expect(cfg.managedDeeplApiKey).toBe('deepl-key')
+      expect(cfg.managedMicrosoftApiKey).toBeNull()
+      expect(cfg.managedMicrosoftRegion).toBeNull()
+    })
+
+    it('#704: caches config so repeat calls do not re-read prefs', async () => {
+      prefFixture = { managedMicrosoftApiKey: 'first-key', managedMicrosoftRegion: 'eastus' }
+      const { loadMdmConfig, getMdmConfig } = await import('./mdm-config')
+
+      const a = loadMdmConfig()
+      // Mutate fixture; cached config should not change because of caching
+      prefFixture = { managedMicrosoftApiKey: 'second-key', managedMicrosoftRegion: 'westus' }
+      const b = getMdmConfig()
+
+      expect(a).toBe(b)
+      expect(b.managedMicrosoftApiKey).toBe('first-key')
+      expect(b.managedMicrosoftRegion).toBe('eastus')
+    })
+  })
+})

--- a/src/main/mdm-config.ts
+++ b/src/main/mdm-config.ts
@@ -17,6 +17,10 @@ export interface MdmConfig {
   managedDeeplApiKey: string | null
   /** Managed Gemini API key */
   managedGeminiApiKey: string | null
+  /** Managed Microsoft (Azure) Translator API key (#704) */
+  managedMicrosoftApiKey: string | null
+  /** Managed Microsoft (Azure) Translator region (e.g. "japaneast") (#704) */
+  managedMicrosoftRegion: string | null
   /** Custom organization name shown in UI */
   organizationName: string | null
   /** Disable auto-update (enterprise may manage updates via MDM) */
@@ -92,6 +96,8 @@ export function loadMdmConfig(): MdmConfig {
     managedApiKey: readManagedPref('managedApiKey'),
     managedDeeplApiKey: readManagedPref('managedDeeplApiKey'),
     managedGeminiApiKey: readManagedPref('managedGeminiApiKey'),
+    managedMicrosoftApiKey: readManagedPref('managedMicrosoftApiKey'),
+    managedMicrosoftRegion: readManagedPref('managedMicrosoftRegion'),
     organizationName: readManagedPref('organizationName'),
     autoUpdateDisabled: readManagedPref('autoUpdateDisabled') === '1'
   }
@@ -104,6 +110,8 @@ export function loadMdmConfig(): MdmConfig {
   if (config.managedApiKey) managed.push('managedApiKey=***')
   if (config.managedDeeplApiKey) managed.push('managedDeeplApiKey=***')
   if (config.managedGeminiApiKey) managed.push('managedGeminiApiKey=***')
+  if (config.managedMicrosoftApiKey) managed.push('managedMicrosoftApiKey=***')
+  if (config.managedMicrosoftRegion) managed.push(`managedMicrosoftRegion=${config.managedMicrosoftRegion}`)
   if (config.organizationName) managed.push(`org=${config.organizationName}`)
   if (config.autoUpdateDisabled) managed.push('autoUpdateDisabled')
 

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -128,6 +128,8 @@ export interface ElectronAPI {
     hasManagedApiKey: boolean
     hasManagedDeeplApiKey: boolean
     hasManagedGeminiApiKey: boolean
+    hasManagedMicrosoftApiKey: boolean
+    managedMicrosoftRegion: string | null
     organizationName: string | null
     autoUpdateDisabled: boolean
   }>

--- a/src/renderer/components/settings/EnterpriseSettings.tsx
+++ b/src/renderer/components/settings/EnterpriseSettings.tsx
@@ -9,6 +9,8 @@ interface MdmConfig {
   hasManagedApiKey: boolean
   hasManagedDeeplApiKey: boolean
   hasManagedGeminiApiKey: boolean
+  hasManagedMicrosoftApiKey: boolean
+  managedMicrosoftRegion: string | null
   organizationName: string | null
   autoUpdateDisabled: boolean
 }
@@ -101,6 +103,14 @@ export function EnterpriseSettings({ disabled }: Props): React.JSX.Element {
           )}
           {mdmConfig.hasManagedGeminiApiKey && (
             <div style={infoLineStyle}>Gemini API key provided by organization</div>
+          )}
+          {mdmConfig.hasManagedMicrosoftApiKey && (
+            <div style={infoLineStyle}>
+              Microsoft Translator API key provided by organization
+              {mdmConfig.managedMicrosoftRegion && (
+                <> (region: <strong>{mdmConfig.managedMicrosoftRegion}</strong>)</>
+              )}
+            </div>
           )}
           {mdmConfig.autoUpdateDisabled && (
             <div style={infoLineStyle}>Auto-updates managed by organization</div>


### PR DESCRIPTION
## Summary

- Add `managedMicrosoftApiKey` and `managedMicrosoftRegion` to `MdmConfig` so admins can deploy the Azure Translator key+region via macOS managed preferences (matches the existing pattern for Google / DeepL / Gemini managed keys).
- Inject the managed key+region into the runtime pipeline config in `pipeline-ipc.ts` only when the user has not provided their own (same gate as the other managed-key paths).
- Expose `hasManagedMicrosoftApiKey` (boolean only — secret stripped) and the literal `managedMicrosoftRegion` (non-secret identifier) to the renderer, and display them in `EnterpriseSettings`.
- Add `docs/mdm-config.md` documenting every supported managed-preferences key, with an Azure example.
- New `src/main/mdm-config.test.ts` covers load + cache + non-macOS no-op paths for the Microsoft fields.

Closes #704.

## Core Value alignment note

CLAUDE.md currently lists "エンタープライズ機能（MDM/管理者ロック/使用量分析）" under Won't Do. This PR is an additive 2-field extension to MDM infrastructure that already exists in the codebase, deliberately scoped to support the hybrid-online-offline-2026-06 plan (Azure key recommendation). The user authorized proceeding with the 9-issue batch; the Won't Do entry is intentionally left untouched here since it's a separate strategic decision.

## Test plan

- [x] `npx vitest run src/main/mdm-config.test.ts` — 4/4 pass
- [x] `npm test` — only pre-existing `virtual-mic-manager` failures (naudiodon not installed in CI env); all 22 other test files pass including the new one
- [x] `npm run typecheck` — only pre-existing `src/main/index.ts` parse errors (already on origin/main); no new errors introduced
- [x] `npm run lint` on touched files — clean; remaining errors/warnings are pre-existing on origin/main
- [ ] Manual: deploy an MDM profile with `managedMicrosoftApiKey` + `managedMicrosoftRegion` and verify rotation mode picks up Azure as a provider