### PR TITLE
Add three-step onboarding with optional Azure F0 key step (#708)

### DIFF
--- a/src/renderer/components/Onboarding.tsx
+++ b/src/renderer/components/Onboarding.tsx
@@ -1,0 +1,614 @@
+import React, { useCallback, useEffect, useState } from 'react'
+import {
+  AZURE_FREE_TIER_CHARS,
+  AZURE_TRANSLATOR_PORTAL_URL,
+  TIER1_TOTAL_MB,
+  TIER2_TOTAL_MB,
+  formatSize,
+  isAzureKeyValid,
+  nextStep,
+  pickInitialStep,
+  type DownloadStatus,
+  type OnboardingStep
+} from './onboarding-steps'
+
+interface OnboardingProps {
+  /** Called once when the user finishes (or skips through) all three steps. */
+  onComplete: () => void
+}
+
+interface DownloadState {
+  status: DownloadStatus
+  progress: number
+  tier1Ready: boolean
+  tier2Ready: boolean
+  error?: string
+}
+
+/**
+ * Three-step first-run onboarding (#708):
+ *  1. Quick Start         — Tier 1 (Whisper Base + LFM2 350M, ~371MB)
+ *                           "Ready to translate in moments"
+ *  2. Quality Upgrade     — Tier 2 (Kotoba Whisper + HY-MT1.5 1.8B, ~1.6GB)
+ *                           Downloads in background; auto-switches when ready
+ *  3. Cloud Boost (opt.)  — Azure Translator F0 key for 2M chars/month free
+ *
+ * Every step is skippable. Step 3 is fully optional and can be configured
+ * later in Translator Settings.
+ */
+export function Onboarding({ onComplete }: OnboardingProps): React.JSX.Element | null {
+  const [step, setStep] = useState<OnboardingStep | null>(null)
+  const [download, setDownload] = useState<DownloadState>({
+    status: 'idle',
+    progress: 0,
+    tier1Ready: false,
+    tier2Ready: false
+  })
+  const [azureKey, setAzureKey] = useState('')
+  const [azureRegion, setAzureRegion] = useState('')
+  const [azureSaving, setAzureSaving] = useState(false)
+  const [azureSaveError, setAzureSaveError] = useState<string | null>(null)
+  const [startError, setStartError] = useState<string | null>(null)
+
+  // Bootstrap: load current onboarding status + any persisted Azure credentials
+  useEffect(() => {
+    let cancelled = false
+    Promise.all([
+      window.api.onboardingGetStatus(),
+      window.api.getSettings()
+    ])
+      .then(([status, settings]) => {
+        if (cancelled) return
+        const s = status as unknown as DownloadState
+        setDownload({
+          status: s.status,
+          progress: s.progress ?? 0,
+          tier1Ready: !!s.tier1Ready,
+          tier2Ready: !!s.tier2Ready
+        })
+        setAzureKey((settings as { microsoftApiKey?: string }).microsoftApiKey ?? '')
+        setAzureRegion((settings as { microsoftRegion?: string }).microsoftRegion ?? '')
+        setStep(
+          pickInitialStep({
+            tier1Ready: !!s.tier1Ready,
+            tier2Ready: !!s.tier2Ready,
+            status: s.status
+          })
+        )
+      })
+      .catch((err: unknown) => {
+        const message = err instanceof Error ? err.message : String(err)
+        console.warn('[onboarding] Failed to load initial state:', message)
+        if (!cancelled) setStep('quick-start')
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  // Subscribe to live download progress so each step reflects current state
+  useEffect(() => {
+    const unsub = window.api.onOnboardingDownloadProgress((data) => {
+      setDownload((prev) => ({
+        status: (data.status as DownloadStatus) ?? prev.status,
+        progress: data.progress ?? prev.progress,
+        tier1Ready: data.tier1Ready ?? prev.tier1Ready,
+        tier2Ready: data.tier2Ready ?? prev.tier2Ready,
+        error: data.error
+      }))
+    })
+    return () => {
+      unsub()
+    }
+  }, [])
+
+  const advance = useCallback((from: OnboardingStep) => {
+    const target = nextStep(from)
+    if (target === 'done') {
+      window.api.quickStartSkip().catch(() => {
+        // best-effort: don't block completion
+      })
+      onComplete()
+    } else {
+      setStep(target)
+    }
+  }, [onComplete])
+
+  const handleStartTier1 = useCallback(async () => {
+    setStartError(null)
+    try {
+      // Triggers Tier 1 download, then Tier 2 in background automatically
+      await window.api.onboardingStartDownload()
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : String(err)
+      setStartError(message)
+    }
+  }, [])
+
+  const handleSwitchToTier1Now = useCallback(async () => {
+    try {
+      await window.api.onboardingSwitchToLocal()
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : String(err)
+      console.warn('[onboarding] Failed to activate Tier 1 engine:', message)
+    }
+  }, [])
+
+  const handleSaveAzureKey = useCallback(async () => {
+    if (!isAzureKeyValid(azureKey, azureRegion)) {
+      setAzureSaveError('Both API key and region are required.')
+      return
+    }
+    setAzureSaving(true)
+    setAzureSaveError(null)
+    try {
+      await window.api.saveSettings({
+        microsoftApiKey: azureKey.trim(),
+        microsoftRegion: azureRegion.trim()
+      })
+      advance('cloud-boost')
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : String(err)
+      setAzureSaveError(`Failed to save Azure credentials: ${message}`)
+    } finally {
+      setAzureSaving(false)
+    }
+  }, [azureKey, azureRegion, advance])
+
+  // Still loading initial state — render placeholder to avoid flicker
+  if (!step) {
+    return <div style={shellStyle} aria-busy="true" />
+  }
+
+  return (
+    <div style={shellStyle}>
+      <header style={headerStyle}>
+        <h2 style={titleStyle}>Welcome to live-translate</h2>
+        <p style={subtitleStyle}>
+          Three quick steps to set up local-first translation. Skip anything you do not need.
+        </p>
+        <StepIndicator current={step} />
+      </header>
+
+      {step === 'quick-start' && (
+        <StepCard
+          number={1}
+          title="Quick Start"
+          subtitle={`Whisper Base + LFM2 350M (${formatSize(TIER1_TOTAL_MB)})`}
+          description="Smallest viable speech-to-text and translation models for an instant offline start. Ready to translate in moments after download."
+          status={download.status}
+          progress={download.progress}
+          isDownloading={download.status === 'downloading-tier1'}
+          isReady={download.tier1Ready}
+          error={startError ?? download.error}
+        >
+          {!download.tier1Ready && download.status !== 'downloading-tier1' && (
+            <PrimaryButton onClick={handleStartTier1}>
+              Download & start ({formatSize(TIER1_TOTAL_MB)})
+            </PrimaryButton>
+          )}
+          {download.status === 'downloading-tier1' && (
+            <p style={hintStyle}>
+              Downloading… {download.progress}% complete. You can continue to the next step.
+            </p>
+          )}
+          {download.tier1Ready && (
+            <>
+              <p style={readyStyle}>Ready — translation can start immediately.</p>
+              <PrimaryButton onClick={handleSwitchToTier1Now}>
+                Use Quick Start now
+              </PrimaryButton>
+            </>
+          )}
+          <SkipButton onClick={() => advance('quick-start')}>
+            {download.tier1Ready ? 'Next: Quality upgrade' : 'Skip — continue'}
+          </SkipButton>
+        </StepCard>
+      )}
+
+      {step === 'quality-upgrade' && (
+        <StepCard
+          number={2}
+          title="Quality Upgrade"
+          subtitle={`Kotoba Whisper + HY-MT1.5 1.8B (${formatSize(TIER2_TOTAL_MB)})`}
+          description="Higher-accuracy Japanese-optimized speech-to-text and translation. Downloads in the background — live-translate switches to high-quality mode automatically when ready."
+          status={download.status}
+          progress={download.progress}
+          isDownloading={download.status === 'downloading-tier2'}
+          isReady={download.tier2Ready}
+          error={download.error}
+        >
+          {download.tier2Ready && (
+            <p style={readyStyle}>
+              Full-quality models ready. live-translate will use them on the next session.
+            </p>
+          )}
+          {download.status === 'downloading-tier2' && !download.tier2Ready && (
+            <p style={hintStyle}>
+              Downloading in background… {download.progress}% complete. Translation keeps working with Quick Start.
+            </p>
+          )}
+          {!download.tier2Ready && download.status !== 'downloading-tier2' && (
+            <p style={hintStyle}>
+              Background download will start once Quick Start finishes. No action needed.
+            </p>
+          )}
+          <SkipButton onClick={() => advance('quality-upgrade')}>
+            Next: Optional cloud boost
+          </SkipButton>
+        </StepCard>
+      )}
+
+      {step === 'cloud-boost' && (
+        <StepCard
+          number={3}
+          title="Cloud Boost (Optional)"
+          subtitle={`Azure Translator free tier — ${AZURE_FREE_TIER_CHARS}`}
+          description="You're already translating offline. Adding a free Azure F0 key adds optional cloud-quality fallback for harder phrases. You can do this later in Translator Settings."
+        >
+          <ol style={instructionListStyle}>
+            <li>
+              Open the Azure portal: <a href={AZURE_TRANSLATOR_PORTAL_URL} target="_blank" rel="noreferrer noopener" style={linkStyle}>
+                Create Translator (F0 free tier)
+              </a>
+            </li>
+            <li>Select pricing tier <strong>F0</strong> ({AZURE_FREE_TIER_CHARS}, no card required).</li>
+            <li>Copy <strong>Key 1</strong> and the <strong>Region</strong> from Keys and Endpoint.</li>
+            <li>Paste them below and save — about 5 minutes total.</li>
+          </ol>
+
+          <label style={fieldLabelStyle} htmlFor="onboarding-azure-key">Azure Translator key</label>
+          <input
+            id="onboarding-azure-key"
+            type="password"
+            value={azureKey}
+            onChange={(e) => setAzureKey(e.target.value)}
+            placeholder="Paste Key 1 from the Azure portal"
+            aria-label="Azure Translator key"
+            style={inputStyle}
+            disabled={azureSaving}
+          />
+
+          <label style={fieldLabelStyle} htmlFor="onboarding-azure-region">Azure region</label>
+          <input
+            id="onboarding-azure-region"
+            type="text"
+            value={azureRegion}
+            onChange={(e) => setAzureRegion(e.target.value)}
+            placeholder="e.g. eastus, japaneast"
+            aria-label="Azure region"
+            style={inputStyle}
+            disabled={azureSaving}
+          />
+
+          {azureSaveError && (
+            <div role="alert" style={errorStyle}>{azureSaveError}</div>
+          )}
+
+          <PrimaryButton
+            onClick={handleSaveAzureKey}
+            disabled={azureSaving || !isAzureKeyValid(azureKey, azureRegion)}
+          >
+            {azureSaving ? 'Saving…' : 'Save Azure key & finish'}
+          </PrimaryButton>
+          <SkipButton onClick={() => advance('cloud-boost')}>
+            Skip — works great offline
+          </SkipButton>
+        </StepCard>
+      )}
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Subcomponents
+// ---------------------------------------------------------------------------
+
+function StepIndicator({ current }: { current: OnboardingStep }): React.JSX.Element {
+  const steps: { id: OnboardingStep; label: string }[] = [
+    { id: 'quick-start', label: '1. Quick Start' },
+    { id: 'quality-upgrade', label: '2. Quality' },
+    { id: 'cloud-boost', label: '3. Cloud (Optional)' }
+  ]
+  return (
+    <nav aria-label="Onboarding progress" style={indicatorWrapStyle}>
+      {steps.map((s) => {
+        const active = s.id === current
+        return (
+          <span
+            key={s.id}
+            style={{
+              ...indicatorPillStyle,
+              background: active ? '#1e3a8a' : '#1e293b',
+              color: active ? '#bfdbfe' : '#94a3b8',
+              borderColor: active ? '#3b82f6' : '#334155'
+            }}
+            aria-current={active ? 'step' : undefined}
+          >
+            {s.label}
+          </span>
+        )
+      })}
+    </nav>
+  )
+}
+
+interface StepCardProps {
+  number: number
+  title: string
+  subtitle: string
+  description: string
+  status?: DownloadStatus
+  progress?: number
+  isDownloading?: boolean
+  isReady?: boolean
+  error?: string
+  children: React.ReactNode
+}
+
+function StepCard(props: StepCardProps): React.JSX.Element {
+  const showProgress = props.isDownloading && typeof props.progress === 'number'
+  return (
+    <section style={cardStyle} aria-labelledby={`onboarding-step-${props.number}-title`}>
+      <div style={cardHeaderStyle}>
+        <span style={stepNumberStyle}>Step {props.number}</span>
+        <h3 id={`onboarding-step-${props.number}-title`} style={cardTitleStyle}>{props.title}</h3>
+      </div>
+      <p style={cardSubtitleStyle}>{props.subtitle}</p>
+      <p style={cardDescriptionStyle}>{props.description}</p>
+
+      {showProgress && (
+        <div style={progressTrackStyle} aria-hidden={false}>
+          <div
+            role="progressbar"
+            aria-label={`${props.title} download progress`}
+            aria-valuenow={props.progress}
+            aria-valuemin={0}
+            aria-valuemax={100}
+            style={{
+              ...progressFillStyle,
+              width: `${Math.max(props.progress ?? 0, 2)}%`
+            }}
+          />
+        </div>
+      )}
+
+      {props.error && (
+        <div role="alert" style={errorStyle}>{props.error}</div>
+      )}
+
+      <div style={actionsStyle}>{props.children}</div>
+    </section>
+  )
+}
+
+function PrimaryButton({
+  children,
+  onClick,
+  disabled
+}: {
+  children: React.ReactNode
+  onClick: () => void
+  disabled?: boolean
+}): React.JSX.Element {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={disabled}
+      style={{
+        ...primaryButtonStyle,
+        opacity: disabled ? 0.6 : 1,
+        cursor: disabled ? 'not-allowed' : 'pointer'
+      }}
+    >
+      {children}
+    </button>
+  )
+}
+
+function SkipButton({
+  children,
+  onClick
+}: {
+  children: React.ReactNode
+  onClick: () => void
+}): React.JSX.Element {
+  return (
+    <button type="button" onClick={onClick} style={skipButtonStyle}>
+      {children}
+    </button>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Styles (kept inline to match existing settings panel conventions)
+// ---------------------------------------------------------------------------
+
+const shellStyle: React.CSSProperties = {
+  padding: '1.5rem',
+  fontFamily: '-apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif',
+  color: '#e2e8f0',
+  background: '#0f172a',
+  minHeight: '100%',
+  fontSize: '0.875rem'
+}
+
+const headerStyle: React.CSSProperties = {
+  marginBottom: '20px'
+}
+
+const titleStyle: React.CSSProperties = {
+  fontSize: '20px',
+  fontWeight: 700,
+  color: '#f8fafc',
+  margin: '0 0 6px 0',
+  letterSpacing: '-0.02em'
+}
+
+const subtitleStyle: React.CSSProperties = {
+  fontSize: '13px',
+  color: '#94a3b8',
+  lineHeight: 1.5,
+  marginBottom: '14px'
+}
+
+const indicatorWrapStyle: React.CSSProperties = {
+  display: 'flex',
+  gap: '8px',
+  flexWrap: 'wrap'
+}
+
+const indicatorPillStyle: React.CSSProperties = {
+  display: 'inline-block',
+  padding: '4px 10px',
+  fontSize: '11px',
+  fontWeight: 600,
+  borderRadius: '999px',
+  border: '1px solid #334155'
+}
+
+const cardStyle: React.CSSProperties = {
+  background: '#1e293b',
+  border: '1px solid #334155',
+  borderRadius: '10px',
+  padding: '18px 20px'
+}
+
+const cardHeaderStyle: React.CSSProperties = {
+  display: 'flex',
+  alignItems: 'baseline',
+  gap: '10px',
+  marginBottom: '6px'
+}
+
+const stepNumberStyle: React.CSSProperties = {
+  fontSize: '10px',
+  fontWeight: 700,
+  letterSpacing: '0.08em',
+  textTransform: 'uppercase',
+  color: '#60a5fa'
+}
+
+const cardTitleStyle: React.CSSProperties = {
+  fontSize: '17px',
+  fontWeight: 700,
+  color: '#f8fafc',
+  margin: 0
+}
+
+const cardSubtitleStyle: React.CSSProperties = {
+  fontSize: '12px',
+  color: '#cbd5f5',
+  marginTop: '4px',
+  marginBottom: '8px',
+  fontWeight: 500
+}
+
+const cardDescriptionStyle: React.CSSProperties = {
+  fontSize: '13px',
+  color: '#94a3b8',
+  lineHeight: 1.5,
+  marginBottom: '14px'
+}
+
+const progressTrackStyle: React.CSSProperties = {
+  width: '100%',
+  height: '6px',
+  background: '#0f172a',
+  borderRadius: '3px',
+  overflow: 'hidden',
+  marginBottom: '12px'
+}
+
+const progressFillStyle: React.CSSProperties = {
+  height: '100%',
+  background: '#3b82f6',
+  borderRadius: '3px',
+  transition: 'width 0.3s ease'
+}
+
+const actionsStyle: React.CSSProperties = {
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '8px'
+}
+
+const primaryButtonStyle: React.CSSProperties = {
+  width: '100%',
+  padding: '10px 14px',
+  fontSize: '13px',
+  fontWeight: 600,
+  border: 'none',
+  borderRadius: '8px',
+  background: '#3b82f6',
+  color: '#fff'
+}
+
+const skipButtonStyle: React.CSSProperties = {
+  width: '100%',
+  padding: '8px 14px',
+  fontSize: '12px',
+  fontWeight: 500,
+  border: '1px solid #334155',
+  borderRadius: '8px',
+  background: 'transparent',
+  color: '#94a3b8',
+  cursor: 'pointer'
+}
+
+const hintStyle: React.CSSProperties = {
+  fontSize: '12px',
+  color: '#94a3b8',
+  margin: '0 0 4px 0'
+}
+
+const readyStyle: React.CSSProperties = {
+  fontSize: '13px',
+  fontWeight: 600,
+  color: '#4ade80',
+  margin: '0 0 6px 0'
+}
+
+const instructionListStyle: React.CSSProperties = {
+  margin: '0 0 14px 0',
+  paddingLeft: '20px',
+  fontSize: '12px',
+  color: '#cbd5f5',
+  lineHeight: 1.6
+}
+
+const linkStyle: React.CSSProperties = {
+  color: '#60a5fa',
+  textDecoration: 'underline'
+}
+
+const fieldLabelStyle: React.CSSProperties = {
+  display: 'block',
+  fontSize: '11px',
+  color: '#94a3b8',
+  marginTop: '8px',
+  marginBottom: '4px'
+}
+
+const inputStyle: React.CSSProperties = {
+  width: '100%',
+  padding: '8px 12px',
+  fontSize: '13px',
+  background: '#0f172a',
+  color: '#e2e8f0',
+  border: '1px solid #334155',
+  borderRadius: '6px',
+  fontFamily: 'monospace'
+}
+
+const errorStyle: React.CSSProperties = {
+  background: '#7f1d1d',
+  color: '#fee2e2',
+  padding: '8px 12px',
+  borderRadius: '6px',
+  fontSize: '12px',
+  marginBottom: '10px'
+}
+
+export default Onboarding

--- a/src/renderer/components/SettingsPanel.tsx
+++ b/src/renderer/components/SettingsPanel.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react'
 import { useSettingsState } from '../hooks/useSettingsState'
+import { Onboarding } from './Onboarding'
 import {
   AudioSettings,
   LanguageSettings,
@@ -12,7 +13,6 @@ import {
   UpdateStatus,
   CrashRecoveryBanner,
   ConfigSummary,
-  QuickStartPanel,
   EnterpriseSettings,
   KeyboardShortcuts,
   AccessibilitySettings,
@@ -25,16 +25,16 @@ function SettingsPanel(): React.JSX.Element {
   const s = useSettingsState()
   const disabled = s.isRunning || s.isStarting
 
-  const [showQuickStart, setShowQuickStart] = useState(false)
-  const [quickStartChecked, setQuickStartChecked] = useState(false)
+  const [showOnboarding, setShowOnboarding] = useState(false)
+  const [onboardingChecked, setOnboardingChecked] = useState(false)
 
-  // Check if Quick Start should be shown on mount
+  // Decide whether to show the first-run Onboarding (#708)
   useEffect(() => {
     window.api.quickStartIsCompleted().then((completed) => {
-      setShowQuickStart(!completed)
-      setQuickStartChecked(true)
+      setShowOnboarding(!completed)
+      setOnboardingChecked(true)
     }).catch(() => {
-      setQuickStartChecked(true)
+      setOnboardingChecked(true)
     })
   }, [])
 
@@ -57,16 +57,16 @@ function SettingsPanel(): React.JSX.Element {
     }
   }, [s.isRunning, s.isStarting, s.handleStart, s.handleStop])
 
-  // Show nothing until we know whether to show Quick Start
-  if (!quickStartChecked) {
+  // Show nothing until we know whether to show Onboarding
+  if (!onboardingChecked) {
     return <div style={containerStyle} />
   }
 
-  // Show Quick Start panel for first-time users
-  if (showQuickStart) {
+  // Show the three-step onboarding for first-time users (#708)
+  if (showOnboarding) {
     return (
       <div style={containerStyle}>
-        <QuickStartPanel onSetupComplete={() => setShowQuickStart(false)} />
+        <Onboarding onComplete={() => setShowOnboarding(false)} />
       </div>
     )
   }

--- a/src/renderer/components/onboarding-steps.test.ts
+++ b/src/renderer/components/onboarding-steps.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect } from 'vitest'
+import {
+  pickInitialStep,
+  nextStep,
+  isAzureKeyValid,
+  formatSize,
+  AZURE_TRANSLATOR_PORTAL_URL,
+  AZURE_FREE_TIER_CHARS,
+  TIER1_TOTAL_MB,
+  TIER2_TOTAL_MB
+} from './onboarding-steps'
+
+describe('Onboarding step constants (#708)', () => {
+  it('exposes the official Azure Translator portal "create" deep link', () => {
+    expect(AZURE_TRANSLATOR_PORTAL_URL).toBe(
+      'https://portal.azure.com/#create/Microsoft.CognitiveServicesTextTranslation'
+    )
+  })
+
+  it('advertises the Azure F0 free tier quota', () => {
+    expect(AZURE_FREE_TIER_CHARS).toBe('2M chars/month')
+  })
+
+  it('declares Tier 1 ~371MB and Tier 2 ~1.6GB to match onboarding-downloader.ts', () => {
+    expect(TIER1_TOTAL_MB).toBe(371)
+    expect(TIER2_TOTAL_MB).toBeGreaterThan(1500)
+    expect(TIER2_TOTAL_MB).toBeLessThan(1800)
+  })
+})
+
+describe('pickInitialStep (#708)', () => {
+  it('starts at quick-start when no models are downloaded yet', () => {
+    expect(
+      pickInitialStep({ tier1Ready: false, tier2Ready: false, status: 'idle' })
+    ).toBe('quick-start')
+  })
+
+  it('starts at quality-upgrade when Tier 1 is ready but Tier 2 is not', () => {
+    expect(
+      pickInitialStep({ tier1Ready: true, tier2Ready: false, status: 'downloading-tier2' })
+    ).toBe('quality-upgrade')
+  })
+
+  it('starts at cloud-boost when both tiers are ready', () => {
+    expect(
+      pickInitialStep({ tier1Ready: true, tier2Ready: true, status: 'all-ready' })
+    ).toBe('cloud-boost')
+  })
+
+  it('treats failed downloads with no Tier 1 as a fresh start', () => {
+    expect(
+      pickInitialStep({ tier1Ready: false, tier2Ready: false, status: 'failed' })
+    ).toBe('quick-start')
+  })
+})
+
+describe('nextStep (#708)', () => {
+  it('advances quick-start → quality-upgrade', () => {
+    expect(nextStep('quick-start')).toBe('quality-upgrade')
+  })
+
+  it('advances quality-upgrade → cloud-boost', () => {
+    expect(nextStep('quality-upgrade')).toBe('cloud-boost')
+  })
+
+  it('cloud-boost is the terminal step', () => {
+    expect(nextStep('cloud-boost')).toBe('done')
+  })
+
+  it('done stays done (idempotent)', () => {
+    expect(nextStep('done')).toBe('done')
+  })
+})
+
+describe('isAzureKeyValid (#708)', () => {
+  it('requires both key and region to be non-empty', () => {
+    expect(isAzureKeyValid('abc123', 'eastus')).toBe(true)
+  })
+
+  it('rejects a missing key', () => {
+    expect(isAzureKeyValid('', 'eastus')).toBe(false)
+  })
+
+  it('rejects a missing region', () => {
+    expect(isAzureKeyValid('abc123', '')).toBe(false)
+  })
+
+  it('treats whitespace-only values as missing', () => {
+    expect(isAzureKeyValid('   ', 'eastus')).toBe(false)
+    expect(isAzureKeyValid('abc123', '  ')).toBe(false)
+  })
+})
+
+describe('formatSize (#708)', () => {
+  it('renders sub-gigabyte values as MB', () => {
+    expect(formatSize(371)).toBe('371MB')
+  })
+
+  it('renders gigabyte values with one decimal place', () => {
+    expect(formatSize(1640)).toBe('1.6GB')
+  })
+
+  it('renders large gigabyte values without decimals', () => {
+    expect(formatSize(10240)).toBe('10GB')
+  })
+})

--- a/src/renderer/components/onboarding-steps.ts
+++ b/src/renderer/components/onboarding-steps.ts
@@ -1,0 +1,83 @@
+// Pure-logic helpers for the Onboarding 3-step flow.
+// Kept React/DOM-free so they can be unit-tested under the
+// `node` Vitest environment configured in vitest.config.ts.
+
+/** The three onboarding steps shown to the user. */
+export type OnboardingStep = 'quick-start' | 'quality-upgrade' | 'cloud-boost' | 'done'
+
+/** Direct Azure portal link to create a Translator (Cognitive Services) resource.
+ *  Surfacing this link satisfies the issue requirement that users can reach the
+ *  F0 free tier (2M chars/month) in ~5 minutes. */
+export const AZURE_TRANSLATOR_PORTAL_URL =
+  'https://portal.azure.com/#create/Microsoft.CognitiveServicesTextTranslation'
+
+/** Step 1 totals: Whisper Base (142MB) + LFM2 350M Q4_K_M (~229MB) ≈ 371MB. */
+export const TIER1_TOTAL_MB = 371
+
+/** Step 2 totals: Kotoba Whisper v2.0 (~540MB) + HY-MT1.5 1.8B Q4_K_M (~1.1GB) ≈ 1.6GB. */
+export const TIER2_TOTAL_MB = 1640
+
+/** Azure Translator F0 free tier quota — surfaced as user-facing copy. */
+export const AZURE_FREE_TIER_CHARS = '2M chars/month'
+
+/** Tier-aware download status string from the main process (onboarding-downloader.ts). */
+export type DownloadStatus =
+  | 'idle'
+  | 'downloading-tier1'
+  | 'tier1-ready'
+  | 'downloading-tier2'
+  | 'all-ready'
+  | 'failed'
+
+export interface StepDecisionInput {
+  tier1Ready: boolean
+  tier2Ready: boolean
+  status: DownloadStatus
+}
+
+/**
+ * Pick the initial step on mount based on persisted download state.
+ *
+ * Rules:
+ *  - Neither tier ready → start at Quick Start (Step 1)
+ *  - Only Tier 1 ready → start at Quality Upgrade (Step 2) — let user see the
+ *    background download or skip ahead
+ *  - Both tiers ready → start at Cloud Boost (Step 3, optional Azure key)
+ */
+export function pickInitialStep(input: StepDecisionInput): OnboardingStep {
+  if (input.tier1Ready && input.tier2Ready) return 'cloud-boost'
+  if (input.tier1Ready) return 'quality-upgrade'
+  return 'quick-start'
+}
+
+/** Compute the next step when the user clicks "Next" / "Skip" on a given step. */
+export function nextStep(current: OnboardingStep): OnboardingStep {
+  switch (current) {
+    case 'quick-start':
+      return 'quality-upgrade'
+    case 'quality-upgrade':
+      return 'cloud-boost'
+    case 'cloud-boost':
+    case 'done':
+      return 'done'
+  }
+}
+
+/**
+ * Azure Translator credentials are only useful when both the key and region
+ * are provided (region defaults to "global" but the Azure resource always
+ * pairs a key with a region). Treat empty string and whitespace as missing.
+ */
+export function isAzureKeyValid(microsoftApiKey: string, microsoftRegion: string): boolean {
+  return microsoftApiKey.trim().length > 0 && microsoftRegion.trim().length > 0
+}
+
+/** Format an MB count for user-visible labels (e.g. 371MB, 1.6GB). */
+export function formatSize(mb: number): string {
+  if (mb >= 1024) {
+    const gb = mb / 1024
+    // 1 decimal place when value is not an integer GB
+    return `${gb.toFixed(gb >= 10 ? 0 : 1)}GB`
+  }
+  return `${Math.round(mb)}MB`
+}


### PR DESCRIPTION
## Description

Implements the three-step first-run onboarding flow described in #708:

1. **Step 1 — Quick Start** — Whisper Base + LFM2 350M (~371MB) for an instant offline start. Triggers `onboardingStartDownload`, which cascades into Tier 2 in the background.
2. **Step 2 — Quality Upgrade (background)** — Kotoba Whisper + HY-MT1.5 1.8B (~1.6GB). Surfaces the live progress bar from `onOnboardingDownloadProgress` and confirms when full-quality models are ready so live-translate auto-switches on the next session.
3. **Step 3 — Cloud Boost (Optional)** — Surfaces the Azure Translator F0 free tier (2M chars/month) with a direct deep link to the portal Create page (`portal.azure.com/#create/Microsoft.CognitiveServicesTextTranslation`). Fully skippable; the form persists `microsoftApiKey` + `microsoftRegion` via `saveSettings` when filled.

Every step has an explicit Skip button. Step 3 always renders a "Skip — works great offline" path so users can finish onboarding without any API key.

### Files

- `src/renderer/components/Onboarding.tsx` — new 3-step wizard component
- `src/renderer/components/onboarding-steps.ts` — pure-logic helpers (step state machine, Azure portal URL, tier size constants, validation, formatting) kept React/DOM-free so they run under the existing `node` Vitest environment
- `src/renderer/components/onboarding-steps.test.ts` — 18 unit tests covering step transitions, Azure key validation, size formatting and constants
- `src/renderer/components/SettingsPanel.tsx` — first-run experience now renders `<Onboarding>` instead of `<QuickStartPanel>`; the old QuickStartPanel module is left intact in case other entry points reach for it later

### Notes for reviewers

- Tier sizes (`TIER1_TOTAL_MB=371`, `TIER2_TOTAL_MB=1640`) intentionally mirror the math in `src/main/onboarding-downloader.ts` (Whisper Base 142MB + LFM2 Q4_K_M 229MB / Kotoba v2.0 ~540MB + HY-MT1.5 Q4_K_M ~1.1GB).
- Azure portal deep link matches the issue spec verbatim.
- Pre-existing test failures in `src/main/virtual-mic-manager.test.ts` are unrelated (naudiodon native dep missing in CI sandbox); confirmed identical pass/fail counts with the change stashed.

## Related Issue
Closes #708