### PR TITLE
#707 README/docs overhaul: Why/Comparison/Differentiating + cloud-boost + glossary

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,11 +24,46 @@ Bidirectional JA↔EN translation with transparent subtitles overlaid on any dis
 └────────────────────────────────────────┘
 ```
 
+## Why live-translate?
+
+- **Free** — MIT-licensed, no subscription, no per-seat pricing. Bring your own (optional) cloud key.
+- **Local-first** — Default pipeline runs entirely offline. Audio never leaves your machine unless you opt in to a cloud translator.
+- **Optional Cloud Boost** — Plug in one Azure F0 key (2M chars/month free) and the rotation controller transparently flips to cloud quality when online, then falls back to the local engine when the quota is exhausted or the network drops.
+- **JA↔EN focused** — Tuned for Japanese↔English meeting subtitles. We do not chase 40+ languages; instead we optimize the two we ship.
+- **MIT, not AGPL** — Safe to use inside closed-source corporate environments without copyleft contamination.
+
+See [docs/cloud-boost.md](docs/cloud-boost.md) for the Azure F0 setup that we recommend, and [docs/glossary.md](docs/glossary.md) for the term-dictionary feature.
+
+## Comparison with alternatives
+
+| Capability | live-translate | [Sokuji](https://github.com/kizuna-ai-lab/sokuji) | [Felo Subtitles](https://felo.ai/) | [DeepL Voice](https://www.deepl.com/en/products/voice) |
+|---|---|---|---|---|
+| License | **MIT** | AGPL-3.0 | Commercial / proprietary | Commercial / proprietary |
+| Pricing | Free | Free (self-host) | Freemium (paid tiers) | Enterprise (≥50 seats) |
+| Offline mode | **Yes (default)** | Partial (depends on provider) | No (cloud-only) | No (cloud-only) |
+| JA↔EN focus | **Yes — tuned default** | No — 100+ languages, generalist | No — multilingual generalist | Yes (curated language pairs) |
+| Recommended cloud | Azure F0 (1 key, 2M chars/mo) | 7 AI providers — bring your own | Hosted (no key needed) | DeepL hosted |
+| Quota tracking & rotation | **Built in (#703)** | Manual per-provider | N/A (hosted) | N/A (hosted) |
+| Glossary (CSV/JSON) | **Yes — personal + org** | No | No | Glossary (paid) |
+| Speaker labels | **Yes (FluidAudio, macOS)** | No | No | No |
+| Transparent overlay | **Yes (any display)** | App window | Browser extension only | App / meeting plugins |
+| Closed-source environment safe | **Yes (MIT)** | Caution (AGPL copyleft) | Yes (commercial) | Yes (commercial) |
+
+In short: Sokuji is the right pick if you need 40+ languages and don't mind AGPL; Felo and DeepL Voice are the right pick if you want a hosted subscription. live-translate is the right pick if you want a free, MIT-licensed, JA↔EN-tuned overlay that runs offline by default and only optionally borrows a free Azure key.
+
+## Differentiating features
+
+- **Glossary (CSV / JSON)** — Personal and organization-wide term dictionaries. Drop a CSV with `source,target` rows and brand names, product names, and acronyms stay consistent across every translation. Organization terms override personal terms on conflict. Details: [docs/glossary.md](docs/glossary.md).
+- **Speaker labels (macOS)** — On-device speaker diarization via FluidAudio (CoreML). Each speaker gets a color-coded label on the overlay; ~32 MB of models, ~40 μs per chunk on Apple Silicon, no audio leaves the device.
+- **API rotation with quota tracking** — `ApiRotationController` cycles through Azure → Google → DeepL → Gemini, persists monthly character counts, classifies 429 rate-limits separately from quota exhaustion, and falls back to the local engine when every cloud provider is out (#703).
+- **Azure F0 single-provider recommendation** — Rather than asking every user to register four cloud accounts, we recommend the Azure Translator F0 tier (2M chars / month, one key) as the single optional boost. See [docs/cloud-boost.md](docs/cloud-boost.md) for the 5-minute walkthrough.
+- **MDM-managed enterprise keys** — For organizations, a Microsoft Translator key + region can be pushed via macOS managed preferences (#704); users never touch the key. See [docs/mdm-config.md](docs/mdm-config.md).
+
 ## Features
 
 - **Real-time translation** — Whisper STT + pluggable translation engines
-- **Local-first** — Runs entirely offline with OPUS-MT (279ms) or Hunyuan-MT 7B (quality mode)
-- **API rotation** — Combine free tiers of Google, DeepL, and Gemini (4M+ chars/month)
+- **Local-first** — Runs entirely offline with HY-MT1.5 1.8B (~180ms default), OPUS-MT (legacy fallback), or Hunyuan-MT 7B (quality mode)
+- **API rotation** — Combine free tiers of Azure, Google, DeepL, and Gemini (4M+ chars/month)
 - **Subtitle overlay** — Transparent, always-on-top subtitles on any display
 - **Customizable subtitles** — Font size, colors, opacity, position
 - **Translation cache** — LRU cache for repeated phrases, instant re-translation
@@ -51,6 +86,18 @@ npm install
 npm run dev
 ```
 
+The default pipeline is fully offline — no keys, no signup. The first launch will download a Whisper STT model (~540 MB) and the HY-MT1.5 1.8B translator (~1 GB).
+
+### Optional: add an Azure F0 key for cloud-quality translation
+
+The Azure Translator **F0 (free) tier** gives you 2 million characters / month at no cost. One key is enough to make cloud translation the primary path while the local engine waits in the background as a fallback.
+
+1. Create an Azure Translator resource on the **F0** pricing tier — see [docs/cloud-boost.md](docs/cloud-boost.md) for the 5-minute walkthrough.
+2. In Settings → Translator, paste the key and region (e.g. `japaneast`).
+3. Live Translate will route through Azure first, drop back to the offline engine automatically when the monthly quota is reached, and resume cloud usage at the start of the next month.
+
+You can stack additional Google / DeepL / Gemini keys for ~4M+ characters/month combined, but a single Azure F0 key is the recommended starting point.
+
 ## Build & Distribute
 
 ```bash
@@ -70,7 +117,7 @@ npm run test         # Run unit tests
 
 - macOS 13+ (Apple Silicon recommended) or Windows 10+ (CUDA recommended for GPU acceleration)
 - Node.js 20+
-- For online engines: API key(s) from Google / DeepL / Gemini
+- For online engines: API key(s) from Azure / Google / DeepL / Gemini
 
 ## STT Engines
 
@@ -99,11 +146,16 @@ Removed: Lightning Whisper MLX (JA CER 162%), Moonshine base (JA CER 221%)
 
 | Engine | JA→EN | EN→JA | Memory | Offline | Free Tier |
 |--------|-------|-------|--------|---------|-----------|
-| **OPUS-MT** (fast default) | 279ms | 462ms | 0.98GB | Yes | Unlimited |
+| **HY-MT1.5 1.8B** (fast default) | ~180ms | ~180ms | ~1GB | Yes | Unlimited |
+| **LFM2** (ultra-fast) | Fast | Fast | ~230MB | Yes | Unlimited |
 | **Hunyuan-MT 7B** (quality) | 3.7s | 6.3s | 4GB | Yes | Unlimited |
-| **Google Translate** | Fast | Fast | — | No | 500K chars/month |
+| **Azure Translator** (cloud boost) | Fast | Fast | — | No | **2M chars/month (F0)** |
+| **Google Translate** | Fast | Fast | — | No | 480K chars/month |
 | **DeepL** | Fast | Fast | — | No | 500K chars/month |
 | **Gemini 2.5 Flash** | Fast | Fast | — | No | Generous |
+| **OPUS-MT** (legacy fallback) | 279ms | 462ms | 0.98GB | Yes | Unlimited |
+
+> Conversational JA↔EN quality is benchmarked under [`benchmark/conversational-ja-en/`](benchmark/conversational-ja-en/) using **chrF** as a tractable stand-in for COMET-22 (the official Unbabel reference is PyTorch-only today). The chrF numbers will be swapped for COMET-22 scores once a stable Node.js ONNX inference path lands — see [#706](https://github.com/rioX432/live-translate/issues/706).
 
 <details>
 <summary>Experimental translation engines (hidden from UI)</summary>
@@ -111,11 +163,11 @@ Removed: Lightning Whisper MLX (JA CER 162%), Moonshine base (JA CER 221%)
 | Engine | Notes |
 |--------|-------|
 | TranslateGemma | 8s/sentence — too slow for real-time |
-| HY-MT1.5 | Speculative decoding with LFM2 draft model |
 | PLaMo | Under evaluation |
 | CT2 OPUS-MT | CTranslate2 variant |
 | CT2 Madlad-400 | CTranslate2, 450+ languages |
 | ANE | Apple Neural Engine backend |
+| Hybrid | Two-stage: OPUS-MT draft + LLM refinement |
 
 Removed: ALMA-Ja, Gemma-2-JPN
 </details>
@@ -163,9 +215,17 @@ export class MyTranslator implements TranslatorEngine {
 - **Build**: electron-vite
 - **STT**: whisper.cpp (native), MLX Whisper (Apple Silicon), Apple SpeechTranscriber (macOS 26+)
 - **VAD**: Silero VAD (@ricky0123/vad-web)
-- **Translation**: OPUS-MT (fast), Hunyuan-MT 7B (quality), HY-MT1.5 (speculative decoding), Google, DeepL, Gemini
+- **Translation**: HY-MT1.5 1.8B (fast default), LFM2 (ultra-fast), Hunyuan-MT 7B (quality), OPUS-MT (legacy fallback), Azure, Google, DeepL, Gemini
 - **LLM**: node-llama-cpp (meeting summaries, context-aware translation)
 - **Testing**: Vitest
+
+## Further reading
+
+- [docs/cloud-boost.md](docs/cloud-boost.md) — Azure F0 key acquisition and ApiRotation setup
+- [docs/glossary.md](docs/glossary.md) — Personal and organization glossary usage
+- [docs/mdm-config.md](docs/mdm-config.md) — Enterprise MDM-managed configuration
+- [docs/RESEARCH.md](docs/RESEARCH.md) — Market and technology research
+- [benchmark/conversational-ja-en/README.md](benchmark/conversational-ja-en/README.md) — Conversational JA↔EN benchmark
 
 ## License
 

--- a/docs/RESEARCH.md
+++ b/docs/RESEARCH.md
@@ -1,248 +1,257 @@
-# リアルタイム同時翻訳ツール 技術調査レポート
+# Real-time translation tool — technology & market research
 
-調査日: 2026-03-16
+Updated: 2026-06
 
-## 目的
+## Purpose
 
-多言語環境でのプレゼンテーション中に、Mac拡張ディスプレイ上でリアルタイム字幕翻訳を表示する。日本語↔英語の自動切替が必要。文字起こしログも残したい。
+Display real-time bidirectional Japanese↔English subtitles on a Mac extended
+display during presentations, so the audience can follow regardless of which
+language the speaker is using. Transcript logging is required. The tool must
+run on a personal laptop, not a corporate seat license.
 
-## 要件
+## Requirements
 
-- 日本語↔英語のリアルタイム翻訳（レイテンシ2秒以内）
-- 言語の自動検出・自動切替（話者が変わっても対応）
-- Mac拡張ディスプレイ上でスライドに重ねて字幕表示
-- 翻訳精度が高い（ビジネス会議レベル）
-- 文字起こしログ保存
-- なるべくコストをかけない
-
----
-
-## 1. 既存ツール比較
-
-### ビデオ会議プラットフォーム
-
-| ツール | 翻訳機能 | 日本語対応 | 料金 | 備考 |
-|---|---|---|---|---|
-| Google Meet 字幕翻訳 | 69言語字幕翻訳 | ○ | Business Standard以上 + Geminiアドオン | 2025/1以降Gemini必須 |
-| Google Meet 音声翻訳 | 6言語音声翻訳 | ✗ | Business Plus以上 | 日本語未対応 |
-| MS Teams AI Interpreter | 9言語音声同時通訳 | ○ | Copilot($4,500/月/人) | 高額 |
-| Zoom 翻訳字幕 | 35言語字幕 | ○ | 月750円オプション | 安い |
-
-### 専用翻訳ツール
-
-| ツール | 料金 | 日本語 | 特徴 |
-|---|---|---|---|
-| Sentio (ポケトーク) | 月3,300円/500人 | ○ | コスパ最強、無料枠30分/月 |
-| VoicePing | 無料〜月20,000円 | ○ | 日本製、Whisper V2ベース |
-| DeepL Voice | 最低50ライセンス | ○ | 翻訳精度最高、中小には敷居高い |
-| Felo Subtitles (Chrome拡張) | 無料あり | ○ | 即効策として有効 |
-
-### Chrome拡張（Google Meet向け）
-
-| 拡張 | 特徴 | リスク |
-|---|---|---|
-| Felo Subtitles | リアルタイム翻訳、無料 | DOMスクレイピング、UI変更で壊れる |
-| JotMe | 77言語、議事録生成 | 同上 |
-| ELI | 無制限無料 | Google Meet専用 |
+- Bidirectional Japanese↔English translation (end-to-end latency target: <2s)
+- Automatic language detection / switching as speakers alternate
+- Transparent subtitle overlay on a Mac extended display (over slides)
+- Business-meeting quality translation
+- Transcript saved locally
+- Minimal cost (ideally free)
 
 ---
 
-## 2. 音声認識 (STT) 技術比較
+## Why this project (positioning vs. the 2026 alternatives)
 
-### クラウドAPI
-
-| サービス | レイテンシ | 日本語精度 | 料金(/分) | ストリーミング | コードスイッチング |
+| Project / product | License | Cost | Focus | Offline default | Why we still ship our own |
 |---|---|---|---|---|---|
-| Google Cloud STT | ~300ms | 高 (CER 2.7%) | $0.024 | ○ | 最大3言語指定 |
-| Deepgram Nova-3 | <300ms | 中〜高 | $0.0043 | ○ | **10言語ネイティブ対応** |
-| Azure Speech | ~300ms | 高 | $0.017 | ○ | △ |
-| OpenAI Whisper API | バッチのみ | 高 | $0.006 | ✗ | ✗ |
+| **[Sokuji](https://github.com/kizuna-ai-lab/sokuji)** | AGPL-3.0 | Free (self-host) | 40+ languages, 7 AI providers | Partial (provider-dependent) | AGPL copyleft is a non-starter for some closed-source corporate users; UX is generalist, not JA↔EN-tuned. |
+| **[Felo Subtitles](https://felo.ai/)** | Commercial | Freemium / subscription | Browser extension, hosted | No (cloud-only) | Cloud-only; sends audio to a third party; pricing scales per user. |
+| **[DeepL Voice](https://www.deepl.com/en/products/voice)** | Commercial | Enterprise (≥50 seats) | Curated language pairs, hosted | No (cloud-only) | Seat-license minimum locks out individuals and small teams. |
+| **live-translate (this project)** | **MIT** | **Free** | **JA↔EN, overlay-first** | **Yes (default)** | Free, MIT, runs offline by default, with an *optional* Azure F0 cloud boost on top. |
 
-### ローカルモデル
+The differentiator is **(MIT) × (local-first) × (JA↔EN tuned)**. We do not
+chase the multilingual frontier; we chase the two languages our core users
+actually speak and let the cloud be an opt-in accelerator.
 
-| モデル | 速度 | 日本語精度 | コスト | 備考 |
+---
+
+## 1. Existing tools (2026-06 snapshot)
+
+### Video-conferencing platforms
+
+| Tool | Translation feature | Japanese | Price | Notes |
 |---|---|---|---|---|
-| **Kotoba-Whisper v2.0** | large-v3の6.3倍速 | 最高（日本語特化） | ¥0 | 英語混在は非対応 |
-| **Lightning Whisper MLX** | whisper.cppの10倍速 | 高 | ¥0 | Apple Silicon最適化 |
-| Whisper large-v3-turbo | large-v3の2倍速 | 高（v2同等） | ¥0 | 809Mパラメータ |
-| whisper.cpp (medium) | ~2秒/チャンク | 90%以上 | ¥0 | Metal対応 |
-| **VoicePing whisper-ja-en** | large-v3の4倍速 | 高 | ¥0 | **日英双方向翻訳内蔵** |
+| Google Meet caption translation | 69-language caption translation | Yes | Business Standard+ with Gemini add-on | Gemini add-on required since 2025-01 |
+| Google Meet voice translation | 6-language voice translation | No | Business Plus+ | Japanese still unsupported |
+| MS Teams AI Interpreter | 9-language simultaneous voice interpretation | Yes | Copilot (≈¥4,500/user/month) | Costly per seat |
+| Zoom translated captions | 35-language captions | Yes | ~¥750/user/month add-on | Cheapest of the platform options |
 
-### Web Speech API（不採用）
+### Dedicated translation tools
 
-- 60秒タイムアウト、無音7秒で停止
-- 先行事例が「barely working」
-- 音声がGoogleに送信（プライバシー懸念）
-- プロダクション利用には不安定
-
----
-
-## 3. 翻訳技術比較
-
-### 翻訳API
-
-| サービス | 日英品質 | 短文精度 | レイテンシ | 無料枠 | リアルタイム適性 |
-|---|---|---|---|---|---|
-| **Google Translation** | 高い | **良好** | 100-300ms | 月50万文字 | ★★★ |
-| DeepL API | 最高 | やや弱い | ms | 月50万文字(600文字/分制限) | ★★☆ |
-| GPT-4o | 最高 | 良好 | 秒 | なし | ★☆☆ |
-| Claude | 最高(WMT24) | 良好 | 秒 | なし | ★☆☆ |
-
-**重要**: リアルタイム翻訳は短文を連続で翻訳するため、**短文精度とレイテンシ**が重要。DeepLは長文向けに最適化されており短文で誤訳が出やすい。Google Translationのほうがリアルタイム用途に適している。
-
-### ローカル翻訳モデル
-
-| モデル | 品質 | コスト | 備考 |
+| Tool | Price | Japanese | Notes |
 |---|---|---|---|
-| M2M100 | 中 | ¥0 | LocalVocalが採用、MIT |
-| OPUS-MT | 中 | ¥0 | CTranslate2で高速化可能 |
-| LibreTranslate | 低〜中 | ¥0 | プロ用途には不十分 |
-| **VoicePing whisper-ja-en** | 高 | ¥0 | STTと翻訳が一体 |
+| Sentio (Pocketalk) | ~¥3,300/month for 500 users | Yes | Best price/performance, free 30 min/month tier |
+| VoicePing | Free → ¥20,000/month | Yes | Japanese vendor, Whisper V2-based |
+| DeepL Voice | ≥50 seats | Yes | Top translation quality, enterprise-only |
+| Felo Subtitles (Chrome ext.) | Free / paid tiers | Yes | Hosted; useful for quick demos |
 
----
+### Chrome extensions (Google Meet)
 
-## 4. 日本語↔英語の自動言語切替
-
-### 方式比較
-
-| 方式 | 仕組み | 精度 | コスト |
-|---|---|---|---|
-| **VoicePing whisper-ja-en** | VAD分割→言語検出→双方向翻訳 | 高 | ¥0 |
-| **Deepgram Nova-3 multi** | 統一マルチリンガルモデル | 最高 | $26/月 |
-| Whisper VAD分割方式 | セグメント毎にdetect_language() | 中 | ¥0 |
-| Google STT multi | 最大3言語指定 | 中〜高 | 有料 |
-
-### Whisperの言語検出の制限
-
-- 最初の30秒で言語判定、セグメント単位の切替は標準機能にない
-- Kotoba-Whisperは日本語特化で英語が破綻する
-- ワークアラウンド: VADで分割→各セグメントでdetect_language()→言語指定で書き起こし
-
----
-
-## 5. Mac字幕オーバーレイ表示
-
-### ユースケース
-
-```
-発表者のMac → HDMI/拡張ディスプレイ → プロジェクター
-メインディスプレイ: 発表者操作用
-拡張ディスプレイ: スライド + 字幕オーバーレイ（聴衆向け）
-```
-
-### 方式
-
-| 方式 | 透過ウィンドウ | 安定性 | 開発工数 |
-|---|---|---|---|
-| **Electron** | ○ (transparent+frameless) | 高 | 低 |
-| SwiftUI + AppKit | ○ | 最高 | 中 |
-| Tauri v2 | △（バグ報告あり） | 中 | 低 |
-
-### 参考OSS
-
-| プロジェクト | 概要 | 技術 |
+| Extension | Notes | Risk |
 |---|---|---|
-| **[Sokuji](https://github.com/kizuna-ai-lab/sokuji)** | 最も完成度の高いElectron翻訳アプリ | Electron+React, 7AIプロバイダ |
-| [electron-speech-to-speech](https://github.com/Kutalia/electron-speech-to-speech) | 100%ローカル翻訳 | Whisper WebGPU + VITS |
-| [OBS LocalVocal](https://github.com/royshil/obs-localvocal) | OBSプラグイン字幕 | whisper.cpp + M2M100 |
+| Felo Subtitles | Real-time translation, free tier | DOM scraping; breaks on Meet UI changes |
+| JotMe | 77 languages, meeting notes | Same DOM-scraping fragility |
+| ELI | Unlimited free | Google Meet only |
 
 ---
 
-## 6. 推奨アーキテクチャ
+## 2. Speech-to-text (STT) options
 
-### 構成A: VoicePing モデル方式（推奨・無料）
+### Cloud APIs
 
-```
-マイク → VAD → 言語検出 → VoicePing whisper-ja-en モデル → Electron透過ウィンドウ
-                              (STT + 翻訳を1モデルで)
+| Service | Latency | JA accuracy | Price (/min) | Streaming | Code-switching |
+|---|---|---|---|---|---|
+| Google Cloud STT | ~300 ms | High (CER 2.7%) | $0.024 | Yes | Up to 3 languages |
+| Deepgram Nova-3 | <300 ms | Medium-high | $0.0043 | Yes | **Native 10-language multilingual** |
+| Azure Speech | ~300 ms | High | $0.017 | Yes | Limited |
+| OpenAI Whisper API | Batch only | High | $0.006 | No | No |
 
-日本語発話 → 英語テキスト出力
-英語発話 → 日本語テキスト出力
-+ 原文テキストも同時表示
-```
+### Local models
 
-- コスト: ¥0
-- 言語切替: セグメント単位で自動
-- レイテンシ: ~1-2秒
-- VoicePingが商用利用で実績あり
+| Model | Speed | JA accuracy | Cost | Notes |
+|---|---|---|---|---|
+| **Kotoba-Whisper v2.0** | 6.3× large-v3 | Best (JA-specialized) | ¥0 | Cannot handle EN code-switch |
+| **MLX Whisper** | Apple Silicon-tuned | JA CER 8.1% / EN WER 3.8% | ¥0 | ~2.9 s per chunk |
+| **Apple SpeechTranscriber** | Native, macOS 26+ | High | ¥0 | Zero-setup, ANE-native |
+| **whisper.cpp (Whisper Local)** | ~2 s / chunk | ≥90% | ¥0 | Cross-platform default |
+| Lightning Whisper MLX | — | **CER 162% — removed** | — | Failed JA benchmark |
+| Moonshine base | — | **CER 221% — removed** | — | Failed JA benchmark |
+| Moonshine Tiny JA | 845 ms | CER 10.1% | ¥0 | Improved variant; experimental |
 
-### 構成B: Whisper STT + Google Translation（精度重視）
+### Web Speech API (rejected)
 
-```
-マイク → VAD → Whisper large-v3-turbo (言語検出+STT)
-  → 日本語検出 → Google Translation → 英語テキスト
-  → 英語検出 → Google Translation → 日本語テキスト
-→ Electron透過ウィンドウ
-```
-
-- コスト: ¥0（Google Translation月50万文字無料枠内）
-- 翻訳精度: 高い（Google NMT、短文に強い）
-- レイテンシ: ~2秒
-- 言語拡張が容易
-
-### 構成C: OBS LocalVocal（開発ゼロ・検証用）
-
-```
-OBS Studio + LocalVocal プラグイン → 字幕オーバーレイ → プロジェクター
-```
-
-- コスト: ¥0、開発不要
-- 翻訳精度: 中（M2M100）
-- 即日検証可能
+- 60-second hard timeout, drops after 7s of silence.
+- Prior art is "barely working".
+- Audio is sent to Google (privacy concern).
+- Not production-grade.
 
 ---
 
-## 7. コスト比較
+## 3. Translation options
 
-| 構成 | STT | 翻訳 | 月額合計 |
+### Translation APIs
+
+| Service | JA↔EN quality | Short-sentence accuracy | Latency | Free tier | Real-time fit |
+|---|---|---|---|---|---|
+| **Azure Translator (F0)** | High | Good | <300 ms | **2 M chars/month** | ★★★ — **recommended single-key boost** |
+| Google Translation | High | Good | 100-300 ms | 480 K chars/month | ★★★ |
+| DeepL API Free | Top | Slightly weaker on short utterances | ms | 500 K chars/month (≤600 chars/min) | ★★ |
+| GPT-4o / Claude | Top | Good | seconds | None | ★ |
+| Gemini 2.5 Flash | High | Good | Sub-second | Generous | ★★★ |
+
+> Real-time translation runs many short utterances back to back, so
+> **short-sentence accuracy and latency** dominate. DeepL is optimized for
+> long-form text and can mis-translate short utterances; Azure F0 and Google
+> are both strong on short input.
+>
+> live-translate's `ApiRotationController` rotates **Azure → Google → DeepL →
+> Gemini → local fallback** when more than one key is configured. The local
+> fallback was added in [#703](https://github.com/rioX432/live-translate/issues/703)
+> so that exhausting every cloud key never breaks the overlay.
+
+### Local translation models
+
+| Model | Quality | Cost | Notes |
 |---|---|---|---|
-| A: VoicePing モデル | ¥0 | ¥0（内蔵） | **¥0** |
-| B: Whisper + Google | ¥0 | ¥0（50万文字以内） | **¥0** |
-| B: Whisper + Google（超過時） | ¥0 | $20/100万文字 | **~$10-20** |
-| C: OBS LocalVocal | ¥0 | ¥0 | **¥0** |
-| 参考: Deepgram + DeepL Pro | $26/月 | $5.49+従量 | **~$40-60** |
+| **HY-MT1.5 1.8B** | High | ¥0 | ~180 ms / sentence; **current default** (replaces OPUS-MT, #544) |
+| **LFM2** | Medium-high | ¥0 | ~230 MB, ultra-fast |
+| **Hunyuan-MT 7B** | Highest local | ¥0 | 3.7-6.3 s / sentence; quality mode only |
+| OPUS-MT | Medium | ¥0 | 279-462 ms; legacy fallback for low-memory systems |
+| M2M100 | Medium | ¥0 | LocalVocal-style |
+| PLaMo | — | ¥0 | Under evaluation; removed from adaptive routing (#705) |
+
+### Translation benchmark (2026-06)
+
+We added a conversational JA↔EN benchmark in
+[#706](https://github.com/rioX432/live-translate/issues/706) under
+[`benchmark/conversational-ja-en/`](../benchmark/conversational-ja-en/). The
+dataset is 25 representative meeting utterances (15 JA, 10 EN). The metric
+is **chrF** (sacreBLEU defaults: n=6, β=2) — used as a tractable stand-in
+for COMET-22, because the official Unbabel implementation is PyTorch-only
+today and no battle-tested Node.js ONNX path exists yet. The TODO to swap
+in COMET-22 is recorded in `benchmark/conversational-ja-en/metrics.ts` and
+referenced by issue #706.
 
 ---
 
-## 8. 開発ロードマップ
+## 4. Japanese↔English auto language switching
 
-### Step 1: 検証（今日）
-- [ ] OBS LocalVocal をインストールして翻訳精度を体感
-- [ ] Sokuji を動かしてElectron翻訳アプリの動作感を確認
+### Approach comparison
 
-### Step 2: 技術検証（今週）
-- [ ] VoicePing whisper-ja-en モデルの日英翻訳精度を検証
-- [ ] Apple Silicon Mac でのリアルタイム推論速度を計測
-- [ ] Whisper large-v3-turbo の言語自動検出精度を検証
+| Approach | Mechanism | Accuracy | Cost |
+|---|---|---|---|
+| **VoicePing whisper-ja-en** | VAD split → language detect → bi-directional translation | High | ¥0 |
+| **Deepgram Nova-3 multi** | Unified multilingual model | Highest | $26/month |
+| Whisper VAD split | Run `detect_language()` per segment | Medium | ¥0 |
+| Google STT multi | Specify up to 3 languages | Medium-high | Paid |
 
-### Step 3: MVP開発（1-2週間）
-- [ ] Electron + React プロジェクト作成
-- [ ] マイク音声取得 + VAD
-- [ ] VoicePing モデル統合（or Whisper + Google Translation）
-- [ ] 透過字幕ウィンドウ（拡張ディスプレイ配置）
-- [ ] 文字起こしログ保存
+### Whisper limitations
 
-### Step 4: 改善
-- [ ] 字幕UI調整（フォント、位置、フェードアウト）
-- [ ] 精度が不足なら構成B（Google Translation）に切替
-- [ ] Notion API連携（議事録保存）
-- [ ] Claudeで議事録要約（各自のサブスクで手動）
+- The 30-second language probe runs once; per-segment switching is not a
+  built-in feature.
+- Kotoba-Whisper is JA-specialized and degrades on English.
+- Workaround: VAD-segment → `detect_language()` → re-decode with the
+  detected language.
 
 ---
 
-## 参考リンク
+## 5. Mac subtitle overlay
+
+### Use case
+
+```
+Presenter Mac → HDMI / extended display → projector
+Primary display:  presenter notes / controls
+Extended display: slides + subtitle overlay (audience view)
+```
+
+### Implementation options
+
+| Approach | Transparent window | Stability | Effort |
+|---|---|---|---|
+| **Electron** | Yes (transparent + frameless) | High | Low |
+| SwiftUI + AppKit | Yes | Highest | Medium |
+| Tauri v2 | Partial (bugs reported) | Medium | Low |
+
+### Reference OSS
+
+| Project | Notes | Tech |
+|---|---|---|
+| **[Sokuji](https://github.com/kizuna-ai-lab/sokuji)** | Most polished Electron translator (AGPL) | Electron + React, 7 AI providers |
+| [electron-speech-to-speech](https://github.com/Kutalia/electron-speech-to-speech) | 100% local | Whisper WebGPU + VITS |
+| [OBS LocalVocal](https://github.com/royshil/obs-localvocal) | OBS subtitle plugin | whisper.cpp + M2M100 |
+
+---
+
+## 6. Architecture decision
+
+We adopted **Whisper STT + (HY-MT1.5 local | Azure F0 cloud boost)** for the
+following reasons:
+
+- HY-MT1.5 1.8B is ~180 ms per sentence on Apple Silicon — the best
+  latency/quality trade-off for a fully-offline default.
+- Azure F0 gives us a single optional cloud key with the largest free
+  quota (2 M chars/month) — bigger than Google or DeepL Free combined.
+- `ApiRotationController` provides a graceful local fallback when the
+  cloud quota is gone or the network is down (#703).
+- Electron lets us reuse the existing subtitle overlay and the cross-platform
+  CI without rewriting in Swift.
+
+This supersedes the 2026-03 recommendation of "VoicePing-only" — VoicePing
+remains a viable alternative but is not the default because HY-MT1.5
+benchmarks better on the conversational dataset (#706) and is easier to
+upgrade in a Node.js pipeline.
+
+---
+
+## 7. Cost comparison
+
+| Configuration | STT | Translation | Monthly cost |
+|---|---|---|---|
+| **A: HY-MT1.5 local only** | ¥0 | ¥0 | **¥0** |
+| **B: HY-MT1.5 + Azure F0 boost** | ¥0 | ¥0 (≤2 M chars) | **¥0** |
+| B (over Azure F0 quota) | ¥0 | local fallback or ~$10/M chars | ¥0 (fallback) or ~$10-20 |
+| C: Stacked rotation (Azure + Google + DeepL + Gemini) | ¥0 | ¥0 (≤4 M chars combined) | **¥0** |
+| Ref: Deepgram + DeepL Pro | $26/month | $5.49 + usage | **~$40-60** |
+
+---
+
+## 8. Open items
+
+- **COMET-22 swap-in** — Replace chrF in
+  `benchmark/conversational-ja-en/metrics.ts` once a stable Node.js ONNX
+  COMET inference path exists. Tracked via the TODO in that file and #706.
+- **PLaMo re-evaluation** — Removed from adaptive routing (#705); revisit
+  when a smaller / faster checkpoint lands.
+- **GPT-Realtime + Whisper** — Evaluate as a future STT path (#698).
+
+---
+
+## References
 
 ### OSS
-- [Sokuji](https://github.com/kizuna-ai-lab/sokuji) - Electron翻訳アプリ
-- [VoicePing whisper-ja-en](https://github.com/voiceping-ai/whisper-ja-en-speech-translation) - 日英双方向翻訳モデル
-- [OBS LocalVocal](https://github.com/royshil/obs-localvocal) - OBS字幕プラグイン
-- [whisper-node-addon](https://github.com/Kutalia/whisper-node-addon) - Electron用Whisperネイティブアドオン
-- [Lightning Whisper MLX](https://github.com/mustafaaljadery/lightning-whisper-mlx) - Apple Silicon最適化
-- [Kotoba-Whisper v2.0](https://huggingface.co/kotoba-tech/kotoba-whisper-v2.0) - 日本語特化Whisper
-- [WhisperLive](https://github.com/collabora/WhisperLive) - リアルタイムWhisper
-- [Meta SeamlessStreaming](https://github.com/facebookresearch/seamless_communication) - E2E翻訳
 
-### 商用サービス
-- [Deepgram Nova-3](https://deepgram.com/) - 多言語コードスイッチング
-- [Google Cloud Translation](https://cloud.google.com/translate) - 月50万文字無料
-- [DeepL API](https://www.deepl.com/pro-api) - 翻訳品質最高
+- [Sokuji](https://github.com/kizuna-ai-lab/sokuji) — Electron translator
+- [VoicePing whisper-ja-en](https://github.com/voiceping-ai/whisper-ja-en-speech-translation) — JA↔EN bi-directional model
+- [OBS LocalVocal](https://github.com/royshil/obs-localvocal) — OBS subtitle plugin
+- [whisper-node-addon](https://github.com/Kutalia/whisper-node-addon) — Electron Whisper native addon
+- [Lightning Whisper MLX](https://github.com/mustafaaljadery/lightning-whisper-mlx) — Apple Silicon-tuned (failed JA benchmark)
+- [Kotoba-Whisper v2.0](https://huggingface.co/kotoba-tech/kotoba-whisper-v2.0) — JA-specialized Whisper
+- [WhisperLive](https://github.com/collabora/WhisperLive) — Real-time Whisper
+
+### Commercial
+
+- [Azure Translator pricing](https://azure.microsoft.com/en-us/pricing/details/cognitive-services/translator/)
+- [Google Cloud Translation](https://cloud.google.com/translate)
+- [DeepL API](https://www.deepl.com/pro-api)
+- [Deepgram Nova-3](https://deepgram.com/)

--- a/docs/cloud-boost.md
+++ b/docs/cloud-boost.md
@@ -1,0 +1,196 @@
+# Cloud Boost: Azure Translator F0 + API Rotation
+
+Live Translate runs **fully offline by default** — the local HY-MT1.5 1.8B
+translator handles JA↔EN in ~180 ms with no network access. "Cloud boost" is
+the optional opt-in path that adds a hosted translator on top, transparently
+falls back to the local engine when the cloud quota is exhausted, and
+disappears entirely if you choose not to configure a key.
+
+This document covers the **recommended single-provider setup** (Azure
+Translator F0) and explains how the `ApiRotationController` orchestrates the
+fallback. For the enterprise (MDM-managed) variant, see
+[mdm-config.md](mdm-config.md).
+
+## Why Azure F0 is the recommended boost
+
+We deliberately recommend **one** cloud key, not four, to keep the setup
+simple:
+
+| Provider | Free tier | Notes |
+|---|---|---|
+| **Azure Translator F0** | **2,000,000 chars / month** | One Azure account, free tier, no credit card required up to the limit. |
+| Google Cloud Translation | 480,000 chars / month | Requires a Google Cloud project with billing enabled (free tier credits cover normal use). |
+| DeepL Free | 500,000 chars / month | EU account required for some flows; rate-limited per minute. |
+| Gemini | Generous free tier | Subject to Google AI Studio policy changes. |
+
+A 2 M / month allowance covers ~1,500 minutes of typical meeting subtitles,
+which is more than enough for individual use. Stacking the others is
+supported (see "Stacking multiple providers" below) but is **not required**.
+
+If you do not want any cloud usage, simply skip this entire document — the
+default install translates everything locally.
+
+## Step 1: Create an Azure Translator resource (F0 tier)
+
+Estimated time: 5 minutes.
+
+1. Sign in to the [Azure portal](https://portal.azure.com/) (free account is
+   fine).
+2. Click **Create a resource** → search for **Translator** → choose the one
+   published by Microsoft and click **Create**.
+3. Fill in the form:
+   - **Subscription** — your Azure subscription
+   - **Resource group** — create a new one (e.g. `live-translate`)
+   - **Region** — pick the region closest to your meetings, e.g.
+     `japaneast` for Japan, `eastus` for the US East coast. Note: the region
+     value is part of the request URL, so it must match what you paste into
+     the app.
+   - **Name** — any unique name, e.g. `live-translate-xxxxxx`
+   - **Pricing tier** — **F0 (Free)** — this is the critical choice. F0 is
+     hard-capped at 2 M characters / month and never bills.
+4. Click **Review + Create** → **Create**. Provisioning takes ~1 minute.
+5. Open the resource → **Keys and Endpoint**.
+6. Copy **KEY 1** and **Location/Region** (the latter is what you pasted in
+   step 3, e.g. `japaneast`).
+
+You are done with Azure. The key is yours; nothing about your subscription is
+shared with Live Translate's developers.
+
+> Microsoft documents the Translator pricing and quotas at
+> <https://azure.microsoft.com/en-us/pricing/details/cognitive-services/translator/>.
+> Verify the F0 limit against the current page before relying on it for
+> production-scale workloads.
+
+## Step 2: Plug the key into Live Translate
+
+1. Open Live Translate → **Settings** → **Translator**.
+2. Set **Engine** to `Auto` or `API Rotation` so the controller is in charge.
+3. Under **Cloud providers**, paste:
+   - **Azure Translator key** — KEY 1 from step 1.6
+   - **Azure region** — e.g. `japaneast` (must match the Azure resource
+     region exactly).
+4. Optionally add Google / DeepL / Gemini keys in the same panel if you want
+   to stack providers.
+5. Click **Start**. The status bar reads `Azure → Google → DeepL → Gemini —
+   up to 4M+ chars/month free` when rotation is active.
+
+Keys are stored via `electron-store`, which encrypts the persisted JSON; they
+are never transmitted to the Live Translate repository or maintainers.
+
+## Step 3: Verify the rotation in action
+
+- **Normal usage** — the active provider is shown in the overlay status. For
+  a fresh month, this is Azure.
+- **Quota approaching** — when a provider reaches 90% of its monthly limit,
+  a warning is logged (`{providerId}: 90% quota used (1800000/2000000)`).
+- **Quota exhausted** — once a provider hits its monthly cap, rotation
+  silently advances to the next. If you only configured Azure, rotation
+  hands off to the **local** fallback engine and the overlay continues
+  without interruption.
+- **Network drop or 429 rate-limit** — short-window rate-limit errors put
+  the provider on a 60-second cooldown but do not consume the failure
+  budget. Hard errors (>5 in a row) put the provider on a 5-minute cooldown.
+
+You can inspect the quota state at any time via the rotation summary in the
+status panel; raw counters are persisted across app restarts.
+
+## How the rotation logic works (#703)
+
+The `ApiRotationController`
+(`src/engines/translator/ApiRotationController.ts`) wraps an ordered list of
+`TranslatorEngine` instances:
+
+```ts
+new ApiRotationController(
+  [
+    { engine: azureEngine,  monthlyCharLimit: 2_000_000 }, // QUOTA_LIMITS.microsoft
+    { engine: googleEngine, monthlyCharLimit:   480_000 }, // QUOTA_LIMITS.google
+    { engine: deeplEngine,  monthlyCharLimit:   500_000 }, // QUOTA_LIMITS.deepl
+    { engine: geminiEngine, monthlyCharLimit: 1_000_000 }  // QUOTA_LIMITS.gemini
+  ],
+  persistence,
+  onStatusUpdate,
+  { fallbackEngine: localTranslator } // #703: drops back to local when exhausted
+)
+```
+
+On each `translate(text, from, to)` call:
+
+1. The controller iterates providers in order, skipping any that:
+   - Failed to initialize (e.g. missing key)
+   - Have exceeded their monthly character cap
+   - Are within the 5-minute consecutive-failure cooldown
+   - Are within the 60-second 429 rate-limit cooldown
+2. The first eligible provider runs the translation. On success the
+   character count is incremented and persisted.
+3. On failure, the error is classified:
+   - **Quota exceeded / HTTP 456** → mark the provider exhausted for the
+     current month; do not count against the failure budget.
+   - **Rate limit** → 60-second cooldown; do not count against the failure
+     budget.
+   - **Other transient errors** → increment the per-provider failure
+     counter; 5 in a row trips the 5-minute cooldown.
+4. When **every** cloud provider is skipped or has failed and a
+   `fallbackEngine` is configured, the controller lazily initializes the
+   local translator and uses it — the user sees `All cloud providers
+   exhausted, using local fallback` in the status bar but the overlay
+   continues without dropping a sentence.
+
+Monthly counters are keyed on `YYYY-MM` and reset automatically at the
+boundary; there is no manual rollover step.
+
+## Stacking multiple providers (optional)
+
+If you want to push the combined free allowance past 4 M characters / month,
+add Google, DeepL, and Gemini keys in the same Settings panel. The rotation
+order is fixed today: **Azure → Google → DeepL → Gemini → local fallback**.
+Azure is first because its F0 tier has by far the largest free quota, so
+draining it first minimizes the chance of ever hitting the smaller per-month
+ceilings on the others.
+
+## Enterprise / MDM-managed deployment
+
+For organizations that want to push a corporate Azure key to every machine
+**without** the user typing it in, Live Translate honors a managed-preference
+plist on macOS (`/Library/Managed Preferences/com.live-translate.app.plist`):
+
+```xml
+<key>managedMicrosoftApiKey</key>
+<string>YOUR-AZURE-TRANSLATOR-KEY</string>
+<key>managedMicrosoftRegion</key>
+<string>japaneast</string>
+```
+
+This was added in [#704](https://github.com/rioX432/live-translate/issues/704)
+and is **strictly opt-in** — it only ships if your organization deploys the
+configuration profile. End users still see the same UI; the keys are simply
+prefilled and (if `lockedEngine` is set) cannot be changed.
+
+See [mdm-config.md](mdm-config.md) for the full list of supported keys.
+
+## FAQ
+
+**Do I have to configure any cloud key?**
+No. The default install is fully offline. This document is only relevant if
+you want to opt in to cloud-quality translation.
+
+**What happens when Azure quota is exhausted?**
+The rotation controller automatically falls back to the local HY-MT1.5 1.8B
+translator. You will see a one-time status message; subtitles continue.
+
+**Are my API keys uploaded anywhere?**
+No. Keys are stored locally via `electron-store` and sent only to the
+provider whose key it is (Azure, Google, etc.) when that provider is the
+active one in the rotation.
+
+**Can I use a paid Azure S1 tier instead of F0?**
+Yes. The app only cares about the key + region; it does not check the
+pricing tier. The `monthlyCharLimit` setting in code is a soft client-side
+counter to avoid surprise bills on free tiers — adjust it (or remove the
+provider from rotation) if you intentionally want to exceed 2 M chars on a
+paid tier.
+
+**Why not OpenAI / Anthropic / Claude as a cloud booster?**
+Cost. The four providers in the rotation all have free tiers usable for
+real-time meeting subtitles; the LLM APIs do not, and even with caching
+they would be 10-100× more expensive per minute of speech.

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -1,0 +1,109 @@
+# Glossary
+
+Live Translate ships with a built-in glossary system that lets you pin specific
+source terms to specific target terms, so brand names, product names, and
+domain acronyms stay consistent across every translation.
+
+There are two glossaries:
+
+- **Personal glossary** — managed by the local user, persisted via
+  `electron-store`.
+- **Organization glossary** — typically imported from a CSV/JSON file shared
+  inside a team. On conflict, organization terms **override** personal terms
+  (see `mergeGlossaries` in
+  `src/engines/translator/glossary-manager.ts`).
+
+Both glossaries are stored locally; nothing is uploaded.
+
+## File formats
+
+The same content can be represented as CSV or JSON.
+
+### CSV
+
+A header row is required. The first column is the source term, the second is
+the target term. Quoted fields (with `"`) are supported for values that
+contain commas, quotes, or newlines.
+
+```csv
+source,target
+Avvy,Avvy
+AnotherBall,AnotherBall
+"AI, ML",AIとML
+DroidKaigi,DroidKaigi
+```
+
+### JSON
+
+A flat array of objects with `source` and `target` keys. Extra keys are
+ignored. Empty / whitespace-only entries are dropped.
+
+```json
+[
+  { "source": "Avvy", "target": "Avvy" },
+  { "source": "AnotherBall", "target": "AnotherBall" },
+  { "source": "DroidKaigi", "target": "DroidKaigi" }
+]
+```
+
+## Importing & exporting
+
+In Settings → Glossary:
+
+1. Click **Import** under either **Personal** or **Organization**.
+2. Pick a `.csv` or `.json` file. The format is detected from the extension.
+3. The imported entries replace the corresponding glossary; the status line
+   shows how many terms were loaded.
+4. Click **Export JSON** or **Export CSV** to save the current contents back
+   out. Exports always include a header row (CSV) or pretty-printed JSON.
+
+If both personal and organization glossaries are present, the UI surfaces
+any **conflicts** (same source, different target) so you can decide which to
+keep. Organization entries win at runtime.
+
+## How glossary terms are applied
+
+The pipeline applies glossaries in two complementary ways depending on the
+translator engine:
+
+- **String replacement** — `applyGlossary` performs a literal `replaceAll`
+  for each `source` term in the input text before the translator sees it.
+  Empty / whitespace-only sources are skipped. This is engine-agnostic and
+  always runs.
+- **LLM prompt injection** — for LLM-based translators (HY-MT1.5, Hunyuan-MT
+  7B, LFM2, Gemini), `formatGlossaryPrompt` formats the entries as a small
+  system-prompt fragment:
+
+  ```
+  Use these fixed translations for specific terms:
+    "Avvy" → "Avvy"
+    "AnotherBall" → "AnotherBall"
+  ```
+
+  This lets the model handle inflection and surrounding context while still
+  honoring the term list.
+
+Both paths use the **merged** glossary (organization overrides personal),
+so a single canonical set of terms is presented to every translator.
+
+## Tips
+
+- Keep the source column **exactly** as it appears in transcription. STT
+  output preserves casing, so `AVVY` and `Avvy` are different entries.
+- Use the organization glossary for company-wide vocabulary (product names,
+  legal entity names) and the personal glossary for per-user preferences
+  (your own handle, your team's nicknames).
+- Glossaries scale to hundreds of entries cheaply because the string-replace
+  pass is O(N · M) over short inputs; the LLM prompt cost is the main
+  bound. If you have ≥1k entries, prefer the CSV path and split by domain.
+- Glossary entries are not language-tagged today; if you need different terms
+  for JA→EN vs EN→JA, maintain two files and swap them per session.
+
+## Related files
+
+- `src/engines/translator/glossary-utils.ts` — `applyGlossary`,
+  `formatGlossaryPrompt`.
+- `src/engines/translator/glossary-manager.ts` — parsers, exporters, merge,
+  format detection.
+- `src/renderer/components/settings/GlossarySettings.tsx` — UI.
+- `src/engines/translator/glossary-manager.test.ts` — round-trip tests.


### PR DESCRIPTION
## Description

Overhauls the project's user-facing documentation so the differentiators identified in the 2026-06 counter-argument review (Free, Local-first, Optional Cloud Boost, Glossary, Speaker labels) are visible at the top of the README rather than buried.

### README.md
- New **Why live-translate?** section — Free / Local-first / Optional Cloud Boost / JA↔EN focus / MIT (not AGPL).
- New **Comparison with alternatives** table — live-translate vs Sokuji (AGPL, multilingual), Felo Subtitles (commercial), DeepL Voice (enterprise).
- New **Differentiating features** section — Glossary (CSV/JSON), Speaker labels (FluidAudio, macOS), API rotation with quota tracking (#703), Azure F0 single-key recommendation, MDM-managed enterprise keys (#704).
- **Quick Start** now describes the optional Azure F0 step alongside the offline default.
- Translation engines table updated: HY-MT1.5 1.8B is the fast default; OPUS-MT is relabeled as legacy fallback; Azure Translator F0 listed with its 2M chars/month free quota.

### docs/glossary.md (new)
- Personal vs organization glossaries, CSV/JSON formats, import/export flow.
- Explains the two application paths (literal `applyGlossary` replacement + `formatGlossaryPrompt` LLM injection).

### docs/cloud-boost.md (new)
- 5-minute Azure F0 acquisition walkthrough, exact `monthlyCharLimit` values from `pipeline-ipc.ts`.
- Full description of `ApiRotationController` behavior: quota tracking, 429 rate-limit cooldown, 5-minute consecutive-failure cooldown, local fallback (#703).
- References the MDM-managed Microsoft key support from #704 as an opt-in enterprise path.

### docs/RESEARCH.md (refresh)
- Replaces 2026-03 snapshot with 2026-06 reality: HY-MT1.5 1.8B as default, Azure F0 as recommended boost, conversational benchmark scaffold from #706 with chrF (COMET-22 swap-in tracked as a TODO).
- Adds an explicit positioning matrix vs Sokuji / Felo / DeepL Voice.

## Test plan
- [x] Verify all referenced source files exist (`ApiRotationController.ts`, `glossary-manager.ts`, `glossary-utils.ts`, FluidAudio speaker settings, MDM Microsoft keys).
- [x] Verify quota numbers match `QUOTA_LIMITS` in `src/main/ipc/pipeline-ipc.ts` (Azure 2M, Google 480K, DeepL 500K, Gemini 1M).
- [x] Verify `mdm-config.md` cross-link target exists.
- [x] Verify `benchmark/conversational-ja-en/` cross-link target exists.
- [x] Verify chrF metric reference matches `benchmark/conversational-ja-en/metrics.ts`.
- [x] `npm test` — the 10 failing tests are pre-existing on `origin/main` (`virtual-mic-manager.test.ts`) and unrelated to this docs-only change.
- [x] `npm run lint` — warnings/errors are pre-existing in `src/`; no docs files are linted.

## Related Issues
Closes #707