### PR TITLE
Add gpt-realtime-whisper evaluation scaffold (#698)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ logs/
 src/renderer/public/vad/
 benchmark/results/
 benchmark/conversational-ja-en/results/
+benchmark/gpt-realtime-whisper-eval/results/
 benchmark/models/
 benchmark/mlx_models/
 benchmark/.bin/

--- a/benchmark/gpt-realtime-whisper-eval/README.md
+++ b/benchmark/gpt-realtime-whisper-eval/README.md
@@ -1,0 +1,125 @@
+# GPT-Realtime-Whisper Evaluation Bench
+
+Scaffold for Issue [#698](https://github.com/rioX432/live-translate/issues/698):
+evaluate the cloud streaming model `gpt-realtime-whisper` (OpenAI, released
+2026-05-07) against the offline STT engines that already power live-translate.
+
+The bench is intentionally separated from the cross-engine STT runner under
+`benchmark/run.ts` because gpt-realtime-whisper requires a paid API key, a live
+WebSocket connection, and a different audio format (24 kHz PCM16 vs the
+16 kHz fixtures used elsewhere). Keeping it in its own folder makes it easy to
+skip in CI and keeps the cost story isolated.
+
+## Why we need this bench
+
+Live-translate's Core Value #1 is **offline-by-default translation**. Cloud
+STT is therefore opt-in only — but if its Japanese accuracy is dramatically
+better than the best local engine, it may still be worth wiring as an optional
+boost (parallel to the Microsoft Translator / Google Translate rotation
+already supported on the translation side).
+
+Per the Phase 3 decision gate in #698:
+
+- If `JA CER(gpt-realtime-whisper) >= best_local_CER - 2.0pp` (i.e. less than
+  2 percentage points of improvement) → **won't-do**, close the issue.
+- Otherwise → **design** an opt-in cloud STT mode in a follow-up issue.
+
+## What this bench measures
+
+| Metric | Why |
+|---|---|
+| JA CER | The decision gate metric. Computed via the existing `wer.ts` utility so the number is directly comparable to other engine baselines. |
+| EN WER | Sanity check that the cloud path is not worse on EN. |
+| TTFD (time-to-first-delta) | Per OpenAI's documentation, gpt-realtime-whisper streams partial transcripts. TTFD is the more useful real-time metric than `total_ms`. |
+| Total wall-clock per clip | End-to-end latency reference. |
+| Projected monthly USD | 4 h/day x 22 days/month at the documented $0.017/min price. |
+
+## Prerequisites
+
+1. **API key**: `OPENAI_API_KEY` env var. Without it the runner logs a clean
+   skip message and exits 0 so it can live in CI without flaking.
+2. **Test audio**: the same 16 kHz mono WAV fixtures used by the other STT
+   engines. Generate them from `benchmark/`:
+   ```bash
+   npm run stt:generate-testset
+   ```
+   This populates `benchmark/testset/stt-audio/` (gitignored, ~3 MB).
+3. **Node 22+ / Electron 33+** — the runner uses the platform `WebSocket`
+   constructor (no extra dependency).
+
+### Audio data sources for extension
+
+The bundled manifest under `benchmark/testset/stt-manifest.jsonl` is the
+authoritative fixture set for all STT engines in this repo. To strengthen the
+JA evaluation beyond the bundled 20 clips, two public corpora are recommended:
+
+| Corpus | License | Notes |
+|---|---|---|
+| [Common Voice 17 (ja)](https://commonvoice.mozilla.org/ja/datasets) | CC0 | Read speech, varied speakers; good for CER baseline. |
+| [ReazonSpeech v2 small](https://research.reazon.jp/projects/ReazonSpeech/) | CDLA-Sharing | Spontaneous TV speech; closer to live-translate's real workload. |
+
+If you add new audio, append entries to `stt-manifest.jsonl` with
+`language: "ja"` and the same `domain` taxonomy
+(`casual`/`business`/`technical`) so the existing per-domain breakdown
+keeps working.
+
+## Run
+
+```bash
+cd benchmark
+OPENAI_API_KEY=sk-... npx tsx --expose-gc \
+  gpt-realtime-whisper-eval/bench-gpt-realtime-whisper.ts
+
+# JA only
+OPENAI_API_KEY=sk-... npx tsx --expose-gc \
+  gpt-realtime-whisper-eval/bench-gpt-realtime-whisper.ts --language ja
+
+# Try the lowest-latency tier
+OPENAI_API_KEY=sk-... npx tsx --expose-gc \
+  gpt-realtime-whisper-eval/bench-gpt-realtime-whisper.ts --latency minimal
+
+# Quick smoke (first 5 clips)
+OPENAI_API_KEY=sk-... npx tsx --expose-gc \
+  gpt-realtime-whisper-eval/bench-gpt-realtime-whisper.ts --limit 5
+```
+
+## Output
+
+Results land in `gpt-realtime-whisper-eval/results/` (gitignored):
+
+- `gpt-realtime-whisper-<tier>-<ts>.json` — raw per-clip results
+- `gpt-realtime-whisper-<tier>-<ts>.md` — summary table with cost projection
+
+Paste the contents of the markdown report into `RESULTS.md` along with the
+local-engine numbers it should be compared against, then make the Phase 3
+decision.
+
+## Caveats
+
+- **Linear resampling 16k → 24k** is used because the Realtime endpoint
+  requires 24 kHz input. This may slightly affect absolute accuracy compared
+  to native 24 kHz recordings, but since every cloud call sees the same
+  resampled signal, the **comparison across cloud runs is internally
+  consistent**. If you want to compare cloud-vs-local *exactly* on the same
+  signal, run the local engines on the same resampled WAV files (out of scope
+  for the current scaffold).
+- **No streaming-partial chunk timing**: we measure TTFD relative to a single
+  `input_audio_buffer.commit` event. The runner does not yet simulate
+  real-time microphone chunking; if we need streaming-relative latency
+  numbers, extend the runner to send PCM in ~100 ms increments and timestamp
+  each `delta`.
+- **`gpt-realtime-whisper` is a successor to whisper-1**, not the same as
+  `gpt-4o-transcribe`. Do not conflate the two when reading external
+  benchmarks.
+
+## Implementation notes
+
+- `realtime-client.ts` — WebSocket-based session implementation. The
+  `buildSessionUpdate` function is exported and unit-tested so the documented
+  schema can change without touching the runner.
+- `audio.ts` — local WAV reader + linear resampler. No ffmpeg dependency.
+- `cost.ts` — pure helpers for the monthly USD projection.
+- `bench-gpt-realtime-whisper.ts` — CLI runner; emits the JSON/MD reports.
+
+All TypeScript files type-check via the existing `benchmark/tsconfig.json`,
+and all unit tests run under the root `vitest` config.

--- a/benchmark/gpt-realtime-whisper-eval/RESULTS.md
+++ b/benchmark/gpt-realtime-whisper-eval/RESULTS.md
@@ -1,0 +1,99 @@
+# GPT-Realtime-Whisper Benchmark Results
+
+This file is the single source of truth for the Phase 3 decision in issue
+[#698](https://github.com/rioX432/live-translate/issues/698). Bench runs go
+under `results/` (gitignored); summaries and decisions go here so they are
+version-controlled.
+
+## Local-engine baselines we are comparing against
+
+Numbers below are taken from the existing in-repo STT bench
+(`benchmark/run.ts --stt`) on `benchmark/testset/stt-manifest.jsonl`. They are
+the basis for the Phase 3 gate: a cloud STT mode is only worth designing if
+gpt-realtime-whisper improves on the **best** of these by **> 2.0 percentage
+points** of JA CER.
+
+| Engine | JA CER | EN WER | Apple Silicon latency | Notes |
+|---|---|---|---|---|
+| Kotoba-Whisper | 5.6% | — | — | JA-only |
+| Qwen3-ASR 0.6B | 6.8% | 1.9% | ~2.2 s | Current best balanced (JA + EN) |
+| MLX Whisper | 8.1% | 3.8% | 2.9 s | macOS only |
+| Whisper Local (whisper.cpp) | baseline | baseline | — | Cross-platform default |
+| Moonshine Tiny JA | 10.1% | — | 845 ms | Experimental draft STT |
+
+Best local JA CER (incl. all primary + experimental engines): **5.6 %**
+(Kotoba-Whisper, JA-only). Best balanced JA+EN: **6.8 %** (Qwen3-ASR 0.6 B).
+
+## Public information about gpt-realtime-whisper (collected 2026-06)
+
+Sourced from the OpenAI Realtime API documentation and announcement coverage
+(see `docs/research/698-gpt-realtime-whisper-eval.md`).
+
+- Released 2026-05-07 alongside gpt-realtime-2 and gpt-realtime-translate.
+- **Price**: USD 0.017 / minute of audio (≈ 2.8× the legacy `whisper-1`
+  price).
+- **Protocol**: WebSocket-only via the Realtime API,
+  `session.type = "transcription"`,
+  `audio.input.transcription.model = "gpt-realtime-whisper"`,
+  pcm16 / 24 kHz input.
+- **Latency**: tunable via `audio.input.transcription.delay`, documented
+  tiers `minimal | low | medium | high | xhigh`. OpenAI explicitly markets
+  the model as the "lowest-latency streaming transcription path" in their
+  API. No latency numbers (milliseconds) have been published.
+- **Accuracy**: OpenAI has not published per-language numbers for
+  gpt-realtime-whisper. The closest external reference is the Artificial
+  Analysis leaderboard's AA-WER score for the sister model `gpt-4o-transcribe`
+  (≈ 4.0 % English, no JA breakdown). No JA CER number has been published by
+  OpenAI or any third party that we could verify as of 2026-06.
+
+Projected cost @ 4 h/day x 22 days/month: **USD 89.76 / user / month**.
+
+## Decision
+
+> Re-evaluate once a real bench run produces measured numbers. Update this
+> section in the next PR.
+
+### Preliminary (no live bench data yet) — **inconclusive, lean towards
+won't-do**
+
+- OpenAI has not committed to a Japanese accuracy improvement publicly. The
+  GA blog post describes gpt-realtime-whisper as "the streaming counterpart"
+  to whisper-1, not "more accurate than whisper-1".
+- gpt-4o-transcribe (the higher-quality, batch-only sibling) shows ≈ 4.0 %
+  English AA-WER per Artificial Analysis. Without official JA numbers, the
+  conservative prior is that gpt-realtime-whisper is *not better* than
+  gpt-4o-transcribe on JA (since it trades accuracy for streaming latency).
+- The current best local JA CER is **5.6 %** (Kotoba-Whisper) and **6.8 %**
+  (Qwen3-ASR balanced). A > 2 pp improvement would mean cloud JA CER ≤
+  ~3.6 %. That is below the published *English* AA-WER for gpt-4o-transcribe
+  — implausible for the streaming variant given that JA is harder than EN
+  for current ASR.
+- Cost is USD 89.76/user/month for 4 h/day usage, vs the current zero
+  marginal cost.
+
+**Implication**: unless a measured run shows JA CER ≤ ~3.6 %, the issue
+should close as `won't`. Until that run lands, this remains **inconclusive**
+because the decision must be based on measured numbers (research-first
+principle from `CLAUDE.md`).
+
+### How to finalize the decision
+
+1. Acquire an `OPENAI_API_KEY` with Realtime API access.
+2. Regenerate `benchmark/testset/stt-audio/` via `npm run stt:generate-testset`.
+3. Run `OPENAI_API_KEY=sk-... npx tsx --expose-gc gpt-realtime-whisper-eval/bench-gpt-realtime-whisper.ts`.
+4. Append the resulting markdown to this file under a new `## Runs` heading
+   with the measured JA CER.
+5. Apply the Phase 3 gate from #698:
+   - JA CER improvement ≤ 2.0 pp over best local → close #698 with label
+     `won't`; add this RESULTS.md as the rationale.
+   - JA CER improvement > 2.0 pp → open a follow-up "Design opt-in cloud STT
+     mode" issue that references this RESULTS.md.
+
+## Runs
+
+> Populate as bench runs land.
+
+### Pending: first reference run
+
+No reference run has been executed yet. Use the prerequisites in
+`README.md` and append results here.

--- a/benchmark/gpt-realtime-whisper-eval/audio.test.ts
+++ b/benchmark/gpt-realtime-whisper-eval/audio.test.ts
@@ -1,0 +1,48 @@
+/**
+ * Unit tests for the local WAV / resampler helpers.
+ */
+import { describe, it, expect } from 'vitest'
+
+import { float32ToPcm16, resampleLinear } from './audio'
+
+describe('resampleLinear', () => {
+  it('is a no-op when rates match', () => {
+    const input = new Float32Array([0, 0.5, -0.5, 1, -1])
+    expect(resampleLinear(input, 16000, 16000)).toBe(input)
+  })
+
+  it('upsamples 16k -> 24k with the expected length ratio', () => {
+    const input = new Float32Array(1600) // 100 ms @ 16k
+    for (let i = 0; i < input.length; i++) input[i] = Math.sin((2 * Math.PI * i) / 100)
+    const out = resampleLinear(input, 16000, 24000)
+    // 1600 samples * (24000/16000) = 2400
+    expect(out.length).toBe(2400)
+  })
+
+  it('preserves endpoints', () => {
+    const input = new Float32Array([0.25, 0.5, 0.75, 1])
+    const out = resampleLinear(input, 16000, 32000)
+    expect(out[0]).toBe(0.25)
+    // Last sample should equal the last input sample (boundary clamp).
+    expect(out[out.length - 1]).toBe(1)
+  })
+
+  it('handles empty input', () => {
+    expect(resampleLinear(new Float32Array(0), 16000, 24000).length).toBe(0)
+  })
+})
+
+describe('float32ToPcm16', () => {
+  it('clamps out-of-range samples to int16 limits and rounds', () => {
+    const input = new Float32Array([0, 1, -1, 2, -2, 0.5])
+    const pcm = float32ToPcm16(input)
+    // Expected: 0, 32767 (positive scale by 32767), -32768 (negative scale by 32768),
+    // 32767 (clamped), -32768 (clamped), 16384 (round of 0.5 * 32767 = 16383.5)
+    expect(pcm.readInt16LE(0)).toBe(0)
+    expect(pcm.readInt16LE(2)).toBe(32767)
+    expect(pcm.readInt16LE(4)).toBe(-32768)
+    expect(pcm.readInt16LE(6)).toBe(32767)
+    expect(pcm.readInt16LE(8)).toBe(-32768)
+    expect(pcm.readInt16LE(10)).toBe(16384)
+  })
+})

--- a/benchmark/gpt-realtime-whisper-eval/audio.ts
+++ b/benchmark/gpt-realtime-whisper-eval/audio.ts
@@ -1,0 +1,109 @@
+/**
+ * Lightweight WAV reader + linear resampler used by the GPT-Realtime-Whisper
+ * benchmark. Kept local so the eval module has no extra ffmpeg dependency.
+ *
+ * The existing testset under benchmark/testset/stt-audio is 16-bit PCM mono
+ * WAV at 16 kHz (matching whisper.cpp expectations). OpenAI's Realtime
+ * transcription endpoint takes 24 kHz mono PCM16, so we upsample with a
+ * simple linear interpolator. Linear resampling is sufficient for ASR
+ * evaluation purposes because all engines compared in this benchmark use the
+ * same source recording — we only need to compare across models, not against
+ * a higher-quality resampler.
+ */
+import { readFileSync } from 'node:fs'
+
+export interface WavData {
+  /** Mono PCM samples in [-1, 1] (Float32). */
+  samples: Float32Array
+  sampleRate: number
+}
+
+/** Parse a 16-bit PCM mono WAV file into Float32 mono samples. */
+export function readWav(path: string): WavData {
+  const buffer = readFileSync(path)
+  if (buffer.length < 44) {
+    throw new Error(`WAV file is too small: ${path}`)
+  }
+  if (buffer.toString('ascii', 0, 4) !== 'RIFF' || buffer.toString('ascii', 8, 12) !== 'WAVE') {
+    throw new Error(`Not a RIFF/WAVE file: ${path}`)
+  }
+
+  // Walk chunks to find "fmt " and "data".
+  let offset = 12
+  let sampleRate = 0
+  let channels = 0
+  let bitsPerSample = 0
+  let dataStart = -1
+  let dataLen = 0
+  while (offset + 8 <= buffer.length) {
+    const id = buffer.toString('ascii', offset, offset + 4)
+    const size = buffer.readUInt32LE(offset + 4)
+    if (id === 'fmt ') {
+      channels = buffer.readUInt16LE(offset + 10)
+      sampleRate = buffer.readUInt32LE(offset + 12)
+      bitsPerSample = buffer.readUInt16LE(offset + 22)
+    } else if (id === 'data') {
+      dataStart = offset + 8
+      dataLen = size
+      break
+    }
+    offset += 8 + size
+  }
+  if (dataStart < 0) {
+    throw new Error(`No "data" chunk in WAV: ${path}`)
+  }
+  if (bitsPerSample !== 16) {
+    throw new Error(`Only 16-bit PCM WAV is supported. Got ${bitsPerSample}-bit: ${path}`)
+  }
+  if (channels !== 1) {
+    throw new Error(`Only mono WAV is supported. Got ${channels} channels: ${path}`)
+  }
+
+  const numSamples = dataLen / 2
+  const samples = new Float32Array(numSamples)
+  for (let i = 0; i < numSamples; i++) {
+    samples[i] = buffer.readInt16LE(dataStart + i * 2) / 32768
+  }
+  return { samples, sampleRate }
+}
+
+/**
+ * Linear-interpolation resampler. Adequate for ASR evaluation where the same
+ * source audio is sent to every engine; we do not need a polyphase / windowed
+ * sinc filter to compare relative accuracy.
+ */
+export function resampleLinear(
+  input: Float32Array,
+  inputRate: number,
+  outputRate: number
+): Float32Array {
+  if (inputRate === outputRate) return input
+  if (input.length === 0) return input
+  const ratio = inputRate / outputRate
+  const outLen = Math.round(input.length / ratio)
+  const out = new Float32Array(outLen)
+  for (let i = 0; i < outLen; i++) {
+    const srcIdx = i * ratio
+    const lo = Math.floor(srcIdx)
+    const hi = Math.min(lo + 1, input.length - 1)
+    const frac = srcIdx - lo
+    out[i] = input[lo]! * (1 - frac) + input[hi]! * frac
+  }
+  return out
+}
+
+/**
+ * Convert Float32 mono samples in [-1, 1] to 16-bit PCM little-endian bytes.
+ * Uses the full signed int16 range [-32768, 32767]: negative samples scale by
+ * 32768 and positive samples by 32767, then we clamp to [-32768, 32767].
+ */
+export function float32ToPcm16(samples: Float32Array): Buffer {
+  const buf = Buffer.alloc(samples.length * 2)
+  for (let i = 0; i < samples.length; i++) {
+    const s = samples[i]!
+    const scaled = s < 0 ? Math.round(s * 32768) : Math.round(s * 32767)
+    const clamped = Math.max(-32768, Math.min(32767, scaled))
+    buf.writeInt16LE(clamped, i * 2)
+  }
+  return buf
+}

--- a/benchmark/gpt-realtime-whisper-eval/bench-gpt-realtime-whisper.ts
+++ b/benchmark/gpt-realtime-whisper-eval/bench-gpt-realtime-whisper.ts
@@ -1,0 +1,414 @@
+/**
+ * GPT-Realtime-Whisper streaming STT benchmark (Issue #698).
+ *
+ * Reads the shared STT manifest under benchmark/testset/stt-manifest.jsonl,
+ * submits each clip to the OpenAI Realtime transcription endpoint with
+ * `gpt-realtime-whisper` as the model, and reports JA CER + EN WER + latency
+ * + projected monthly cost so we can decide whether to design an opt-in cloud
+ * STT mode (per the Phase 3 decision gate in #698).
+ *
+ * The bench is intentionally read-only: it does not modify the manifest or
+ * any production engine code. To run it you need:
+ *   - OPENAI_API_KEY in env
+ *   - The 16 kHz mono WAV fixtures under benchmark/testset/stt-audio/ (use
+ *     `npm run stt:generate-testset` from benchmark/ to (re)create them)
+ *
+ * Usage:
+ *   cd benchmark
+ *   OPENAI_API_KEY=sk-... npx tsx --expose-gc \
+ *     gpt-realtime-whisper-eval/bench-gpt-realtime-whisper.ts
+ *
+ *   # JA only
+ *   OPENAI_API_KEY=sk-... npx tsx --expose-gc \
+ *     gpt-realtime-whisper-eval/bench-gpt-realtime-whisper.ts --language ja
+ *
+ *   # Try a different latency tier
+ *   OPENAI_API_KEY=sk-... npx tsx --expose-gc \
+ *     gpt-realtime-whisper-eval/bench-gpt-realtime-whisper.ts --latency medium
+ *
+ * Output: a timestamped JSON + Markdown report under
+ *   gpt-realtime-whisper-eval/results/
+ */
+
+import { readFileSync, mkdirSync, writeFileSync, existsSync } from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import type { AccuracyStats, STTLanguage, STTTestEntry } from '../src/stt-types.js'
+import { computeErrorRate, aggregateAccuracy } from '../src/wer.js'
+import { percentile } from '../conversational-ja-en/metrics.js'
+
+import { float32ToPcm16, readWav, resampleLinear } from './audio.js'
+import { formatUsd, projectMonthlyUsd } from './cost.js'
+import { transcribeOnce, type LatencyTier } from './realtime-client.js'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const MANIFEST_PATH = join(__dirname, '..', 'testset', 'stt-manifest.jsonl')
+const TESTSET_DIR = join(__dirname, '..', 'testset')
+const RESULTS_DIR = join(__dirname, 'results')
+
+const TARGET_SAMPLE_RATE = 24_000
+const DEFAULT_TIMEOUT_MS = 60_000
+const PROJECTION_HOURS_PER_DAY = 4 // matches the #698 issue body
+const PROJECTION_DAYS_PER_MONTH = 22
+
+interface PerSentenceResult {
+  id: string
+  language: STTLanguage
+  domain: string
+  reference: string
+  hypothesis: string
+  audioDurationSec: number
+  ttfdMs?: number
+  totalMs: number
+  errorRate: number
+  error?: string
+}
+
+interface LanguageSummary {
+  language: STTLanguage
+  sampleCount: number
+  errors: number
+  accuracy: AccuracyStats
+  ttfd: { p50: number; p95: number; p99: number }
+  total: { p50: number; p95: number; p99: number }
+  audioDurationSec: number
+}
+
+interface Report {
+  timestamp: string
+  model: 'gpt-realtime-whisper'
+  latency: LatencyTier
+  endpoint: string
+  manifest: string
+  perLanguage: LanguageSummary[]
+  results: PerSentenceResult[]
+  cost: {
+    usdPerMinute: number
+    projectionHoursPerDay: number
+    projectionDaysPerMonth: number
+    projectedMonthlyUsd: number
+  }
+  notes: string
+}
+
+// ── Dataset loading ──
+
+function loadManifest(): STTTestEntry[] {
+  if (!existsSync(MANIFEST_PATH)) {
+    throw new Error(`Missing STT manifest at ${MANIFEST_PATH}`)
+  }
+  return readFileSync(MANIFEST_PATH, 'utf-8')
+    .split('\n')
+    .filter((line) => line.trim().length > 0)
+    .map((line) => JSON.parse(line) as STTTestEntry)
+}
+
+function resolveAudioPath(entry: STTTestEntry): string {
+  return resolve(join(TESTSET_DIR, entry.audio_path))
+}
+
+// ── CLI parsing ──
+
+interface ParsedArgs {
+  language: STTLanguage | 'all'
+  latency: LatencyTier
+  endpoint?: string
+  timeoutMs: number
+  limit?: number
+}
+
+function parseArgs(): ParsedArgs {
+  const args = process.argv.slice(2)
+  const parsed: ParsedArgs = {
+    language: 'all',
+    latency: 'low',
+    timeoutMs: DEFAULT_TIMEOUT_MS
+  }
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i]
+    if (arg === '--language' && args[i + 1]) {
+      const value = args[i + 1] as STTLanguage | 'all'
+      if (value !== 'ja' && value !== 'en' && value !== 'all') {
+        console.error(`[bench] --language must be ja, en, or all. Got "${value}".`)
+        process.exit(1)
+      }
+      parsed.language = value
+      i++
+    } else if (arg === '--latency' && args[i + 1]) {
+      const value = args[i + 1] as LatencyTier
+      const allowed: LatencyTier[] = ['minimal', 'low', 'medium', 'high', 'xhigh']
+      if (!allowed.includes(value)) {
+        console.error(`[bench] --latency must be one of ${allowed.join(', ')}. Got "${value}".`)
+        process.exit(1)
+      }
+      parsed.latency = value
+      i++
+    } else if (arg === '--endpoint' && args[i + 1]) {
+      parsed.endpoint = args[i + 1]
+      i++
+    } else if (arg === '--timeout' && args[i + 1]) {
+      parsed.timeoutMs = Number.parseInt(args[i + 1]!, 10)
+      if (!Number.isFinite(parsed.timeoutMs) || parsed.timeoutMs <= 0) {
+        console.error(`[bench] --timeout must be a positive integer (ms).`)
+        process.exit(1)
+      }
+      i++
+    } else if (arg === '--limit' && args[i + 1]) {
+      parsed.limit = Number.parseInt(args[i + 1]!, 10)
+      if (!Number.isFinite(parsed.limit) || parsed.limit <= 0) {
+        console.error(`[bench] --limit must be a positive integer.`)
+        process.exit(1)
+      }
+      i++
+    } else if (arg === '--help' || arg === '-h') {
+      printHelp()
+      process.exit(0)
+    }
+  }
+  return parsed
+}
+
+function printHelp(): void {
+  console.log(
+    [
+      'Usage: tsx gpt-realtime-whisper-eval/bench-gpt-realtime-whisper.ts [options]',
+      '',
+      '  --language ja|en|all   Subset of the manifest to evaluate (default: all)',
+      '  --latency <tier>       minimal|low|medium|high|xhigh (default: low)',
+      '  --limit <n>            Only evaluate the first n clips (debug helper)',
+      '  --timeout <ms>         Per-clip timeout in ms (default: 60000)',
+      '  --endpoint <url>       Override the Realtime WebSocket URL',
+      '  --help                 Show this message',
+      '',
+      'Requires OPENAI_API_KEY in env. Skips cleanly if not set so CI never',
+      'flakes on missing secrets.'
+    ].join('\n')
+  )
+}
+
+// ── Reporting helpers ──
+
+function summarizeLanguage(
+  language: STTLanguage,
+  results: PerSentenceResult[]
+): LanguageSummary {
+  const filtered = results.filter((r) => r.language === language)
+  const successful = filtered.filter((r) => !r.error)
+  const ttfd = successful
+    .map((r) => r.ttfdMs ?? r.totalMs)
+    .sort((a, b) => a - b)
+  const total = successful.map((r) => r.totalMs).sort((a, b) => a - b)
+  const accuracy = aggregateAccuracy(
+    successful.map((r) =>
+      computeErrorRate(r.reference, r.hypothesis, r.language)
+    )
+  )
+  return {
+    language,
+    sampleCount: filtered.length,
+    errors: filtered.length - successful.length,
+    accuracy,
+    ttfd: {
+      p50: percentile(ttfd, 50),
+      p95: percentile(ttfd, 95),
+      p99: percentile(ttfd, 99)
+    },
+    total: {
+      p50: percentile(total, 50),
+      p95: percentile(total, 95),
+      p99: percentile(total, 99)
+    },
+    audioDurationSec: successful.reduce((acc, r) => acc + r.audioDurationSec, 0)
+  }
+}
+
+function buildMarkdown(report: Report): string {
+  const lines: string[] = [
+    '# GPT-Realtime-Whisper Benchmark',
+    '',
+    `Run: ${report.timestamp}`,
+    `Model: ${report.model}`,
+    `Latency tier: ${report.latency}`,
+    `Endpoint: ${report.endpoint}`,
+    `Manifest: ${report.manifest}`,
+    '',
+    '## Accuracy & Latency',
+    '',
+    '| Language | Samples | Errors | Error rate (CER/WER) | TTFD p50 | TTFD p95 | Total p50 | Total p95 |',
+    '|---|---|---|---|---|---|---|---|'
+  ]
+  for (const s of report.perLanguage) {
+    const errPct = (s.accuracy.errorRate * 100).toFixed(2)
+    lines.push(
+      `| ${s.language.toUpperCase()} | ${s.sampleCount} | ${s.errors} | ${errPct}% | ${s.ttfd.p50.toFixed(0)}ms | ${s.ttfd.p95.toFixed(0)}ms | ${s.total.p50.toFixed(0)}ms | ${s.total.p95.toFixed(0)}ms |`
+    )
+  }
+  lines.push('')
+  lines.push('## Projected Cost')
+  lines.push('')
+  lines.push(
+    `Price: ${formatUsd(report.cost.usdPerMinute, 3)} per minute (documented 2026-05-07).`
+  )
+  lines.push(
+    `Projection @ ${report.cost.projectionHoursPerDay}h/day x ${report.cost.projectionDaysPerMonth} days/month: ${formatUsd(report.cost.projectedMonthlyUsd)}/month per user.`
+  )
+  lines.push('')
+  lines.push('## Notes')
+  lines.push('')
+  lines.push(report.notes)
+  return lines.join('\n') + '\n'
+}
+
+function writeReport(report: Report): { jsonPath: string; mdPath: string } {
+  mkdirSync(RESULTS_DIR, { recursive: true })
+  const ts = report.timestamp.replace(/[:.]/g, '-').slice(0, 19)
+  const base = `gpt-realtime-whisper-${report.latency}-${ts}`
+  const jsonPath = join(RESULTS_DIR, `${base}.json`)
+  writeFileSync(jsonPath, JSON.stringify(report, null, 2))
+  const mdPath = join(RESULTS_DIR, `${base}.md`)
+  writeFileSync(mdPath, buildMarkdown(report))
+  return { jsonPath, mdPath }
+}
+
+// ── Main ──
+
+async function main(): Promise<void> {
+  const parsed = parseArgs()
+  const apiKey = process.env.OPENAI_API_KEY
+  if (!apiKey) {
+    console.warn(
+      '[bench] OPENAI_API_KEY is not set. Skipping the gpt-realtime-whisper benchmark.\n' +
+        '        Re-run with the env var set to produce a real result.'
+    )
+    return
+  }
+
+  const manifest = loadManifest()
+  let entries =
+    parsed.language === 'all'
+      ? manifest
+      : manifest.filter((e) => e.language === parsed.language)
+  if (parsed.limit !== undefined) {
+    entries = entries.slice(0, parsed.limit)
+  }
+  if (entries.length === 0) {
+    console.error(`[bench] No manifest entries matched filter "${parsed.language}".`)
+    process.exit(1)
+  }
+
+  console.log(
+    `[bench] gpt-realtime-whisper @ ${parsed.latency} latency, ${entries.length} clips`
+  )
+  const results: PerSentenceResult[] = []
+  for (let i = 0; i < entries.length; i++) {
+    const entry = entries[i]!
+    const audioPath = resolveAudioPath(entry)
+    if (!existsSync(audioPath)) {
+      console.error(
+        `  [${i + 1}/${entries.length}] ${entry.id}: missing audio file at ${audioPath}.\n` +
+          '        Run `npm run stt:generate-testset` from benchmark/ to (re)create it.'
+      )
+      results.push({
+        id: entry.id,
+        language: entry.language,
+        domain: entry.domain,
+        reference: entry.reference_text,
+        hypothesis: '',
+        audioDurationSec: 0,
+        totalMs: 0,
+        errorRate: 1,
+        error: `missing audio file: ${audioPath}`
+      })
+      continue
+    }
+
+    try {
+      const wav = readWav(audioPath)
+      const upsampled = resampleLinear(wav.samples, wav.sampleRate, TARGET_SAMPLE_RATE)
+      const pcm = float32ToPcm16(upsampled)
+      const result = await transcribeOnce({
+        apiKey,
+        languageHint: entry.language,
+        latency: parsed.latency,
+        pcm16At24kHz: pcm,
+        timeoutMs: parsed.timeoutMs,
+        endpoint: parsed.endpoint
+      })
+      const accuracy = computeErrorRate(entry.reference_text, result.text, entry.language)
+      results.push({
+        id: entry.id,
+        language: entry.language,
+        domain: entry.domain,
+        reference: entry.reference_text,
+        hypothesis: result.text,
+        audioDurationSec: wav.samples.length / wav.sampleRate,
+        ttfdMs: result.ttfdMs,
+        totalMs: result.totalMs,
+        errorRate: accuracy.errorRate
+      })
+      const errPct = (accuracy.errorRate * 100).toFixed(1)
+      const ttfd = result.ttfdMs ? `${result.ttfdMs.toFixed(0)}ms` : 'n/a'
+      console.log(
+        `  [${i + 1}/${entries.length}] ${entry.id}: ER=${errPct}% TTFD=${ttfd} total=${result.totalMs.toFixed(0)}ms`
+      )
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err)
+      console.error(`  [${i + 1}/${entries.length}] ${entry.id}: ERROR ${message}`)
+      results.push({
+        id: entry.id,
+        language: entry.language,
+        domain: entry.domain,
+        reference: entry.reference_text,
+        hypothesis: '',
+        audioDurationSec: 0,
+        totalMs: 0,
+        errorRate: 1,
+        error: message
+      })
+    }
+  }
+
+  const languages: STTLanguage[] =
+    parsed.language === 'all' ? ['ja', 'en'] : [parsed.language]
+  const perLanguage = languages.map((lang) => summarizeLanguage(lang, results))
+
+  const report: Report = {
+    timestamp: new Date().toISOString(),
+    model: 'gpt-realtime-whisper',
+    latency: parsed.latency,
+    endpoint: parsed.endpoint ?? 'wss://api.openai.com/v1/realtime?model=gpt-realtime-whisper',
+    manifest: MANIFEST_PATH,
+    perLanguage,
+    results,
+    cost: {
+      usdPerMinute: 0.017,
+      projectionHoursPerDay: PROJECTION_HOURS_PER_DAY,
+      projectionDaysPerMonth: PROJECTION_DAYS_PER_MONTH,
+      projectedMonthlyUsd: projectMonthlyUsd(PROJECTION_HOURS_PER_DAY, PROJECTION_DAYS_PER_MONTH)
+    },
+    notes:
+      'Audio: 16 kHz mono WAV from benchmark/testset/stt-audio, linearly upsampled to 24 kHz PCM16 ' +
+      'because the Realtime endpoint requires 24 kHz input. CER/WER are computed against the manifest references ' +
+      'with the same tokenization rules used by every other engine in benchmark/src/wer.ts so the numbers are ' +
+      'directly comparable to existing local-engine baselines.'
+  }
+  const { jsonPath, mdPath } = writeReport(report)
+  console.log(`\n[bench] JSON: ${jsonPath}`)
+  console.log(`[bench] Markdown: ${mdPath}`)
+  for (const summary of perLanguage) {
+    const errPct = (summary.accuracy.errorRate * 100).toFixed(2)
+    console.log(
+      `[bench] ${summary.language.toUpperCase()}: ${errPct}% (n=${summary.sampleCount}, errors=${summary.errors}) ` +
+        `TTFD p50=${summary.ttfd.p50.toFixed(0)}ms total p50=${summary.total.p50.toFixed(0)}ms`
+    )
+  }
+  console.log(
+    `[bench] Projected cost @ ${PROJECTION_HOURS_PER_DAY}h/day x ${PROJECTION_DAYS_PER_MONTH}d/month: ${formatUsd(report.cost.projectedMonthlyUsd)}`
+  )
+}
+
+main().catch((err) => {
+  console.error('[bench] Fatal:', err)
+  process.exit(1)
+})

--- a/benchmark/gpt-realtime-whisper-eval/cost.test.ts
+++ b/benchmark/gpt-realtime-whisper-eval/cost.test.ts
@@ -1,0 +1,44 @@
+/**
+ * Unit tests for the cost projection helpers.
+ */
+import { describe, it, expect } from 'vitest'
+
+import { GPT_REALTIME_WHISPER_USD_PER_MINUTE, formatUsd, projectMonthlyUsd } from './cost'
+
+describe('projectMonthlyUsd', () => {
+  it('computes USD cost for the documented price', () => {
+    // 4h/day * 22 days = 88h = 5,280 minutes. 5,280 * 0.017 = 89.76 USD.
+    const usd = projectMonthlyUsd(4, 22)
+    expect(Number(usd.toFixed(2))).toBe(89.76)
+  })
+
+  it('is linear in hoursPerDay', () => {
+    const oneHour = projectMonthlyUsd(1, 22)
+    const fourHours = projectMonthlyUsd(4, 22)
+    expect(Number((fourHours / oneHour).toFixed(6))).toBe(4)
+  })
+
+  it('treats zero usage as zero cost', () => {
+    expect(projectMonthlyUsd(0, 22)).toBe(0)
+    expect(projectMonthlyUsd(8, 0)).toBe(0)
+  })
+
+  it('rejects negative inputs', () => {
+    expect(() => projectMonthlyUsd(-1, 22)).toThrow()
+    expect(() => projectMonthlyUsd(1, -22)).toThrow()
+  })
+})
+
+describe('GPT_REALTIME_WHISPER_USD_PER_MINUTE', () => {
+  it('matches the public price card (2026-05-07)', () => {
+    expect(GPT_REALTIME_WHISPER_USD_PER_MINUTE).toBe(0.017)
+  })
+})
+
+describe('formatUsd', () => {
+  it('produces a stable USD string', () => {
+    expect(formatUsd(89.7621)).toBe('$89.76')
+    expect(formatUsd(0, 2)).toBe('$0.00')
+    expect(formatUsd(1.2345, 4)).toBe('$1.2345')
+  })
+})

--- a/benchmark/gpt-realtime-whisper-eval/cost.ts
+++ b/benchmark/gpt-realtime-whisper-eval/cost.ts
@@ -1,0 +1,31 @@
+/**
+ * Cost projection utilities for GPT-Realtime-Whisper.
+ *
+ * OpenAI prices gpt-realtime-whisper at USD 0.017 per minute of audio
+ * duration (announced 2026-05-07, source: developers.openai.com docs).
+ * That is per-minute billing of duration sent to the API, independent of
+ * latency tier or transcript length.
+ */
+
+export const GPT_REALTIME_WHISPER_USD_PER_MINUTE = 0.017
+
+/**
+ * Projected monthly USD cost for a target daily usage pattern.
+ *
+ * @param hoursPerDay Average hours of speech transcribed per day.
+ * @param daysPerMonth Number of usage days per month (default 22 — work days).
+ */
+export function projectMonthlyUsd(hoursPerDay: number, daysPerMonth = 22): number {
+  if (hoursPerDay < 0 || daysPerMonth < 0) {
+    throw new Error('hoursPerDay and daysPerMonth must be non-negative')
+  }
+  const minutesPerMonth = hoursPerDay * 60 * daysPerMonth
+  return minutesPerMonth * GPT_REALTIME_WHISPER_USD_PER_MINUTE
+}
+
+/**
+ * Format a USD cost as a stable string for tables and logs.
+ */
+export function formatUsd(usd: number, decimals = 2): string {
+  return `$${usd.toFixed(decimals)}`
+}

--- a/benchmark/gpt-realtime-whisper-eval/realtime-client.test.ts
+++ b/benchmark/gpt-realtime-whisper-eval/realtime-client.test.ts
@@ -1,0 +1,52 @@
+/**
+ * Unit tests for the Realtime transcription client helpers.
+ */
+import { describe, it, expect } from 'vitest'
+
+import { buildSessionUpdate, transcribeOnce } from './realtime-client'
+
+describe('buildSessionUpdate', () => {
+  it('uses the documented schema for gpt-realtime-whisper', () => {
+    const payload = buildSessionUpdate('ja', 'low') as {
+      type: string
+      session: {
+        type: string
+        audio: {
+          input: {
+            format: { type: string; rate: number }
+            transcription: { model: string; language?: string; delay: string }
+            turn_detection: null
+          }
+        }
+      }
+    }
+    expect(payload.type).toBe('session.update')
+    expect(payload.session.type).toBe('transcription')
+    expect(payload.session.audio.input.format.type).toBe('audio/pcm')
+    expect(payload.session.audio.input.format.rate).toBe(24_000)
+    expect(payload.session.audio.input.transcription.model).toBe('gpt-realtime-whisper')
+    expect(payload.session.audio.input.transcription.language).toBe('ja')
+    expect(payload.session.audio.input.transcription.delay).toBe('low')
+    expect(payload.session.audio.input.turn_detection).toBeNull()
+  })
+
+  it('omits language when no hint is provided', () => {
+    const payload = buildSessionUpdate(undefined, 'medium') as {
+      session: { audio: { input: { transcription: Record<string, unknown> } } }
+    }
+    const transcription = payload.session.audio.input.transcription
+    expect('language' in transcription).toBe(false)
+    expect(transcription.delay).toBe('medium')
+  })
+})
+
+describe('transcribeOnce', () => {
+  it('rejects when API key is missing', async () => {
+    await expect(
+      transcribeOnce({
+        apiKey: '',
+        pcm16At24kHz: Buffer.alloc(0)
+      })
+    ).rejects.toThrow(/OPENAI_API_KEY is required/)
+  })
+})

--- a/benchmark/gpt-realtime-whisper-eval/realtime-client.ts
+++ b/benchmark/gpt-realtime-whisper-eval/realtime-client.ts
@@ -1,0 +1,227 @@
+/**
+ * Thin OpenAI Realtime transcription client used by the GPT-Realtime-Whisper
+ * benchmark.
+ *
+ * The transcription session protocol (verified against developers.openai.com
+ * docs in 2026-06):
+ *   - WebSocket URL: wss://api.openai.com/v1/realtime?model=gpt-realtime-whisper
+ *     (the connection-time model query parameter selects the transcription
+ *     entry point; a session.update event then sets the transcription-specific
+ *     options).
+ *   - Authorization: Bearer <OPENAI_API_KEY>
+ *   - Configure with a "session.update" event whose payload is
+ *     { session: { type: "transcription", audio: { input: { format, transcription, turn_detection } } } }.
+ *   - Send PCM via "input_audio_buffer.append" (base64 string).
+ *   - With turn_detection disabled, commit explicitly with
+ *     "input_audio_buffer.commit" and wait for
+ *     "conversation.item.input_audio_transcription.completed".
+ *
+ * Sources:
+ *   - https://developers.openai.com/api/docs/guides/realtime-transcription
+ *   - https://developers.openai.com/api/docs/guides/realtime-websocket
+ *
+ * This module is intentionally framework-free — it relies on the global
+ * WebSocket constructor available in Node 22+ (and Electron 33+).
+ */
+
+import { Buffer } from 'node:buffer'
+
+export type LatencyTier = 'minimal' | 'low' | 'medium' | 'high' | 'xhigh'
+
+export interface TranscribeOptions {
+  apiKey: string
+  /** Either "ja" or "en" to provide a language hint, or undefined for auto. */
+  languageHint?: 'ja' | 'en'
+  /** Documented latency tier. Default "low" matches live-translate's 3 s chunks. */
+  latency?: LatencyTier
+  /** PCM16 mono samples at 24 kHz (the documented Realtime input format). */
+  pcm16At24kHz: Buffer
+  /** Wall-clock timeout for a single transcription. */
+  timeoutMs?: number
+  /** Override the WebSocket endpoint (used in tests). */
+  endpoint?: string
+}
+
+export interface TranscribeResult {
+  /** Final transcript. */
+  text: string
+  /** Wall-clock time-to-first-delta in milliseconds, undefined if no delta arrived. */
+  ttfdMs?: number
+  /** Wall-clock time to "completed" event in milliseconds. */
+  totalMs: number
+}
+
+const DEFAULT_ENDPOINT = 'wss://api.openai.com/v1/realtime?model=gpt-realtime-whisper'
+const DEFAULT_TIMEOUT_MS = 60_000
+const MAX_APPEND_CHUNK_BYTES = 64 * 1024 // keep individual WebSocket frames small
+const TARGET_RATE_HZ = 24_000
+
+/**
+ * Build the session.update payload sent on connect. Exposed for unit testing
+ * so we can lock in the documented schema without spinning up a mock
+ * WebSocket server.
+ */
+export function buildSessionUpdate(
+  languageHint: 'ja' | 'en' | undefined,
+  latency: LatencyTier
+): Record<string, unknown> {
+  return {
+    type: 'session.update',
+    session: {
+      type: 'transcription',
+      audio: {
+        input: {
+          format: { type: 'audio/pcm', rate: TARGET_RATE_HZ },
+          transcription: {
+            model: 'gpt-realtime-whisper',
+            ...(languageHint ? { language: languageHint } : {}),
+            delay: latency
+          },
+          turn_detection: null
+        }
+      }
+    }
+  }
+}
+
+/**
+ * Run one transcription against the GPT-Realtime-Whisper streaming endpoint.
+ * Reject on timeout, transport error, or "error" event from the server.
+ */
+export function transcribeOnce(options: TranscribeOptions): Promise<TranscribeResult> {
+  const {
+    apiKey,
+    languageHint,
+    latency = 'low',
+    pcm16At24kHz,
+    timeoutMs = DEFAULT_TIMEOUT_MS,
+    endpoint = DEFAULT_ENDPOINT
+  } = options
+
+  if (!apiKey) {
+    return Promise.reject(new Error('OPENAI_API_KEY is required'))
+  }
+  if (typeof WebSocket === 'undefined') {
+    return Promise.reject(
+      new Error(
+        'Global WebSocket is not available. Run on Node 22+ or Electron 33+.'
+      )
+    )
+  }
+
+  return new Promise<TranscribeResult>((resolve, reject) => {
+    // Node's WebSocket (undici-backed since 22.x) accepts an options bag as
+    // second arg with custom headers. The DOM lib types do not include this,
+    // so we cast through unknown here.
+    const ws = new WebSocket(endpoint, {
+      headers: {
+        Authorization: `Bearer ${apiKey}`
+      }
+    } as unknown as string)
+
+    const start = performance.now()
+    let firstDeltaAt: number | undefined
+    let finalText = ''
+    let settled = false
+
+    const timer = setTimeout(() => {
+      if (settled) return
+      settled = true
+      try {
+        ws.close(1000, 'timeout')
+      } catch {
+        /* ignore */
+      }
+      reject(new Error(`gpt-realtime-whisper transcription timed out after ${timeoutMs}ms`))
+    }, timeoutMs)
+
+    const finish = (err: Error | null, value?: TranscribeResult): void => {
+      if (settled) return
+      settled = true
+      clearTimeout(timer)
+      try {
+        ws.close()
+      } catch {
+        /* ignore */
+      }
+      if (err) reject(err)
+      else if (value) resolve(value)
+    }
+
+    ws.addEventListener('open', () => {
+      // Shape per developers.openai.com/api/docs/guides/realtime-transcription
+      // (verified 2026-06). Manual commit because we send the entire
+      // utterance in one shot.
+      ws.send(JSON.stringify(buildSessionUpdate(languageHint, latency)))
+
+      // Stream PCM in modest chunks so individual frames stay <= 64 KB.
+      for (let i = 0; i < pcm16At24kHz.length; i += MAX_APPEND_CHUNK_BYTES) {
+        const chunk = pcm16At24kHz.subarray(i, i + MAX_APPEND_CHUNK_BYTES)
+        ws.send(
+          JSON.stringify({
+            type: 'input_audio_buffer.append',
+            audio: chunk.toString('base64')
+          })
+        )
+      }
+      ws.send(JSON.stringify({ type: 'input_audio_buffer.commit' }))
+    })
+
+    ws.addEventListener('message', (event: MessageEvent<unknown>) => {
+      try {
+        const data = event.data
+        let raw: string
+        if (typeof data === 'string') raw = data
+        else if (data instanceof ArrayBuffer) raw = Buffer.from(data).toString('utf-8')
+        else if (Buffer.isBuffer(data)) raw = data.toString('utf-8')
+        else if (data instanceof Uint8Array) raw = Buffer.from(data).toString('utf-8')
+        else raw = String(data)
+        const msg = JSON.parse(raw) as RealtimeServerEvent
+        switch (msg.type) {
+          case 'conversation.item.input_audio_transcription.delta': {
+            if (firstDeltaAt === undefined) firstDeltaAt = performance.now() - start
+            if (typeof msg.delta === 'string') finalText += msg.delta
+            break
+          }
+          case 'conversation.item.input_audio_transcription.completed': {
+            if (typeof msg.transcript === 'string' && msg.transcript.length > 0) {
+              finalText = msg.transcript
+            }
+            const totalMs = performance.now() - start
+            finish(null, { text: finalText.trim(), ttfdMs: firstDeltaAt, totalMs })
+            break
+          }
+          case 'error': {
+            const code = msg.error?.code ? ` [${msg.error.code}]` : ''
+            const message = msg.error?.message ?? 'unknown error'
+            finish(new Error(`gpt-realtime-whisper server error${code}: ${message}`))
+            break
+          }
+          default:
+            // Ignore session.* lifecycle, etc.
+            break
+        }
+      } catch (err) {
+        finish(err instanceof Error ? err : new Error(String(err)))
+      }
+    })
+
+    ws.addEventListener('error', (event: Event) => {
+      const message = (event as { message?: string }).message ?? 'WebSocket transport error'
+      finish(new Error(message))
+    })
+
+    ws.addEventListener('close', (event: CloseEvent) => {
+      if (settled) return
+      const reason = event.reason ? `: ${event.reason}` : ''
+      finish(new Error(`WebSocket closed before completion (code ${event.code}${reason})`))
+    })
+  })
+}
+
+interface RealtimeServerEvent {
+  type: string
+  delta?: string
+  transcript?: string
+  error?: { code?: string; message?: string }
+}

--- a/benchmark/tsconfig.json
+++ b/benchmark/tsconfig.json
@@ -8,13 +8,20 @@
     "rootDir": ".",
     "declaration": false
   },
-  "include": ["src/**/*.ts", "run.ts", "conversational-ja-en/**/*.ts"],
+  "include": [
+    "src/**/*.ts",
+    "run.ts",
+    "conversational-ja-en/**/*.ts",
+    "gpt-realtime-whisper-eval/**/*.ts"
+  ],
   "exclude": [
     "node_modules",
     "dist",
     "models",
     "results",
     "conversational-ja-en/results",
-    "conversational-ja-en/**/*.test.ts"
+    "conversational-ja-en/**/*.test.ts",
+    "gpt-realtime-whisper-eval/results",
+    "gpt-realtime-whisper-eval/**/*.test.ts"
   ]
 }

--- a/docs/research/698-gpt-realtime-whisper-eval.md
+++ b/docs/research/698-gpt-realtime-whisper-eval.md
@@ -1,0 +1,141 @@
+# #698 — GPT-Realtime-Whisper Evaluation
+
+Research scaffold and public-data summary for Issue
+[#698](https://github.com/rioX432/live-translate/issues/698).
+
+Filed under `docs/research/` per `.claude/rules/ai-ops.md` — research
+documents are **not** implementations. The Phase 3 decision in #698 still
+gates whether any production code changes happen.
+
+## Scope
+
+Evaluate whether OpenAI's `gpt-realtime-whisper` (Realtime API streaming
+transcription, released 2026-05-07) should be wired as an **opt-in cloud STT
+mode** in live-translate. Per #698:
+
+- Phase 1 — measure JA CER, EN WER, latency, and cost.
+- Phase 2 — compare against the existing local STT engines.
+- Phase 3 decision gate:
+  - JA CER improvement ≤ 2.0 pp over best local → close as `won't`.
+  - JA CER improvement > 2.0 pp → open follow-up design issue.
+
+Core Value alignment: this does **not** change the offline default. Cloud STT
+would be opt-in only, parallel to the existing Microsoft Translator / Google
+Translate / Gemini rotation on the translation side. CV #1 (offline-first)
+remains intact; CV #2 (realtime) is the candidate improvement axis.
+
+## What gpt-realtime-whisper actually is
+
+| Attribute | Value | Source |
+|---|---|---|
+| Release | 2026-05-07 | [MarkTechPost coverage](https://www.marktechpost.com/2026/05/08/openai-releases-three-realtime-audio-models-gpt-realtime-2-gpt-realtime-translate-and-gpt-realtime-whisper-in-the-realtime-api/) |
+| Pricing | USD 0.017 / minute of audio | [OpenAI model docs](https://developers.openai.com/api/docs/models/gpt-realtime-whisper) |
+| Protocol | Realtime API WebSocket, `session.type = "transcription"`, model in `audio.input.transcription.model` | [OpenAI Realtime Transcription guide](https://developers.openai.com/api/docs/guides/realtime-transcription) |
+| Audio format | pcm16 mono @ 24 kHz | Same guide |
+| Latency tuning | `audio.input.transcription.delay` ∈ {`minimal`,`low`,`medium`,`high`,`xhigh`} | Same guide |
+| Marketing claim | "Lowest-latency streaming transcription path" | [Realtime models overview](https://www.mindstudio.ai/blog/gpt-realtime-voice-models-explained) |
+| Relation to `whisper-1` | Streaming successor for live-output use cases; whisper-1 still cheaper for batch | Same overview |
+| Relation to `gpt-4o-transcribe` | Different model; gpt-4o-transcribe is batch HTTP, optimized for accuracy | [OpenAI model docs](https://developers.openai.com/api/docs/models/gpt-4o-transcribe) |
+
+### Published accuracy data (or lack thereof)
+
+- **OpenAI**: no per-language WER/CER published for `gpt-realtime-whisper`
+  as of 2026-06.
+- **Artificial Analysis**: has a leaderboard slot for the model but the
+  entry is empty (no AA-WER reported). [Page](https://artificialanalysis.ai/speech-to-text/models/openai-gpt-realtime-whisper).
+- **Artificial Analysis (sibling model gpt-4o-transcribe)**: AA-WER 4.0 %
+  on the combined English benchmark, 33.0 audio-seconds-per-second median
+  speed, USD 6.00 / 1,000 minutes. No JA breakdown.
+- **Independent JA ASR benchmarks (2026)**:
+  - [Neosophie 2026-02 JA ASR benchmark](https://neosophie.com/en/blog/20260226-japanese-asr-benchmark)
+    reports (CER, conversational JA):
+    - `qwen/qwen3-asr-1.7b`: 14.0 %
+    - `openai/whisper-large-v3-turbo`: 18.4 %
+    - `mistralai/voxtral-mini-4b-realtime-2602`: 21.2 %
+    - `kotoba-tech/kotoba-whisper-v2.0`: 49.5 %
+    - Neither `gpt-realtime-whisper` nor `gpt-4o-transcribe` appears in the
+      table.
+  - Numbers from this external benchmark use a different test set
+    (~10 min of natural conversational Japanese vs the in-repo
+    business/technical sentence fixtures), so they are **not directly
+    comparable** to live-translate's published baselines. They are useful
+    only as a sanity check on the *relative ordering* of local engines.
+
+### Why "no JA number" is itself informative
+
+The conservative prior for a streaming model launched in May 2026 with no
+language-specific accuracy story:
+
+1. OpenAI explicitly markets the model as **latency-first**, not
+   accuracy-first. The press materials position gpt-4o-transcribe as the
+   "high-accuracy" sibling for batch use.
+2. Streaming systems with low-latency partial output (sub-second TTFD) have
+   historically given up several percentage points of accuracy vs their
+   batch counterparts (e.g. Microsoft / Google streaming-vs-batch deltas
+   in [Soniox 2026 benchmark](https://soniox.com/benchmarks)).
+3. Japanese is consistently 1.5–3× harder than English for current
+   multilingual ASR systems. If the English AA-WER for `gpt-4o-transcribe`
+   is ≈ 4 %, the JA equivalent is typically ≥ 8–10 %.
+
+A 2 pp improvement over the current best local JA CER of 5.6 % means cloud
+JA CER **≤ 3.6 %**, which is *better than the published English number for
+the higher-accuracy batch sibling*. That is implausible but not impossible —
+hence the need to actually measure rather than assume.
+
+## What we built
+
+`benchmark/gpt-realtime-whisper-eval/` — a self-contained STT bench scaffold:
+
+- `realtime-client.ts` — WebSocket client implementing the documented
+  Realtime transcription protocol. Exports a pure `buildSessionUpdate`
+  helper so the schema is locked in by unit tests.
+- `audio.ts` — local 16-bit mono WAV reader + linear resampler
+  (16 kHz → 24 kHz, the format the Realtime endpoint requires). Avoids an
+  ffmpeg dependency.
+- `cost.ts` — pure helpers for monthly USD projection at the documented
+  $0.017/min price.
+- `bench-gpt-realtime-whisper.ts` — CLI runner over the existing
+  `benchmark/testset/stt-manifest.jsonl` corpus, reusing `wer.ts` so CER/WER
+  numbers are directly comparable to existing engines.
+- `cost.test.ts`, `audio.test.ts`, `realtime-client.test.ts` — 14 unit tests
+  (vitest) covering price math, audio helpers, and the session.update
+  payload shape.
+- `README.md` — how to run, audio-source suggestions for extending the
+  corpus (Common Voice JA, ReazonSpeech v2).
+- `RESULTS.md` — Phase 3 decision template with the local-engine baseline
+  table, public-data summary, and a "how to finalize" checklist.
+
+Skipping cleanly without `OPENAI_API_KEY` is intentional so the bench can
+live in CI without flaking.
+
+## Preliminary recommendation
+
+**Inconclusive, leaning `won't-do`.** Justification:
+
+- No third party has published a JA CER for `gpt-realtime-whisper`, so the
+  Phase 3 gate cannot be evaluated from public data alone.
+- The implied threshold (JA CER ≤ ~3.6 %) is below the *English* AA-WER of
+  the higher-accuracy batch sibling. Reaching it with a streaming model on
+  Japanese would be an outlier.
+- A measured bench is cheap (USD < 1 to run the bundled 20-clip manifest at
+  $0.017/min). The blocker is access to a Realtime API key.
+
+Next steps once a key is available:
+
+1. Run `OPENAI_API_KEY=sk-... npx tsx --expose-gc benchmark/gpt-realtime-whisper-eval/bench-gpt-realtime-whisper.ts`.
+2. Append the resulting markdown into `benchmark/gpt-realtime-whisper-eval/RESULTS.md`.
+3. Apply the Phase 3 gate and either close #698 as `won't` or open a
+   "design opt-in cloud STT mode" follow-up.
+
+## Sources
+
+- [OpenAI — gpt-realtime-whisper model card](https://developers.openai.com/api/docs/models/gpt-realtime-whisper)
+- [OpenAI — Realtime transcription guide](https://developers.openai.com/api/docs/guides/realtime-transcription)
+- [OpenAI — Advancing voice intelligence (announcement)](https://openai.com/index/advancing-voice-intelligence-with-new-models-in-the-api/)
+- [Artificial Analysis — gpt-realtime-whisper](https://artificialanalysis.ai/speech-to-text/models/openai-gpt-realtime-whisper)
+- [Artificial Analysis — gpt-4o-transcribe](https://artificialanalysis.ai/speech-to-text/models/openai-gpt-4o-transcribe)
+- [MarkTechPost — OpenAI Releases Three Realtime Audio Models](https://www.marktechpost.com/2026/05/08/openai-releases-three-realtime-audio-models-gpt-realtime-2-gpt-realtime-translate-and-gpt-realtime-whisper-in-the-realtime-api/)
+- [Neosophie — 2026 Japanese ASR benchmark](https://neosophie.com/en/blog/20260226-japanese-asr-benchmark)
+- [Soniox 2026 STT benchmark](https://soniox.com/benchmarks)
+- [9to5Mac — OpenAI voice models that reason, translate and transcribe (2026-05-07)](https://9to5mac.com/2026/05/07/openai-has-new-voice-models-that-reason-translate-and-transcribe-as-you-speak/)
+- [Latent.Space AINews — GPT-Realtime-2, -Translate, -Whisper](https://www.latent.space/p/ainews-gpt-realtime-2-translate-and)

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -3,7 +3,11 @@ import { defineConfig } from 'vitest/config'
 export default defineConfig({
   test: {
     environment: 'node',
-    include: ['src/**/*.test.ts', 'benchmark/conversational-ja-en/**/*.test.ts'],
+    include: [
+      'src/**/*.test.ts',
+      'benchmark/conversational-ja-en/**/*.test.ts',
+      'benchmark/gpt-realtime-whisper-eval/**/*.test.ts'
+    ],
     globals: true
   }
 })


### PR DESCRIPTION
## Description

Scaffold for Issue #698 — evaluate OpenAI's `gpt-realtime-whisper` (released 2026-05-07, USD 0.017/min) against the existing local STT engines.

This PR does **not** change the offline default or any production engine code. It only adds:

- `benchmark/gpt-realtime-whisper-eval/` — self-contained STT bench (WebSocket client, WAV+resampler helpers, cost projection, CLI runner) that reuses the existing `wer.ts` so CER/WER numbers are directly comparable to other engines in this repo.
- `docs/research/698-gpt-realtime-whisper-eval.md` — public-data summary, sources, and a preliminary recommendation.
- 14 unit tests (vitest) covering the price math, audio helpers, and the documented session.update payload shape.
- `benchmark/tsconfig.json` + `vitest.config.ts` + `.gitignore` plumbing for the new directory.

The bench skips cleanly when `OPENAI_API_KEY` is unset (logs an info message and exits 0) so it can live in CI without flaking on missing secrets.

### Preliminary recommendation (Phase 3 of #698): **inconclusive, leaning won't-do**

- No third party has published a JA CER for `gpt-realtime-whisper` as of 2026-06 (OpenAI marketing only, Artificial Analysis leaderboard entry is empty, MarkTechPost/9to5Mac coverage carries no numbers).
- The sister model `gpt-4o-transcribe` (higher accuracy, batch-only) shows ~4.0 % AA-WER on English. Reaching the > 2 pp improvement threshold over our best local JA CER (5.6 % Kotoba-Whisper / 6.8 % Qwen3-ASR balanced) would require cloud JA CER ≤ ~3.6 %, which would be *better than the published English number for the higher-accuracy batch sibling* — implausible for a streaming variant.
- Final decision must wait for a measured run; this PR provides the scaffold so that run is trivial once an `OPENAI_API_KEY` is available.

## Related Issue

Refs #698 (kept as Refs — the issue closes only after a measured bench run determines the Phase 3 outcome).

## Test Checklist
- [x] Unit tests added — 14 new vitest cases (`cost.test.ts`, `audio.test.ts`, `realtime-client.test.ts`), all green
- [x] Type-check passes (`tsc --noEmit -p benchmark/`)
- [x] Full suite still green except pre-existing `virtual-mic-manager.test.ts` failures (naudiodon not built in worktree — unrelated to this PR)
- [ ] N/A — no UI changes
- [ ] N/A — no browser surface

## Checklist
- [x] CLAUDE.md rules followed — research stays in `benchmark/` + `docs/research/`, no production engine code touched
- [x] Core Value alignment documented — does NOT change offline default; any cloud STT mode would be opt-in (CV #1 preserved, CV #2 candidate improvement axis)
- [x] No hardcoded secrets — API key only flows from env into Authorization header, never logged
- [x] English comments / single-line commit message / no AI stamp