### PR TITLE
#719 e2e streaming foundation: E2EStreamingSession + pipeline e2e path + switchEngine reset

### DIFF
--- a/src/engines/types.ts
+++ b/src/engines/types.ts
@@ -180,8 +180,80 @@ export interface E2ETranslationEngine {
    */
   processAudio(audioChunk: Float32Array, sampleRate: number): Promise<TranslationResult | null>
 
+  /**
+   * Optional: create a streaming session for continuous, low-latency
+   * translation of a live audio stream (cloud realtime / local e2e).
+   * Engines that only support single-shot batch translation omit this.
+   */
+  createStreamingSession?(): E2EStreamingSession
+
   /** Release resources */
   dispose(): Promise<void>
+}
+
+/**
+ * Backpressure signal returned by {@link E2EStreamingSession.pushAudio} when the
+ * session's input buffer is full. Callers should await `drained` before pushing more.
+ */
+export interface Backpressure {
+  /** Resolves when the session is ready to accept more audio. */
+  drained: Promise<void>
+}
+
+/**
+ * Sink that receives streaming output from an E2E session.
+ * The pipeline supplies the sink; the session pushes interim/final results into it.
+ * Implementations must ignore emissions once their owning session is aborted.
+ */
+export interface E2EStreamingSink {
+  /** Emit an interim (unconfirmed) result. */
+  interim(result: TranslationResult): void
+  /** Emit a final (confirmed) result. */
+  final(result: TranslationResult): void
+  /** Report a non-fatal error. */
+  error(error: Error): void
+}
+
+/** Options passed to {@link E2EStreamingSession.start}. */
+export interface E2EStreamingStartOptions {
+  /** Sink that receives interim/final results. */
+  sink: E2EStreamingSink
+  /**
+   * Abort signal for the session generation. When aborted, the session must stop
+   * pushing to the sink and release resources. This replaces bare EventEmitter
+   * wiring to avoid post-dispose emits, listener leaks, and cross-session mixing.
+   */
+  signal: AbortSignal
+}
+
+/** Options passed to {@link E2EStreamingSession.stop}. */
+export interface E2EStreamingStopOptions {
+  /** When true, flush any buffered audio and emit a final result before closing. */
+  flush?: boolean
+}
+
+/**
+ * End-to-end streaming session performing continuous STT + translation on a live
+ * audio stream, pushing interim/final results into a sink.
+ *
+ * Lifecycle: start() → pushAudio()* [→ flushSegment()]* → stop().
+ * Generation isolation is enforced via the AbortSignal passed to start(): once
+ * aborted, no further sink emissions are permitted. This is the streaming
+ * counterpart to the single-shot {@link E2ETranslationEngine}, which remains for
+ * backward compatibility.
+ */
+export interface E2EStreamingSession {
+  /** Begin the session with the given sink and abort signal. */
+  start(options: E2EStreamingStartOptions): Promise<void>
+  /**
+   * Push an audio chunk into the session. Returns a {@link Backpressure} signal
+   * when the input buffer is full; returns void when there is capacity.
+   */
+  pushAudio(chunk: Float32Array): Promise<void | Backpressure>
+  /** Optional: force a segment boundary (e.g. on a detected speech pause). */
+  flushSegment?(): Promise<void>
+  /** Stop the session, optionally flushing buffered audio first. */
+  stop(options?: E2EStreamingStopOptions): Promise<void>
 }
 
 /** A glossary entry mapping a source term to its fixed translation */

--- a/src/pipeline/E2EStreamingAdapter.ts
+++ b/src/pipeline/E2EStreamingAdapter.ts
@@ -1,0 +1,39 @@
+import type { EventEmitter } from 'events'
+import type { E2EStreamingSink, TranslationResult } from '../engines/types'
+
+/**
+ * Bridges an E2E streaming session's sink output onto the pipeline's existing
+ * EventEmitter contract ('interim-result' / 'result' / 'error'), so downstream
+ * consumers (SubtitleOverlay / SessionManager) need no changes.
+ *
+ * Emissions are gated by two conditions: the owning session's AbortSignal, and a
+ * generation predicate supplied by the pipeline. Once the session is aborted or
+ * the pipeline generation advances (engine switch), results are dropped — stale
+ * cross-session output is never forwarded.
+ */
+export class E2EStreamingAdapter implements E2EStreamingSink {
+  constructor(
+    private readonly emitter: EventEmitter,
+    private readonly signal: AbortSignal,
+    private readonly isCurrentGeneration: () => boolean
+  ) {}
+
+  private get active(): boolean {
+    return !this.signal.aborted && this.isCurrentGeneration()
+  }
+
+  interim(result: TranslationResult): void {
+    if (!this.active) return
+    this.emitter.emit('interim-result', { ...result, isInterim: true })
+  }
+
+  final(result: TranslationResult): void {
+    if (!this.active) return
+    this.emitter.emit('result', { ...result, isInterim: false })
+  }
+
+  error(error: Error): void {
+    if (!this.active) return
+    this.emitter.emit('error', error)
+  }
+}

--- a/src/pipeline/GERProcessor.ts
+++ b/src/pipeline/GERProcessor.ts
@@ -33,6 +33,8 @@ export interface GERDeps {
   readonly emitter: EventEmitter
   getTranslator(): TranslatorEngine | null
   getGlossary(): GlossaryEntry[]
+  /** Current pipeline session generation — used to drop stale async emits (#719) */
+  getGeneration?(): number
 }
 
 /**
@@ -129,6 +131,7 @@ export class GERProcessor {
     timestamp: number
   ): Promise<void> {
     const t0 = performance.now()
+    const gen = this.deps.getGeneration?.()
 
     const glossaryEntries = this.deps.getGlossary()
     const glossary = glossaryEntries.length > 0
@@ -200,6 +203,12 @@ export class GERProcessor {
       timestamp,
       isInterim: false,
       translationStage: 'ger-corrected'
+    }
+
+    // Drop the correction if the engine was switched/stopped while it was in flight (#719)
+    if (gen !== undefined && this.deps.getGeneration?.() !== gen) {
+      log.info('GER: generation changed during correction, dropping stale result')
+      return
     }
 
     log.info(`GER corrected: "${trimmedOriginal}" → "${trimmedCorrected}" → "${translatedText}"`)

--- a/src/pipeline/StreamingProcessor.ts
+++ b/src/pipeline/StreamingProcessor.ts
@@ -39,6 +39,8 @@ export interface StreamingDeps {
   getDraftSTTEngine?(): STTEngine | null
   /** Speaker diarizer for multi-speaker identification (#549) */
   getDiarizer?(): SpeakerDiarizer | null
+  /** Current pipeline session generation — used to drop stale async emits (#719) */
+  getGeneration?(): number
 }
 
 /**
@@ -83,6 +85,14 @@ export class StreamingProcessor {
     return this.streamingLock
   }
 
+  /**
+   * Whether a result scheduled under generation `gen` may still be emitted (#719).
+   * Returns true when generation tracking is unavailable (no getGeneration dep).
+   */
+  private isCurrentGeneration(gen: number | undefined): boolean {
+    return gen === undefined || this.deps.getGeneration?.() === gen
+  }
+
   /** Reset all streaming state */
   reset(): void {
     this.streamingLock = false
@@ -120,6 +130,7 @@ export class StreamingProcessor {
 
     this.deps.incrementProcessing()
     this.streamingLock = true
+    const gen = this.deps.getGeneration?.()
     try {
       // Fire draft STT in parallel for fast interim results (#536)
       const draftSttEngine = this.deps.getDraftSTTEngine?.()
@@ -208,6 +219,9 @@ export class StreamingProcessor {
               : dbTranslator.translate(fullSourceText, sttResult.language, targetLang, ctx)
 
             translatePromise.then((translated) => {
+              // Drop stale results before mutating shared state, so a switch mid-flight
+              // cannot leave a resurfacing translatedText for the next generation (#719).
+              if (!this.isCurrentGeneration(gen)) return
               this.lastTranslatedConfirmed = translated
               const debouncedResult: TranslationResult = {
                 sourceText: fullSourceText,
@@ -407,6 +421,7 @@ export class StreamingProcessor {
     this.simulMtLastBoundaryText = textToTranslate
     this.simulMtInFlight = true
 
+    const gen = this.deps.getGeneration?.()
     const glossaryEntries = this.deps.getGlossary()
     const glossary = glossaryEntries.length > 0 ? glossaryEntries : undefined
 
@@ -418,6 +433,8 @@ export class StreamingProcessor {
       false, // not a revision — incremental
       this.deps.contextBuffer.getContext(glossary)
     ).then((translated) => {
+      if (!this.isCurrentGeneration(gen)) return
+
       this.simulMtPreviousOutput = translated
       this.lastTranslatedConfirmed = translated
 
@@ -448,6 +465,7 @@ export class StreamingProcessor {
    */
   private runDraftStt(draftEngine: STTEngine, audioBuffer: Float32Array, sampleRate: number): void {
     const t0 = performance.now()
+    const gen = this.deps.getGeneration?.()
     draftEngine.processAudio(audioBuffer, sampleRate)
       .then((draftResult) => {
         const draftMs = (performance.now() - t0).toFixed(0)
@@ -456,6 +474,8 @@ export class StreamingProcessor {
           return
         }
         log.info(`Draft STT: ${draftMs}ms → "${draftResult.text}" [${draftResult.language}]`)
+
+        if (!this.isCurrentGeneration(gen)) return
 
         const targetLang = this.deps.resolveTargetLanguage(draftResult.language)
 
@@ -531,6 +551,7 @@ export class StreamingProcessor {
 
     this.clauseTranslationInFlight = true
 
+    const gen = this.deps.getGeneration?.()
     const glossaryEntries = this.deps.getGlossary()
     const glossary = glossaryEntries.length > 0 ? glossaryEntries : undefined
     const ctx = this.deps.contextBuffer.getContext(glossary)
@@ -554,6 +575,8 @@ export class StreamingProcessor {
     translatePromise.then((translated) => {
       const clauseMs = (performance.now() - t0).toFixed(0)
       log.info(`Clause translation: ${clauseMs}ms → "${translated}" (prefix: "${textToTranslate}")`)
+
+      if (!this.isCurrentGeneration(gen)) return
 
       this.clauseTranslatedPrefix = textToTranslate
       this.clauseTranslation = translated

--- a/src/pipeline/TranslationPipeline.test.ts
+++ b/src/pipeline/TranslationPipeline.test.ts
@@ -1,0 +1,263 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { TranslationPipeline } from './TranslationPipeline'
+import type {
+  STTEngine,
+  STTResult,
+  TranslatorEngine,
+  E2ETranslationEngine,
+  E2EStreamingSession,
+  E2EStreamingSink,
+  E2EStreamingStartOptions,
+  E2EStreamingStopOptions,
+  TranslationResult
+} from '../engines/types'
+
+// GERProcessor transitively imports the Electron-backed worker pool; stub it so the
+// pipeline can be exercised in a plain Node test environment. GER stays disabled here.
+vi.mock('../main/worker-pool', () => ({
+  workerPool: { isAlive: false, sendRequest: vi.fn() }
+}))
+
+function makeResult(source: string, translated: string): TranslationResult {
+  return {
+    sourceText: source,
+    translatedText: translated,
+    sourceLanguage: 'en',
+    targetLanguage: 'ja',
+    timestamp: Date.now()
+  }
+}
+
+class MockStreamingSession implements E2EStreamingSession {
+  sink: E2EStreamingSink | null = null
+  signal: AbortSignal | null = null
+  started = false
+  stopped = false
+  flushed = 0
+  stopFlush: boolean | undefined = undefined
+
+  async start(opts: E2EStreamingStartOptions): Promise<void> {
+    this.sink = opts.sink
+    this.signal = opts.signal
+    this.started = true
+  }
+
+  async pushAudio(): Promise<void> {
+    // Mock: no automatic emission — the test drives sink output explicitly.
+  }
+
+  async flushSegment(): Promise<void> {
+    this.flushed++
+  }
+
+  async stop(opts?: E2EStreamingStopOptions): Promise<void> {
+    this.stopped = true
+    this.stopFlush = opts?.flush
+  }
+}
+
+class MockE2EStreamingEngine implements E2ETranslationEngine {
+  readonly isOffline = true
+  session = new MockStreamingSession()
+  disposed = false
+
+  constructor(readonly id: string, readonly name = id) {}
+
+  async initialize(): Promise<void> {}
+  async processAudio(): Promise<TranslationResult | null> {
+    return null
+  }
+  createStreamingSession(): E2EStreamingSession {
+    return this.session
+  }
+  async dispose(): Promise<void> {
+    this.disposed = true
+  }
+}
+
+class MockSTT implements STTEngine {
+  readonly isOffline = true
+  constructor(
+    readonly id: string,
+    private readonly result: STTResult | null,
+    readonly name = id
+  ) {}
+  async initialize(): Promise<void> {}
+  async processAudio(): Promise<STTResult | null> {
+    return this.result
+  }
+  async dispose(): Promise<void> {}
+}
+
+class MockTranslator implements TranslatorEngine {
+  readonly isOffline = true
+  translateCalls: string[] = []
+  pending: { resolve: (value: string) => void } | null = null
+
+  constructor(
+    readonly id: string,
+    private readonly mode: 'immediate' | 'deferred' = 'immediate',
+    readonly name = id
+  ) {}
+
+  async initialize(): Promise<void> {}
+
+  async translate(text: string): Promise<string> {
+    this.translateCalls.push(text)
+    if (this.mode === 'deferred') {
+      return new Promise<string>((resolve) => {
+        this.pending = { resolve }
+      })
+    }
+    return `T(${text})`
+  }
+
+  async dispose(): Promise<void> {}
+}
+
+describe('TranslationPipeline e2e streaming path (#719)', () => {
+  let pipeline: TranslationPipeline
+  let engine: MockE2EStreamingEngine
+
+  beforeEach(async () => {
+    pipeline = new TranslationPipeline()
+    engine = new MockE2EStreamingEngine('mock-e2e')
+    pipeline.registerE2E('mock-e2e', () => engine)
+    await pipeline.switchEngine({ mode: 'e2e', e2eEngineId: 'mock-e2e' })
+    pipeline.start()
+  })
+
+  afterEach(async () => {
+    await pipeline.dispose()
+  })
+
+  it('starts a session lazily on first realtime audio and forwards sink.interim as interim-result', async () => {
+    const interim: TranslationResult[] = []
+    pipeline.on('interim-result', (r) => interim.push(r))
+
+    expect(engine.session.started).toBe(false)
+    await pipeline.pushRealtimeAudio(new Float32Array(16000))
+    expect(engine.session.started).toBe(true)
+
+    engine.session.sink!.interim(makeResult('hello', 'こんにちは'))
+
+    expect(interim).toHaveLength(1)
+    expect(interim[0].isInterim).toBe(true)
+    expect(interim[0].translatedText).toBe('こんにちは')
+  })
+
+  it('forwards sink.final as a result event with isInterim=false', async () => {
+    const finals: TranslationResult[] = []
+    pipeline.on('result', (r) => finals.push(r))
+
+    await pipeline.pushRealtimeAudio(new Float32Array(16000))
+    engine.session.sink!.final(makeResult('hello', 'こんにちは'))
+
+    expect(finals).toHaveLength(1)
+    expect(finals[0].isInterim).toBe(false)
+    expect(finals[0].translatedText).toBe('こんにちは')
+  })
+
+  it('reuses a single session across multiple pushes', async () => {
+    await pipeline.pushRealtimeAudio(new Float32Array(16000))
+    const first = engine.session
+    await pipeline.pushRealtimeAudio(new Float32Array(16000))
+    expect(engine.session).toBe(first)
+  })
+
+  it('forwards speech boundary to the session flush', async () => {
+    await pipeline.pushRealtimeAudio(new Float32Array(16000))
+    await pipeline.onSpeechBoundary()
+    expect(engine.session.flushed).toBe(1)
+  })
+
+  it('is a no-op when not in e2e mode', async () => {
+    const cascade = new TranslationPipeline()
+    cascade.registerSTT('stt', () => new MockSTT('stt', null))
+    cascade.registerTranslator('tr', () => new MockTranslator('tr'))
+    await cascade.switchEngine({ mode: 'cascade', sttEngineId: 'stt', translatorEngineId: 'tr' })
+    cascade.start()
+    // Must not throw and must not create a session.
+    await expect(cascade.pushRealtimeAudio(new Float32Array(16000))).resolves.toBeUndefined()
+    await cascade.dispose()
+  })
+})
+
+describe('TranslationPipeline switchEngine reset regression (#719)', () => {
+  it('drops results from an e2e session torn down by switchEngine', async () => {
+    const pipeline = new TranslationPipeline()
+    const engineA = new MockE2EStreamingEngine('e2e-a')
+    const engineB = new MockE2EStreamingEngine('e2e-b')
+    pipeline.registerE2E('e2e-a', () => engineA)
+    pipeline.registerE2E('e2e-b', () => engineB)
+
+    await pipeline.switchEngine({ mode: 'e2e', e2eEngineId: 'e2e-a' })
+    pipeline.start()
+
+    const emitted: TranslationResult[] = []
+    pipeline.on('interim-result', (r) => emitted.push(r))
+    pipeline.on('result', (r) => emitted.push(r))
+
+    await pipeline.pushRealtimeAudio(new Float32Array(16000))
+    const staleSink = engineA.session.sink!
+
+    await pipeline.switchEngine({ mode: 'e2e', e2eEngineId: 'e2e-b' })
+
+    // Late emissions from the previous (aborted) session must be dropped.
+    staleSink.interim(makeResult('stale', 'stale'))
+    staleSink.final(makeResult('stale', 'stale'))
+
+    expect(emitted).toHaveLength(0)
+    expect(engineA.session.stopped).toBe(true)
+    await pipeline.dispose()
+  })
+
+  it('does not emit stale cascade translations after switching to e2e', async () => {
+    vi.useFakeTimers()
+    try {
+      const pipeline = new TranslationPipeline()
+      const stt = new MockSTT('stt', {
+        text: 'hello world',
+        language: 'en',
+        isFinal: false,
+        timestamp: Date.now()
+      })
+      const translator = new MockTranslator('tr', 'deferred')
+      const e2e = new MockE2EStreamingEngine('e2e')
+      pipeline.registerSTT('stt', () => stt)
+      pipeline.registerTranslator('tr', () => translator)
+      pipeline.registerE2E('e2e', () => e2e)
+
+      await pipeline.switchEngine({ mode: 'cascade', sttEngineId: 'stt', translatorEngineId: 'tr' })
+      pipeline.start()
+
+      const translated: TranslationResult[] = []
+      const collect = (r: TranslationResult) => {
+        if (r.translatedText) translated.push(r)
+      }
+      pipeline.on('interim-result', collect)
+      pipeline.on('result', collect)
+
+      // Schedule a debounced streaming translation.
+      await pipeline.processStreaming(new Float32Array(16000), 16000)
+      // Fire the debounce timer so translate() is invoked and left in flight.
+      vi.advanceTimersByTime(1500)
+      expect(translator.translateCalls.length).toBeGreaterThan(0)
+      expect(translator.pending).not.toBeNull()
+
+      // Switch engines while the translation promise is still pending.
+      await pipeline.switchEngine({ mode: 'e2e', e2eEngineId: 'e2e' })
+
+      // Resolve the now-stale translation.
+      translator.pending!.resolve('STALE-TRANSLATION')
+      await Promise.resolve()
+      await Promise.resolve()
+
+      expect(translated.find((r) => r.translatedText === 'STALE-TRANSLATION')).toBeUndefined()
+
+      await pipeline.dispose()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+})

--- a/src/pipeline/TranslationPipeline.ts
+++ b/src/pipeline/TranslationPipeline.ts
@@ -4,12 +4,14 @@ import type {
   STTEngine,
   TranslatorEngine,
   E2ETranslationEngine,
+  E2EStreamingSession,
   SpeakerDiarizer,
   TranslationResult,
   Language,
   SourceLanguage,
   GlossaryEntry
 } from '../engines/types'
+import { E2EStreamingAdapter } from './E2EStreamingAdapter'
 import { LocalAgreement } from './LocalAgreement'
 import { ContextBuffer } from './ContextBuffer'
 import { TranslationCache } from './TranslationCache'
@@ -103,6 +105,15 @@ export class TranslationPipeline extends EventEmitter {
   // Auto-recovery state
   private consecutiveErrors = 0
 
+  // Session generation counter (#719). Bumped on every engine switch / stop so
+  // async results scheduled under a previous engine are dropped instead of emitted.
+  private generation = 0
+
+  // E2E streaming session state (#719)
+  private streamingSession: E2EStreamingSession | null = null
+  private sessionAbort: AbortController | null = null
+  private sessionStartPromise: Promise<E2EStreamingSession | null> | null = null
+
   // Glossary terms for context-aware translation
   private glossary: GlossaryEntry[] = []
 
@@ -137,12 +148,14 @@ export class TranslationPipeline extends EventEmitter {
       },
       getGER: () => this.ger,
       getDraftSTTEngine: () => this.draftSttEnabled ? this.engineManager.draftSttEngine : null,
-      getDiarizer: () => this.diarizationEnabled ? this.engineManager.diarizer : null
+      getDiarizer: () => this.diarizationEnabled ? this.engineManager.diarizer : null,
+      getGeneration: () => this.generation
     })
     this.ger = new GERProcessor({
       emitter: this,
       getTranslator: () => this.engineManager.translator,
-      getGlossary: () => this.glossary
+      getGlossary: () => this.glossary,
+      getGeneration: () => this.generation
     })
   }
 
@@ -289,6 +302,15 @@ export class TranslationPipeline extends EventEmitter {
 
     try {
       await this.waitForProcessing()
+      // stop()-equivalent reset (#719): bump the generation and clear all streaming
+      // state so results scheduled under the previous engine are never emitted after
+      // the switch (stale LocalAgreement / ContextBuffer / SimulMT / GER / e2e output).
+      this.generation++
+      await this.teardownStreamingSession(false)
+      this.agreement.reset()
+      this.contextBuffer.reset()
+      this.streaming.reset()
+      this.ger.reset()
       this.translationCache.clear()
       await this.engineManager.disposeEngines()
       await this.engineManager.initializeEngines(config, this)
@@ -370,6 +392,10 @@ export class TranslationPipeline extends EventEmitter {
   async stop(): Promise<void> {
     this.memoryMonitor.stop()
     this.setState(PipelineState.IDLE)
+    // Bump generation and tear down the e2e session so no stale async result is
+    // emitted after stop (#719).
+    this.generation++
+    await this.teardownStreamingSession(false)
     this.streaming.reset()
     this.ger.reset()
     this.agreement.reset()
@@ -554,6 +580,107 @@ export class TranslationPipeline extends EventEmitter {
     if (!this.running || !this.engineManager.config) return null
     if (this.engineManager.config.mode !== 'cascade') return null
     return this.streaming.finalizeStreaming(audioChunk, sampleRate)
+  }
+
+  // --- E2E streaming (#719) ---
+
+  /**
+   * Feed a live audio chunk to the e2e streaming session (e2e mode only).
+   * The session emits interim/final results via the existing pipeline events
+   * ('interim-result' / 'result') through {@link E2EStreamingAdapter}.
+   * No-op in cascade mode — use processStreaming/finalizeStreaming there.
+   */
+  async pushRealtimeAudio(chunk: Float32Array): Promise<void> {
+    if (this._state !== PipelineState.RUNNING || !this.engineManager.config) return
+    if (this.engineManager.config.mode !== 'e2e') return
+
+    const session = await this.ensureStreamingSession()
+    if (!session) return
+
+    const backpressure = await session.pushAudio(chunk)
+    if (backpressure) {
+      await backpressure.drained
+    }
+  }
+
+  /**
+   * Signal a speech segment boundary (e.g. VAD pause) to the e2e session so it can
+   * finalize the current segment. No-op in cascade mode or when the session has no
+   * flush capability.
+   */
+  async onSpeechBoundary(): Promise<void> {
+    if (this.engineManager.config?.mode !== 'e2e') return
+    await this.streamingSession?.flushSegment?.()
+  }
+
+  /**
+   * Lazily start the e2e streaming session on first realtime audio. Concurrent
+   * callers share a single in-flight start. Returns null when the active e2e
+   * engine does not support streaming.
+   */
+  private async ensureStreamingSession(): Promise<E2EStreamingSession | null> {
+    if (this.streamingSession) return this.streamingSession
+    if (this.sessionStartPromise) return this.sessionStartPromise
+
+    const engine = this.engineManager.e2eEngine
+    if (!engine || typeof engine.createStreamingSession !== 'function') return null
+
+    const abort = new AbortController()
+    const generation = this.generation
+    const adapter = new E2EStreamingAdapter(
+      this,
+      abort.signal,
+      () => this.generation === generation
+    )
+    const session = engine.createStreamingSession()
+    this.sessionAbort = abort
+
+    const startPromise = (async (): Promise<E2EStreamingSession | null> => {
+      try {
+        await session.start({ sink: adapter, signal: abort.signal })
+        // A switch/stop may have raced ahead while start() was in-flight.
+        if (abort.signal.aborted) {
+          await session.stop({ flush: false }).catch(() => {})
+          return null
+        }
+        this.streamingSession = session
+        return session
+      } catch (err) {
+        log.warn('Failed to start e2e streaming session:', err)
+        await session.stop({ flush: false }).catch(() => {})
+        return null
+      } finally {
+        // Only clear the shared reference if this attempt is still the current one —
+        // a newer switch may have already replaced it while start() was pending.
+        if (this.sessionAbort === abort) {
+          this.sessionStartPromise = null
+        }
+      }
+    })()
+
+    this.sessionStartPromise = startPromise
+    return startPromise
+  }
+
+  /**
+   * Abort and close the current e2e streaming session. Aborting first guarantees
+   * the adapter drops any late results before stop() completes its drain.
+   */
+  private async teardownStreamingSession(flush: boolean): Promise<void> {
+    const session = this.streamingSession
+    const abort = this.sessionAbort
+    this.streamingSession = null
+    this.sessionAbort = null
+    this.sessionStartPromise = null
+
+    abort?.abort()
+    if (session) {
+      try {
+        await session.stop({ flush })
+      } catch (err) {
+        log.warn('Error stopping e2e streaming session:', err)
+      }
+    }
   }
 
   /**


### PR DESCRIPTION
## Description
Establishes the e2e streaming foundation (#719 M0) so cloud-realtime / local-e2e engines can flow through the existing event subscriptions, and hardens cascade⇄e2e switching so stale results are never emitted after a switch.

- `E2EStreamingSession` abstraction added to `src/engines/types.ts` (`start({ sink, signal })` / `pushAudio` returning optional `Backpressure` / optional `flushSegment` / `stop({ flush })`). Uses an AbortSignal-gated session instead of bare EventEmitter wiring to avoid post-dispose emits, listener leaks, and cross-session mixing. The single-shot `E2ETranslationEngine` is retained for backward compatibility, with an optional `createStreamingSession()`.
- `E2EStreamingAdapter` converts sink output onto the existing `interim-result` / `result` events, so downstream (SubtitleOverlay / SessionManager / main index) is unmodified. Emissions are gated by the session AbortSignal and a generation predicate.
- `TranslationPipeline` gains an e2e streaming path (`pushRealtimeAudio` / `onSpeechBoundary`) with lazy single-session start and teardown. `processStreaming` / `finalizeStreaming` remain cascade-only (unchanged `config.mode !== 'cascade'` guards).
- `switchEngine()` (and `stop()`) now perform a stop()-equivalent reset: session generation bump + `agreement`/`contextBuffer`/`streaming`/GER resets + old session abort/stop. `StreamingProcessor` and `GERProcessor` drop async results scheduled under a prior generation, so stale LocalAgreement/ContextBuffer/SimulMT/GER output is never emitted after a switch.

Design note: the AbortSignal-based session (over bare EventEmitter) and the switchEngine generation reset follow the issue's Codex-verified design; no live streaming engine is wired yet (real engines return no session → safe no-op), keeping this a pure foundation change.

## Related Issue
Closes #719

## Test Checklist
- [x] Unit tests added/updated (`src/pipeline/TranslationPipeline.test.ts`: e2e session lifecycle, sink→event mapping, switchEngine stale-result regression for both e2e teardown and pending cascade translation)

## Checklist
- [x] CLAUDE.md rules followed
- [x] Error handling complete (session start failure caught, session stop errors logged, no throw out of pushRealtimeAudio)
- [x] No console.log left in production code

## Verification
- `npm run typecheck` — clean
- `npm run lint` — clean on changed files (only pre-existing unrelated warnings/error remain)
- `npm test` — 329 passing incl. new suite; the 10 failures are pre-existing, environment-dependent `virtual-mic-manager` tests unrelated to this change (verified they fail identically on the base).