### PR TITLE
Add ShadowRunner parallel measurement harness and multivariate benchmark metrics

### DIFF
--- a/benchmark/conversational-ja-en/multivariate.test.ts
+++ b/benchmark/conversational-ja-en/multivariate.test.ts
@@ -1,0 +1,177 @@
+import { describe, it, expect } from 'vitest'
+import {
+  properNounBreakage,
+  scoreQuality,
+  buildPathReport,
+  recommendDefault,
+  buildMultivariateReport,
+  type MultivariatePathInput
+} from './multivariate'
+
+describe('properNounBreakage', () => {
+  it('returns 0 when there are no proper nouns to check', () => {
+    expect(properNounBreakage('anything', [])).toBe(0)
+  })
+
+  it('returns the fraction of missing proper nouns (case-insensitive)', () => {
+    const hyp = 'We migrated to Kotlin and Ktor last year.'
+    expect(properNounBreakage(hyp, ['kotlin', 'ktor'])).toBe(0)
+    expect(properNounBreakage(hyp, ['Kotlin', 'Rails'])).toBe(0.5)
+    expect(properNounBreakage(hyp, ['Rails', 'Django'])).toBe(1)
+  })
+})
+
+describe('scoreQuality', () => {
+  it('averages chrF and proper-noun breakage across sentences', () => {
+    const q = scoreQuality([
+      { hypothesis: 'hello world', reference: 'hello world', properNouns: ['hello'] },
+      { hypothesis: 'foo', reference: 'completely different', properNouns: ['bar'] }
+    ])
+    expect(q.meanChrF).toBeGreaterThan(0)
+    expect(q.meanChrF).toBeLessThan(100)
+    // first sentence: 0 breakage, second: 1.0 breakage -> mean 0.5
+    expect(q.properNounBreakage).toBeCloseTo(0.5, 6)
+  })
+
+  it('handles empty input', () => {
+    expect(scoreQuality([])).toEqual({ meanChrF: 0, properNounBreakage: 0 })
+  })
+})
+
+describe('buildPathReport', () => {
+  it('produces all five multivariate axes', () => {
+    const input: MultivariatePathInput = {
+      pathId: 'offline-llm',
+      label: 'HY-MT1.5 (offline)',
+      isOffline: true,
+      usdPerMillionChars: 0,
+      sentences: [{ hypothesis: 'good output', reference: 'good output' }],
+      latenciesMs: [180, 200, 220, 500],
+      sourceCharsTotal: 1000,
+      supportsGlossary: true,
+      supportsArbitrarySurface: true
+    }
+    const report = buildPathReport(input)
+    expect(report.quality.meanChrF).toBeGreaterThan(99)
+    expect(report.latency.p50).toBeGreaterThan(0)
+    expect(report.latency.p95).toBeGreaterThanOrEqual(report.latency.p50)
+    expect(report.cost.totalUsd).toBe(0) // offline
+    expect(report.privacy.offlineCompleteness).toBe(1)
+    expect(report.value.supportsGlossary).toBe(true)
+  })
+
+  it('meters cloud cost from source characters', () => {
+    const report = buildPathReport({
+      pathId: 'cloud',
+      label: 'Cloud API',
+      isOffline: false,
+      usdPerMillionChars: 20,
+      sentences: [{ hypothesis: 'x', reference: 'x' }],
+      latenciesMs: [50],
+      sourceCharsTotal: 500_000,
+      supportsGlossary: false,
+      supportsArbitrarySurface: false
+    })
+    expect(report.cost.totalUsd).toBeCloseTo(10, 6) // 0.5M chars * $20/M
+    expect(report.privacy.offlineCompleteness).toBe(0)
+  })
+})
+
+describe('recommendDefault (decision rule)', () => {
+  const offline = buildPathReport({
+    pathId: 'offline',
+    label: 'Offline hybrid',
+    isOffline: true,
+    usdPerMillionChars: 0,
+    sentences: [{ hypothesis: 'The new parser improved recovery.', reference: 'The new parser improved recovery.' }],
+    latenciesMs: [180],
+    sourceCharsTotal: 1000,
+    supportsGlossary: true,
+    supportsArbitrarySurface: true
+  })
+
+  it('prefers cost/privacy/value on a quality tie (keeps switchable hybrid)', () => {
+    // Cloud path is marginally better on chrF but within the tie delta.
+    const cloud = buildPathReport({
+      pathId: 'cloud',
+      label: 'Cloud API',
+      isOffline: false,
+      usdPerMillionChars: 20,
+      sentences: [{ hypothesis: 'The new parser improved recovery.', reference: 'The new parser improved recovery.' }],
+      latenciesMs: [60],
+      sourceCharsTotal: 1000,
+      supportsGlossary: false,
+      supportsArbitrarySurface: false
+    })
+    const rec = recommendDefault([cloud, offline], 2)
+    expect(rec.qualityTiedPathIds.sort()).toEqual(['cloud', 'offline'])
+    // On a tie, offline (privacy) wins over the cloud path.
+    expect(rec.pathId).toBe('offline')
+  })
+
+  it('picks the clearly higher-quality path when not tied', () => {
+    const poor = buildPathReport({
+      pathId: 'poor',
+      label: 'Poor path',
+      isOffline: true,
+      usdPerMillionChars: 0,
+      sentences: [{ hypothesis: 'unrelated text', reference: 'The new parser improved recovery.' }],
+      latenciesMs: [100],
+      sourceCharsTotal: 1000,
+      supportsGlossary: false,
+      supportsArbitrarySurface: false
+    })
+    const rec = recommendDefault([offline, poor], 2)
+    expect(rec.pathId).toBe('offline')
+    expect(rec.qualityTiedPathIds).toEqual(['offline'])
+  })
+
+  it('handles no paths', () => {
+    expect(recommendDefault([]).pathId).toBeNull()
+  })
+})
+
+describe('buildMultivariateReport (smoke)', () => {
+  it('produces a full report end-to-end', () => {
+    const inputs: MultivariatePathInput[] = [
+      {
+        pathId: 'cascade-offline',
+        label: 'Whisper + HY-MT1.5',
+        isOffline: true,
+        usdPerMillionChars: 0,
+        sentences: [
+          { hypothesis: 'We adopted Kotlin.', reference: 'We adopted Kotlin.', properNouns: ['Kotlin'] }
+        ],
+        latenciesMs: [180, 210],
+        sourceCharsTotal: 400,
+        supportsGlossary: true,
+        supportsArbitrarySurface: true
+      },
+      {
+        pathId: 'cloud-realtime',
+        label: 'Cloud realtime',
+        isOffline: false,
+        usdPerMillionChars: 16,
+        sentences: [
+          { hypothesis: 'We used Kotlin.', reference: 'We adopted Kotlin.', properNouns: ['Kotlin'] }
+        ],
+        latenciesMs: [70, 90],
+        sourceCharsTotal: 400,
+        supportsGlossary: false,
+        supportsArbitrarySurface: false
+      }
+    ]
+    const report = buildMultivariateReport(inputs)
+    expect(report.paths).toHaveLength(2)
+    expect(report.generatedAt).toMatch(/^\d{4}-\d{2}-\d{2}T/)
+    expect(report.recommendation.pathId).not.toBeNull()
+    // Every path carries all five axes.
+    for (const p of report.paths) {
+      expect(p.quality).toBeDefined()
+      expect(p.latency).toBeDefined()
+      expect(p.cost).toBeDefined()
+      expect(p.privacy).toBeDefined()
+      expect(p.value).toBeDefined()
+    }
+  })
+})

--- a/benchmark/conversational-ja-en/multivariate.ts
+++ b/benchmark/conversational-ja-en/multivariate.ts
@@ -1,0 +1,202 @@
+/**
+ * Multivariate evaluation for the conversational JA<->EN benchmark (#720).
+ *
+ * Extends the chrF-only quality metric (#706) into the five axes the shadow
+ * measurement plan calls for, so engine paths are compared on more than a
+ * single variable:
+ *
+ *   quality  — chrF (reference-based) + proper-noun breakage
+ *   latency  — p50 / p95 wall-clock per path
+ *   cost     — BYOK metered USD (source chars * rate; 0 for offline paths)
+ *   privacy  — offline completeness (fully offline == 1)
+ *   value    — glossary applicability / arbitrary output surface
+ *
+ * It also encodes the decision rule from the issue: when quality is within a
+ * small delta, prefer cost / privacy / value and keep the switchable hybrid as
+ * the default (rather than becoming a degraded copy of Apple/Google).
+ */
+
+import { chrF, percentile } from './metrics'
+
+/** Reference-based quality signals for one path. */
+export interface QualitySignals {
+  /** Mean chrF over all sentences (0-100). */
+  meanChrF: number
+  /** Fraction of expected proper nouns missing from the output (0-1, lower is better). */
+  properNounBreakage: number
+}
+
+/** A single translated sentence paired with its reference. */
+export interface ScoredSentence {
+  hypothesis: string
+  reference: string
+  /** Proper nouns expected to survive translation (checked for breakage). */
+  properNouns?: string[]
+}
+
+/** Input describing one measurable path for multivariate scoring. */
+export interface MultivariatePathInput {
+  pathId: string
+  label: string
+  /** True if the path completes fully offline. */
+  isOffline: boolean
+  /** BYOK cost rate; 0 for offline paths. */
+  usdPerMillionChars: number
+  /** Per-sentence outputs with references. */
+  sentences: ScoredSentence[]
+  /** Wall-clock latency per sentence (ms). */
+  latenciesMs: number[]
+  /** Total source characters processed (for cost metering). */
+  sourceCharsTotal: number
+  /** Whether the path can honor a user glossary (user-value axis). */
+  supportsGlossary: boolean
+  /** Whether the path exposes an arbitrary output surface (user-value axis). */
+  supportsArbitrarySurface: boolean
+}
+
+/** Per-path multivariate report. */
+export interface MultivariatePathReport {
+  pathId: string
+  label: string
+  quality: QualitySignals
+  latency: { p50: number; p95: number }
+  cost: { totalUsd: number; usdPerMillionChars: number }
+  privacy: { offlineCompleteness: number }
+  value: { supportsGlossary: boolean; supportsArbitrarySurface: boolean }
+}
+
+/**
+ * Fraction of expected proper nouns absent from the hypothesis. Proper-noun
+ * breakage is a common failure of aggressive MT on meeting speech (names,
+ * product/library names), so it is tracked separately from chrF.
+ */
+export function properNounBreakage(hypothesis: string, properNouns: string[]): number {
+  if (properNouns.length === 0) return 0
+  const hay = hypothesis.toLowerCase()
+  let missing = 0
+  for (const noun of properNouns) {
+    if (!hay.includes(noun.toLowerCase())) missing++
+  }
+  return missing / properNouns.length
+}
+
+/** Compute the quality signals for a set of scored sentences. */
+export function scoreQuality(sentences: ScoredSentence[]): QualitySignals {
+  if (sentences.length === 0) return { meanChrF: 0, properNounBreakage: 0 }
+
+  let chrfSum = 0
+  let breakageSum = 0
+  let breakageDenom = 0
+  for (const s of sentences) {
+    chrfSum += chrF(s.hypothesis, s.reference)
+    if (s.properNouns && s.properNouns.length > 0) {
+      breakageSum += properNounBreakage(s.hypothesis, s.properNouns)
+      breakageDenom++
+    }
+  }
+  return {
+    meanChrF: chrfSum / sentences.length,
+    properNounBreakage: breakageDenom === 0 ? 0 : breakageSum / breakageDenom
+  }
+}
+
+/** Build a per-path multivariate report from raw path inputs. */
+export function buildPathReport(input: MultivariatePathInput): MultivariatePathReport {
+  const sorted = [...input.latenciesMs].sort((a, b) => a - b)
+  const totalUsd =
+    input.usdPerMillionChars <= 0 || input.sourceCharsTotal <= 0
+      ? 0
+      : (input.sourceCharsTotal / 1_000_000) * input.usdPerMillionChars
+  return {
+    pathId: input.pathId,
+    label: input.label,
+    quality: scoreQuality(input.sentences),
+    latency: { p50: percentile(sorted, 50), p95: percentile(sorted, 95) },
+    cost: { totalUsd, usdPerMillionChars: input.usdPerMillionChars },
+    privacy: { offlineCompleteness: input.isOffline ? 1 : 0 },
+    value: {
+      supportsGlossary: input.supportsGlossary,
+      supportsArbitrarySurface: input.supportsArbitrarySurface
+    }
+  }
+}
+
+/** Recommendation output of {@link recommendDefault}. */
+export interface DefaultRecommendation {
+  /** Chosen default path id, or null when there are no paths. */
+  pathId: string | null
+  /** Human-readable rationale referencing the decision rule. */
+  rationale: string
+  /** Paths that tied on quality (within the delta) and competed on cost/privacy/value. */
+  qualityTiedPathIds: string[]
+}
+
+/** chrF points within which two paths are treated as a quality tie. */
+export const DEFAULT_QUALITY_TIE_DELTA = 2
+
+/**
+ * Decision rule (issue #720): when quality is within `qualityTieDelta` chrF
+ * points of the best path, prefer cost / privacy / value and keep the
+ * switchable hybrid default. Concretely, among the quality-tied paths we prefer
+ * (in order): lower proper-noun breakage, offline (privacy), lower cost, then
+ * glossary support.
+ */
+export function recommendDefault(
+  reports: MultivariatePathReport[],
+  qualityTieDelta = DEFAULT_QUALITY_TIE_DELTA
+): DefaultRecommendation {
+  if (reports.length === 0) {
+    return { pathId: null, rationale: 'No paths to evaluate.', qualityTiedPathIds: [] }
+  }
+
+  const bestChrF = Math.max(...reports.map((r) => r.quality.meanChrF))
+  const tied = reports.filter((r) => bestChrF - r.quality.meanChrF <= qualityTieDelta)
+
+  const ranked = [...tied].sort((a, b) => {
+    if (a.quality.properNounBreakage !== b.quality.properNounBreakage) {
+      return a.quality.properNounBreakage - b.quality.properNounBreakage
+    }
+    if (a.privacy.offlineCompleteness !== b.privacy.offlineCompleteness) {
+      return b.privacy.offlineCompleteness - a.privacy.offlineCompleteness
+    }
+    if (a.cost.totalUsd !== b.cost.totalUsd) {
+      return a.cost.totalUsd - b.cost.totalUsd
+    }
+    return Number(b.value.supportsGlossary) - Number(a.value.supportsGlossary)
+  })
+
+  const winner = ranked[0]!
+  const rationale =
+    tied.length === 1
+      ? `${winner.label} leads on quality (chrF ${winner.quality.meanChrF.toFixed(1)}).`
+      : `Quality tie within ${qualityTieDelta} chrF; tie broken by proper-noun breakage, ` +
+        `then privacy/cost/value — keeping the switchable hybrid default. Chose ${winner.label} ` +
+        `(offline=${winner.privacy.offlineCompleteness === 1}, cost=$${winner.cost.totalUsd.toFixed(4)}, ` +
+        `proper-noun breakage=${winner.quality.properNounBreakage.toFixed(2)}).`
+
+  return {
+    pathId: winner.pathId,
+    rationale,
+    qualityTiedPathIds: tied.map((r) => r.pathId)
+  }
+}
+
+/** Full multivariate report across all paths plus the default recommendation. */
+export interface MultivariateReport {
+  generatedAt: string
+  paths: MultivariatePathReport[]
+  recommendation: DefaultRecommendation
+}
+
+/** Build the full multivariate report for a set of paths. */
+export function buildMultivariateReport(
+  inputs: MultivariatePathInput[],
+  qualityTieDelta = DEFAULT_QUALITY_TIE_DELTA
+): MultivariateReport {
+  const paths = inputs.map(buildPathReport)
+  return {
+    generatedAt: new Date().toISOString(),
+    paths,
+    recommendation: recommendDefault(paths, qualityTieDelta)
+  }
+}

--- a/src/pipeline/shadow/Semaphore.ts
+++ b/src/pipeline/shadow/Semaphore.ts
@@ -1,0 +1,37 @@
+/**
+ * Non-blocking counting semaphore for the shadow measurement harness.
+ *
+ * The shadow runner uses a "drop-if-busy" policy rather than queuing: when no
+ * permit is available the caller drops the sample instead of waiting. Queuing
+ * would fold wait time into measured latency and corrupt the telemetry, so this
+ * semaphore intentionally exposes only a synchronous {@link tryAcquire} — there
+ * is no blocking acquire.
+ */
+export class Semaphore {
+  private available: number
+
+  constructor(private readonly permits: number) {
+    if (permits < 1) throw new Error(`Semaphore permits must be >= 1, got ${permits}`)
+    this.available = permits
+  }
+
+  /** Attempt to take a permit without waiting. Returns true if one was acquired. */
+  tryAcquire(): boolean {
+    if (this.available > 0) {
+      this.available--
+      return true
+    }
+    return false
+  }
+
+  /** Return a permit. Never exceeds the configured maximum. */
+  release(): void {
+    if (this.available < this.permits) {
+      this.available++
+    }
+  }
+
+  get availablePermits(): number {
+    return this.available
+  }
+}

--- a/src/pipeline/shadow/ShadowRunner.test.ts
+++ b/src/pipeline/shadow/ShadowRunner.test.ts
@@ -1,0 +1,282 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { ShadowRunner } from './ShadowRunner'
+import type { ShadowPath, PathSampleResult, ShadowCostModel } from './types'
+
+const OFFLINE_COST: ShadowCostModel = { usdPerMillionChars: 0 }
+const CLOUD_COST: ShadowCostModel = { usdPerMillionChars: 20 }
+
+/** Deferred promise helper for controlling when a path resolves. */
+function deferred<T>(): { promise: Promise<T>; resolve: (v: T) => void; reject: (e: unknown) => void } {
+  let resolve!: (v: T) => void
+  let reject!: (e: unknown) => void
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res
+    reject = rej
+  })
+  return { promise, resolve, reject }
+}
+
+/** A configurable mock path. */
+class MockPath implements ShadowPath {
+  readonly kind = 'cascade' as const
+  calls: Array<{ audio: Float32Array; sampleRate: number }> = []
+
+  constructor(
+    readonly id: string,
+    readonly usesLocalLlm = false,
+    readonly isOffline = true,
+    readonly cost: ShadowCostModel = OFFLINE_COST,
+    private readonly handler: (
+      audio: Float32Array,
+      sampleRate: number,
+      signal: AbortSignal
+    ) => Promise<PathSampleResult> = async (a) => ({
+      sourceText: 'x'.repeat(a.length),
+      translatedText: 'y',
+      firstSubtitleMs: 10,
+      revisionCount: 0
+    })
+  ) {}
+
+  async process(audio: Float32Array, sampleRate: number, signal: AbortSignal): Promise<PathSampleResult> {
+    this.calls.push({ audio, sampleRate })
+    return this.handler(audio, sampleRate, signal)
+  }
+}
+
+describe('ShadowRunner', () => {
+  let runner: ShadowRunner
+
+  beforeEach(() => {
+    runner = new ShadowRunner()
+  })
+
+  it('fans identical audio out to multiple paths in parallel and records a sample each', async () => {
+    const a = new MockPath('a')
+    const b = new MockPath('b')
+    runner.register(a)
+    runner.register(b)
+
+    runner.start()
+    const audio = new Float32Array([1, 2, 3])
+    runner.submit(audio, 16000)
+    await runner.whenIdle()
+
+    expect(a.calls).toHaveLength(1)
+    expect(b.calls).toHaveLength(1)
+    // Both paths see the same content...
+    expect(Array.from(a.calls[0]!.audio)).toEqual([1, 2, 3])
+    expect(Array.from(b.calls[0]!.audio)).toEqual([1, 2, 3])
+
+    const samples = runner.getSamples()
+    expect(samples).toHaveLength(2)
+    expect(new Set(samples.map((s) => s.pathId))).toEqual(new Set(['a', 'b']))
+  })
+
+  it('snapshots audio so later mutation of the caller buffer does not affect paths', async () => {
+    const seen = deferred<void>()
+    const path = new MockPath('p', false, true, OFFLINE_COST, async (audio) => {
+      seen.resolve()
+      return { sourceText: Array.from(audio).join(','), translatedText: '', firstSubtitleMs: null, revisionCount: 0 }
+    })
+    runner.register(path)
+    runner.start()
+
+    const audio = new Float32Array([5, 6, 7])
+    runner.submit(audio, 16000)
+    await seen.promise
+    audio[0] = 999 // mutate after submit
+    await runner.whenIdle()
+
+    expect(Array.from(path.calls[0]!.audio)).toEqual([5, 6, 7])
+  })
+
+  it('drops (does not queue) a segment when the path is still busy', async () => {
+    const gate = deferred<PathSampleResult>()
+    const path = new MockPath('busy', false, true, OFFLINE_COST, () => gate.promise)
+    runner.register(path)
+    runner.start()
+
+    runner.submit(new Float32Array([1]), 16000) // occupies the single permit
+    runner.submit(new Float32Array([2]), 16000) // should be dropped as path-busy
+
+    const drops = runner.getDrops()
+    expect(drops).toHaveLength(1)
+    expect(drops[0]!.reason).toBe('path-busy')
+    expect(path.calls).toHaveLength(1) // second submit never reached the engine
+
+    gate.resolve({ sourceText: 'ok', translatedText: 't', firstSubtitleMs: 5, revisionCount: 1 })
+    await runner.whenIdle()
+    expect(runner.getSamples()).toHaveLength(1)
+  })
+
+  it('discards results that resolve after stop() (cancellation)', async () => {
+    const gate = deferred<PathSampleResult>()
+    const path = new MockPath('slow', false, true, OFFLINE_COST, () => gate.promise)
+    runner.register(path)
+    runner.start()
+    runner.submit(new Float32Array([1]), 16000)
+
+    const stopPromise = runner.stop()
+    // Resolve the path AFTER stop() was requested — the result must be discarded.
+    gate.resolve({ sourceText: 'late', translatedText: 't', firstSubtitleMs: 5, revisionCount: 0 })
+    await stopPromise
+
+    expect(runner.getSamples()).toHaveLength(0)
+  })
+
+  it('serializes local-LLM paths behind a single global permit', async () => {
+    const gate1 = deferred<PathSampleResult>()
+    const gate2 = deferred<PathSampleResult>()
+    const llmA = new MockPath('llmA', true, true, OFFLINE_COST, () => gate1.promise)
+    const llmB = new MockPath('llmB', true, true, OFFLINE_COST, () => gate2.promise)
+    // Local-LLM paths default disabled; enable both at full sampling.
+    runner.register(llmA, { enabled: true, samplingInterval: 1 })
+    runner.register(llmB, { enabled: true, samplingInterval: 1 })
+    runner.start()
+
+    runner.submit(new Float32Array([1]), 16000)
+
+    // Only one of the two LLM paths runs; the other is dropped as local-llm-busy.
+    const started = llmA.calls.length + llmB.calls.length
+    expect(started).toBe(1)
+    const drops = runner.getDrops()
+    expect(drops).toHaveLength(1)
+    expect(drops[0]!.reason).toBe('local-llm-busy')
+
+    gate1.resolve({ sourceText: 'a', translatedText: 't', firstSubtitleMs: 1, revisionCount: 0 })
+    gate2.resolve({ sourceText: 'b', translatedText: 't', firstSubtitleMs: 1, revisionCount: 0 })
+    await runner.whenIdle()
+  })
+
+  it('applies 1-in-N sampling for thinned paths', async () => {
+    const path = new MockPath('sampled')
+    runner.register(path, { enabled: true, samplingInterval: 3 })
+    runner.start()
+
+    for (let i = 0; i < 6; i++) {
+      runner.submit(new Float32Array([i]), 16000)
+      await runner.whenIdle()
+    }
+
+    // Segments 0 and 3 measured; 1,2,4,5 dropped as sampling.
+    expect(path.calls).toHaveLength(2)
+    const samplingDrops = runner.getDrops().filter((d) => d.reason === 'sampling')
+    expect(samplingDrops).toHaveLength(4)
+  })
+
+  it('local-LLM paths default to disabled', async () => {
+    const llm = new MockPath('llm', true)
+    runner.register(llm) // no override
+    runner.start()
+    runner.submit(new Float32Array([1]), 16000)
+    await runner.whenIdle()
+
+    expect(llm.calls).toHaveLength(0)
+    expect(runner.getDrops()[0]!.reason).toBe('disabled')
+  })
+
+  it('records errors without recording a sample', async () => {
+    const path = new MockPath('err', false, true, OFFLINE_COST, async () => {
+      throw new Error('boom')
+    })
+    runner.register(path)
+    runner.start()
+    runner.submit(new Float32Array([1]), 16000)
+    await runner.whenIdle()
+
+    expect(runner.getSamples()).toHaveLength(0)
+    const errors = runner.getErrors()
+    expect(errors).toHaveLength(1)
+    expect(errors[0]!.message).toBe('boom')
+  })
+
+  it('ignores submit when not running', () => {
+    const path = new MockPath('p')
+    runner.register(path)
+    const id = runner.submit(new Float32Array([1]), 16000)
+    expect(id).toBe(-1)
+    expect(path.calls).toHaveLength(0)
+  })
+
+  it('discards stale results from a previous run after stop() then start()', async () => {
+    const gate = deferred<PathSampleResult>()
+    let call = 0
+    const path = new MockPath('restart', false, true, OFFLINE_COST, () => {
+      call++
+      return call === 1
+        ? gate.promise // first run: hangs past stop()
+        : Promise.resolve({ sourceText: 'fresh', translatedText: 't', firstSubtitleMs: 1, revisionCount: 0 })
+    })
+    // Tiny drain timeout so stop() returns while the first task is still in-flight.
+    const r = new ShadowRunner({ stopDrainTimeoutMs: 10 })
+    r.register(path)
+
+    r.start()
+    r.submit(new Float32Array([1]), 16000)
+    await r.stop() // returns via drain timeout; first task still pending
+
+    r.start()
+    // Resolve the run-1 task while run 2 is active — it must NOT be recorded
+    // into run 2 telemetry (generation guard), and it releases the path permit.
+    gate.resolve({ sourceText: 'stale', translatedText: 't', firstSubtitleMs: 1, revisionCount: 0 })
+    await r.whenIdle()
+    expect(r.getSamples()).toHaveLength(0)
+
+    r.submit(new Float32Array([2]), 16000)
+    await r.whenIdle()
+
+    const samples = r.getSamples()
+    expect(samples).toHaveLength(1)
+    expect(samples[0]!.sourceChars).toBe('fresh'.length)
+  })
+
+  it('bounds telemetry buffers at maxRecords', async () => {
+    const path = new MockPath('bounded')
+    const r = new ShadowRunner({ maxRecords: 3 })
+    r.register(path)
+    r.start()
+
+    for (let i = 0; i < 5; i++) {
+      r.submit(new Float32Array([i]), 16000)
+      await r.whenIdle()
+    }
+
+    expect(r.getSamples()).toHaveLength(3)
+    // Oldest evicted: remaining samples are the last three segments.
+    expect(r.getSamples().map((s) => s.segmentId)).toEqual([2, 3, 4])
+  })
+
+  it('aggregates a multivariate report with cost, privacy, and drop rate', async () => {
+    const offline = new MockPath('offline', false, true, OFFLINE_COST, async () => ({
+      sourceText: 'hello', // 5 chars
+      translatedText: 'x',
+      firstSubtitleMs: 12,
+      revisionCount: 2
+    }))
+    const cloud = new MockPath('cloud', false, false, CLOUD_COST, async () => ({
+      sourceText: 'hello', // 5 chars * $20/M = $0.0001
+      translatedText: 'x',
+      firstSubtitleMs: 30,
+      revisionCount: 0
+    }))
+    runner.register(offline)
+    runner.register(cloud)
+    runner.start()
+    runner.submit(new Float32Array([1]), 16000)
+    await runner.whenIdle()
+
+    const report = runner.getReport()
+    const offlineSummary = report.paths.find((p) => p.pathId === 'offline')!
+    const cloudSummary = report.paths.find((p) => p.pathId === 'cloud')!
+
+    expect(offlineSummary.processedCount).toBe(1)
+    expect(offlineSummary.offlineCompleteness).toBe(1)
+    expect(offlineSummary.totalCostUsd).toBe(0)
+    expect(offlineSummary.meanRevisionCount).toBe(2)
+
+    expect(cloudSummary.offlineCompleteness).toBe(0)
+    expect(cloudSummary.totalCostUsd).toBeCloseTo((5 / 1_000_000) * 20, 12)
+    expect(cloudSummary.latency.p50).toBeGreaterThanOrEqual(0)
+  })
+})

--- a/src/pipeline/shadow/ShadowRunner.ts
+++ b/src/pipeline/shadow/ShadowRunner.ts
@@ -1,0 +1,293 @@
+/**
+ * ShadowRunner — parallel engine-path measurement harness (#720).
+ *
+ * Feeds identical audio to multiple engine paths in parallel and records
+ * multivariate telemetry (latency / cost / privacy / stability). It is fully
+ * SEPARATED from the production pipeline:
+ * - it never touches EngineManager's single active engine,
+ * - it emits nothing to the UI or session (telemetry only), and
+ * - it is fed audio through an explicit tap ({@link submit}), so the production
+ *   audio IPC path (which is deduplicated) is never entangled.
+ *
+ * Design (verified with Codex):
+ * - Per-path "drop-if-busy" semaphore: when a path is still processing, new
+ *   audio is DROPPED, not queued. Queuing would fold wait time into measured
+ *   latency and corrupt the numbers.
+ * - Local-LLM paths share ONE global semaphore so at most one runs at a time —
+ *   they contend for a single node-llama-cpp UtilityProcess worker, so
+ *   overlapping them would measure pool contention instead of path behavior.
+ *   They also default to disabled / low-frequency sampling.
+ * - Cancellation: an AbortController plus a monotonic generation counter. A
+ *   task that resolves after stop() (or a subsequent start()) is discarded, not
+ *   recorded, so stale cross-run results never leak into telemetry.
+ * - Bounded record buffers cap memory during long sessions.
+ */
+
+import { Semaphore } from './Semaphore'
+import { estimateCostUsd, summarize } from './metrics'
+import type { ShadowReport } from './metrics'
+import {
+  DEFAULT_PATH_CONFIG,
+  DEFAULT_LOCAL_LLM_PATH_CONFIG,
+  DEFAULT_RUNNER_CONFIG
+} from './types'
+import type {
+  ShadowPath,
+  ShadowPathConfig,
+  ShadowPathDescriptor,
+  ShadowRunnerConfig,
+  ShadowSample,
+  ShadowDrop,
+  ShadowError,
+  DropReason
+} from './types'
+
+interface RegisteredPath {
+  path: ShadowPath
+  config: ShadowPathConfig
+  semaphore: Semaphore
+  /** Submit counter used to implement 1-in-N sampling. */
+  submitCount: number
+}
+
+export class ShadowRunner {
+  private readonly config: ShadowRunnerConfig
+  private readonly paths = new Map<string, RegisteredPath>()
+  private readonly localLlmSemaphore: Semaphore
+
+  private samples: ShadowSample[] = []
+  private drops: ShadowDrop[] = []
+  private errors: ShadowError[] = []
+
+  private running = false
+  private generation = 0
+  private abort: AbortController | null = null
+  private nextSegmentId = 0
+  /** Segments submitted since the last clearTelemetry(), matching the record window. */
+  private submittedSegments = 0
+  private inFlight = new Set<Promise<void>>()
+  private stopPromise: Promise<void> | null = null
+
+  constructor(config: Partial<ShadowRunnerConfig> = {}) {
+    this.config = { ...DEFAULT_RUNNER_CONFIG, ...config }
+    this.localLlmSemaphore = new Semaphore(this.config.localLlmPermits)
+  }
+
+  /**
+   * Register a measurable path. Local-LLM paths default to disabled with
+   * low-frequency sampling unless an explicit override is supplied.
+   */
+  register(path: ShadowPath, configOverride: Partial<ShadowPathConfig> = {}): void {
+    const base = path.usesLocalLlm ? DEFAULT_LOCAL_LLM_PATH_CONFIG : DEFAULT_PATH_CONFIG
+    const config: ShadowPathConfig = { ...base, ...configOverride }
+    if (config.samplingInterval < 1) config.samplingInterval = 1
+    if (config.permits < 1) config.permits = 1
+    this.paths.set(path.id, {
+      path,
+      config,
+      semaphore: new Semaphore(config.permits),
+      submitCount: 0
+    })
+  }
+
+  /** Descriptors of all registered paths (for reporting on zero-sample paths). */
+  get descriptors(): ShadowPathDescriptor[] {
+    return [...this.paths.values()].map((r) => r.path)
+  }
+
+  get isRunning(): boolean {
+    return this.running
+  }
+
+  /** Begin a measurement run. Resets per-run cancellation state. */
+  start(): void {
+    if (this.running) return
+    this.running = true
+    this.generation++
+    this.abort = new AbortController()
+  }
+
+  /**
+   * Abort the current run. In-flight path tasks are cancelled and their results
+   * discarded. Waits for outstanding tasks to drain, bounded by
+   * stopDrainTimeoutMs — a path that ignores its AbortSignal (local-LLM
+   * inference cannot be cancelled mid-generation) must not hang shutdown.
+   * Concurrent stop() calls share the same drain.
+   */
+  async stop(): Promise<void> {
+    if (this.stopPromise) return this.stopPromise
+    if (!this.running) return
+    this.running = false
+    this.generation++
+    this.abort?.abort()
+    this.abort = null
+    this.stopPromise = this.drainWithTimeout().finally(() => {
+      this.stopPromise = null
+    })
+    return this.stopPromise
+  }
+
+  private async drainWithTimeout(): Promise<void> {
+    let timer: ReturnType<typeof setTimeout> | undefined
+    const timeout = new Promise<void>((resolve) => {
+      timer = setTimeout(resolve, this.config.stopDrainTimeoutMs)
+    })
+    try {
+      await Promise.race([this.whenIdle(), timeout])
+    } finally {
+      clearTimeout(timer)
+    }
+  }
+
+  /** Resolve once all in-flight path tasks have settled. */
+  async whenIdle(): Promise<void> {
+    while (this.inFlight.size > 0) {
+      await Promise.allSettled([...this.inFlight])
+    }
+  }
+
+  /**
+   * Fan a single audio segment out to every enabled path. Returns the segment
+   * id, or -1 when the runner is not running. The audio is copied once up front
+   * so paths observe identical, immutable sample data even if the caller reuses
+   * its buffer.
+   */
+  submit(audio: Float32Array, sampleRate: number): number {
+    if (!this.running || !this.abort) return -1
+
+    const segmentId = this.nextSegmentId++
+    this.submittedSegments++
+    const generation = this.generation
+    const signal = this.abort.signal
+    // Copy once, share the immutable snapshot across all paths.
+    const snapshot = Float32Array.from(audio)
+
+    for (const registered of this.paths.values()) {
+      this.dispatch(registered, snapshot, sampleRate, segmentId, generation, signal)
+    }
+    return segmentId
+  }
+
+  private dispatch(
+    registered: RegisteredPath,
+    audio: Float32Array,
+    sampleRate: number,
+    segmentId: number,
+    generation: number,
+    signal: AbortSignal
+  ): void {
+    const { path, config, semaphore } = registered
+
+    if (!config.enabled) {
+      this.recordDrop(path.id, segmentId, 'disabled')
+      return
+    }
+
+    // 1-in-N sampling: measure the first submit and every Nth thereafter.
+    const measure = registered.submitCount % config.samplingInterval === 0
+    registered.submitCount++
+    if (!measure) {
+      this.recordDrop(path.id, segmentId, 'sampling')
+      return
+    }
+
+    // Drop-if-busy on the per-path semaphore.
+    if (!semaphore.tryAcquire()) {
+      this.recordDrop(path.id, segmentId, 'path-busy')
+      return
+    }
+
+    // Local-LLM paths additionally share one global permit.
+    const usesGlobal = path.usesLocalLlm
+    if (usesGlobal && !this.localLlmSemaphore.tryAcquire()) {
+      semaphore.release()
+      this.recordDrop(path.id, segmentId, 'local-llm-busy')
+      return
+    }
+
+    const task = this.runPath(path, audio, sampleRate, segmentId, generation, signal)
+      .finally(() => {
+        semaphore.release()
+        if (usesGlobal) this.localLlmSemaphore.release()
+      })
+    const tracked = task.finally(() => {
+      this.inFlight.delete(tracked)
+    })
+    this.inFlight.add(tracked)
+  }
+
+  private async runPath(
+    path: ShadowPath,
+    audio: Float32Array,
+    sampleRate: number,
+    segmentId: number,
+    generation: number,
+    signal: AbortSignal
+  ): Promise<void> {
+    const start = performance.now()
+    try {
+      const result = await path.process(audio, sampleRate, signal)
+      const latencyMs = performance.now() - start
+
+      // Discard results that outlived their run: aborted, superseded by a newer
+      // generation, or arriving after stop().
+      if (signal.aborted || generation !== this.generation || !this.running) return
+
+      const sourceChars = result.sourceText.length
+      this.recordSample({
+        pathId: path.id,
+        segmentId,
+        timestamp: Date.now(),
+        latencyMs,
+        firstSubtitleMs: result.firstSubtitleMs,
+        revisionCount: result.revisionCount,
+        sourceChars,
+        costUsd: estimateCostUsd(sourceChars, path.cost.usdPerMillionChars),
+        isOffline: path.isOffline
+      })
+    } catch (err) {
+      if (signal.aborted || generation !== this.generation || !this.running) return
+      this.recordError(path.id, segmentId, err instanceof Error ? err.message : String(err))
+    }
+  }
+
+  private recordSample(sample: ShadowSample): void {
+    this.samples.push(sample)
+    if (this.samples.length > this.config.maxRecords) this.samples.shift()
+  }
+
+  private recordDrop(pathId: string, segmentId: number, reason: DropReason): void {
+    this.drops.push({ pathId, segmentId, timestamp: Date.now(), reason })
+    if (this.drops.length > this.config.maxRecords) this.drops.shift()
+  }
+
+  private recordError(pathId: string, segmentId: number, message: string): void {
+    this.errors.push({ pathId, segmentId, timestamp: Date.now(), message })
+    if (this.errors.length > this.config.maxRecords) this.errors.shift()
+  }
+
+  getSamples(): readonly ShadowSample[] {
+    return this.samples
+  }
+
+  getDrops(): readonly ShadowDrop[] {
+    return this.drops
+  }
+
+  getErrors(): readonly ShadowError[] {
+    return this.errors
+  }
+
+  /** Build the multivariate telemetry report from recorded samples/drops/errors. */
+  getReport(): ShadowReport {
+    return summarize(this.descriptors, this.samples, this.drops, this.errors, this.submittedSegments)
+  }
+
+  /** Clear all recorded telemetry (keeps registrations and run state). */
+  clearTelemetry(): void {
+    this.samples = []
+    this.drops = []
+    this.errors = []
+    this.submittedSegments = 0
+  }
+}

--- a/src/pipeline/shadow/index.ts
+++ b/src/pipeline/shadow/index.ts
@@ -1,0 +1,23 @@
+/** Shadow measurement harness (#720) — parallel engine-path telemetry. */
+export { ShadowRunner } from './ShadowRunner'
+export { Semaphore } from './Semaphore'
+export { summarize, percentile, estimateCostUsd } from './metrics'
+export type { ShadowReport, PathSummary, LatencyStats } from './metrics'
+export {
+  DEFAULT_PATH_CONFIG,
+  DEFAULT_LOCAL_LLM_PATH_CONFIG,
+  DEFAULT_RUNNER_CONFIG
+} from './types'
+export type {
+  ShadowPath,
+  ShadowPathDescriptor,
+  ShadowPathKind,
+  ShadowPathConfig,
+  ShadowRunnerConfig,
+  ShadowCostModel,
+  PathSampleResult,
+  ShadowSample,
+  ShadowDrop,
+  ShadowError,
+  DropReason
+} from './types'

--- a/src/pipeline/shadow/metrics.ts
+++ b/src/pipeline/shadow/metrics.ts
@@ -1,0 +1,153 @@
+/**
+ * Multivariate telemetry aggregation for the shadow measurement harness (#720).
+ *
+ * Runtime telemetry deliberately covers only what is measurable WITHOUT a
+ * reference translation: latency, first-subtitle latency, cost (BYOK metered),
+ * privacy (offline completeness), drop/error rates, and a revision-count
+ * stability proxy. Reference-based quality (chrF/COMET) is computed offline in
+ * the benchmark extension, never at runtime.
+ */
+
+import type {
+  ShadowSample,
+  ShadowDrop,
+  ShadowError,
+  ShadowPathDescriptor,
+  ShadowPathKind
+} from './types'
+
+/** Nearest-rank percentile of an already-sorted ascending array. */
+export function percentile(sortedValues: number[], p: number): number {
+  if (sortedValues.length === 0) return 0
+  const idx = Math.min(
+    Math.max(Math.ceil((p / 100) * sortedValues.length) - 1, 0),
+    sortedValues.length - 1
+  )
+  return sortedValues[idx]!
+}
+
+function mean(values: number[]): number {
+  if (values.length === 0) return 0
+  return values.reduce((a, b) => a + b, 0) / values.length
+}
+
+/** Latency distribution summary (ms). */
+export interface LatencyStats {
+  p50: number
+  p95: number
+  mean: number
+}
+
+/** Per-path multivariate summary. */
+export interface PathSummary {
+  pathId: string
+  kind: ShadowPathKind
+  usesLocalLlm: boolean
+  isOffline: boolean
+  /** Number of measured samples. */
+  processedCount: number
+  /** Total dropped segments across all reasons (busy / sampling / disabled). */
+  droppedCount: number
+  /** Segments dropped because the path (or the global local-LLM permit) was busy. */
+  busyDroppedCount: number
+  /** Number of processing errors. */
+  errorCount: number
+  /**
+   * busyDropped / (processed + busyDropped). Deliberately excludes sampling and
+   * disabled drops (those are policy, not saturation) — a fast-looking path
+   * that busy-dropped most of its work is not actually fast.
+   */
+  busyDropRate: number
+  /** errors / (processed + errors). */
+  errorRate: number
+  /** End-to-end latency distribution. */
+  latency: LatencyStats
+  /** First-subtitle latency distribution, or null when no sample emitted an interim. */
+  firstSubtitle: LatencyStats | null
+  /** Mean interim revisions per sample (STABILITY proxy, not quality). */
+  meanRevisionCount: number
+  /** Total BYOK-metered cost across samples (USD). */
+  totalCostUsd: number
+  /** Fraction of samples that stayed fully offline (privacy: offline completeness). */
+  offlineCompleteness: number
+}
+
+/** Full multivariate telemetry report emitted by the runner. */
+export interface ShadowReport {
+  generatedAt: number
+  totalSegments: number
+  paths: PathSummary[]
+}
+
+function latencyStats(values: number[]): LatencyStats {
+  const sorted = [...values].sort((a, b) => a - b)
+  return {
+    p50: percentile(sorted, 50),
+    p95: percentile(sorted, 95),
+    mean: mean(values)
+  }
+}
+
+/**
+ * Aggregate raw records into a per-path multivariate report. Pure function —
+ * takes the records and the set of registered path descriptors so paths with
+ * zero samples still appear (a path that dropped everything is meaningful).
+ */
+export function summarize(
+  descriptors: ShadowPathDescriptor[],
+  samples: readonly ShadowSample[],
+  drops: readonly ShadowDrop[],
+  errors: readonly ShadowError[],
+  totalSegments: number
+): ShadowReport {
+  const paths: PathSummary[] = descriptors.map((d) => {
+    const pathSamples = samples.filter((s) => s.pathId === d.id)
+    const pathDrops = drops.filter((x) => x.pathId === d.id)
+    const droppedCount = pathDrops.length
+    const busyDroppedCount = pathDrops.filter(
+      (x) => x.reason === 'path-busy' || x.reason === 'local-llm-busy'
+    ).length
+    const errorCount = errors.filter((x) => x.pathId === d.id).length
+    const processedCount = pathSamples.length
+
+    const latencies = pathSamples.map((s) => s.latencyMs)
+    const firstSubs = pathSamples
+      .map((s) => s.firstSubtitleMs)
+      .filter((v): v is number => v !== null)
+    const offlineSamples = pathSamples.filter((s) => s.isOffline).length
+
+    const processedPlusBusyDropped = processedCount + busyDroppedCount
+    const processedPlusErrors = processedCount + errorCount
+
+    return {
+      pathId: d.id,
+      kind: d.kind,
+      usesLocalLlm: d.usesLocalLlm,
+      isOffline: d.isOffline,
+      processedCount,
+      droppedCount,
+      busyDroppedCount,
+      errorCount,
+      busyDropRate: processedPlusBusyDropped === 0 ? 0 : busyDroppedCount / processedPlusBusyDropped,
+      errorRate: processedPlusErrors === 0 ? 0 : errorCount / processedPlusErrors,
+      latency: latencyStats(latencies),
+      firstSubtitle: firstSubs.length === 0 ? null : latencyStats(firstSubs),
+      meanRevisionCount: mean(pathSamples.map((s) => s.revisionCount)),
+      totalCostUsd: pathSamples.reduce((sum, s) => sum + s.costUsd, 0),
+      offlineCompleteness: processedCount === 0 ? (d.isOffline ? 1 : 0) : offlineSamples / processedCount
+    }
+  })
+
+  return {
+    generatedAt: Date.now(),
+    totalSegments,
+    paths
+  }
+}
+
+/** Estimate BYOK-metered cost in USD for a sample of `sourceChars` characters. */
+export function estimateCostUsd(sourceChars: number, usdPerMillionChars: number): number {
+  if (!Number.isFinite(sourceChars) || !Number.isFinite(usdPerMillionChars)) return 0
+  if (sourceChars <= 0 || usdPerMillionChars <= 0) return 0
+  return (sourceChars / 1_000_000) * usdPerMillionChars
+}

--- a/src/pipeline/shadow/types.ts
+++ b/src/pipeline/shadow/types.ts
@@ -1,0 +1,152 @@
+/**
+ * Types for the shadow measurement harness (#720).
+ *
+ * The ShadowRunner feeds identical audio to multiple engine paths in parallel
+ * purely for telemetry. It is fully decoupled from the production pipeline and
+ * emits nothing to the UI or session — only measurement records.
+ */
+
+/** How a shadow path turns audio into a translation. */
+export type ShadowPathKind = 'cascade' | 'e2e' | 'e2e-streaming'
+
+/**
+ * Cost model for a path (BYOK metered). Offline paths have zero marginal cost;
+ * cloud paths are billed per source character.
+ */
+export interface ShadowCostModel {
+  /** USD per 1,000,000 source characters. 0 for fully offline paths. */
+  usdPerMillionChars: number
+}
+
+/** Static description of a measurable path. */
+export interface ShadowPathDescriptor {
+  readonly id: string
+  readonly kind: ShadowPathKind
+  /**
+   * True if this path routes through the shared node-llama-cpp UtilityProcess
+   * pool. Such paths contend for a single worker, so they are gated by a global
+   * local-LLM semaphore and default to disabled / low-frequency sampling.
+   */
+  readonly usesLocalLlm: boolean
+  /** True if the path completes entirely offline (privacy: offline completeness). */
+  readonly isOffline: boolean
+  /** Cost model for BYOK metering. */
+  readonly cost: ShadowCostModel
+}
+
+/** Result of processing one audio segment through a path. */
+export interface PathSampleResult {
+  /** Recognized source text (may be empty for silence/no-speech). */
+  sourceText: string
+  /** Translated text. */
+  translatedText: string
+  /**
+   * Time from audio submission to the first interim subtitle output (ms), or
+   * null if the path produced no interim result before its final one.
+   */
+  firstSubtitleMs: number | null
+  /**
+   * Number of interim revisions before the final result. This is a STABILITY
+   * proxy, not a translation-quality signal — a path can be stable and wrong,
+   * or revise often yet end up more accurate.
+   */
+  revisionCount: number
+}
+
+/**
+ * A measurable engine path. Engine-agnostic so it can be unit-tested with mocks
+ * and wired to real cascade / e2e / e2e-streaming engines without changing the
+ * runner.
+ */
+export interface ShadowPath extends ShadowPathDescriptor {
+  /**
+   * Process one audio segment and return its result. Implementations must:
+   * - honor `signal` (reject or return promptly once aborted), and
+   * - treat `audio` as read-only (never mutate it).
+   */
+  process(audio: Float32Array, sampleRate: number, signal: AbortSignal): Promise<PathSampleResult>
+}
+
+/** Per-path activation and sampling policy. */
+export interface ShadowPathConfig {
+  /** Whether the path participates in measurement. Local-LLM paths default false. */
+  enabled: boolean
+  /**
+   * Process 1 of every N submitted segments (>= 1). 1 measures every segment;
+   * higher values thin out local-LLM paths to avoid pool contention.
+   */
+  samplingInterval: number
+  /** Concurrent permits for this path (default 1 — engines are sequential). */
+  permits: number
+}
+
+export const DEFAULT_PATH_CONFIG: ShadowPathConfig = {
+  enabled: true,
+  samplingInterval: 1,
+  permits: 1
+}
+
+/** Local-LLM paths are expensive and share one worker, so they start off. */
+export const DEFAULT_LOCAL_LLM_PATH_CONFIG: ShadowPathConfig = {
+  enabled: false,
+  samplingInterval: 8,
+  permits: 1
+}
+
+export interface ShadowRunnerConfig {
+  /** Max records retained per category (samples / drops / errors). Bounded to cap memory. */
+  maxRecords: number
+  /** Permits shared by ALL local-LLM paths so only one runs at a time. */
+  localLlmPermits: number
+  /**
+   * Max time stop() waits for in-flight tasks to drain (ms). Paths are required
+   * to honor their AbortSignal, but local-LLM inference generally cannot be
+   * cancelled mid-generation, so stop() must not hang on a stuck path. Results
+   * arriving after the timeout are discarded by the generation guard.
+   */
+  stopDrainTimeoutMs: number
+}
+
+export const DEFAULT_RUNNER_CONFIG: ShadowRunnerConfig = {
+  maxRecords: 2000,
+  localLlmPermits: 1,
+  stopDrainTimeoutMs: 5000
+}
+
+/** Reason a segment was not measured on a given path. */
+export type DropReason = 'disabled' | 'sampling' | 'path-busy' | 'local-llm-busy' | 'not-running'
+
+/** A recorded telemetry sample for one processed segment on one path. */
+export interface ShadowSample {
+  pathId: string
+  segmentId: number
+  timestamp: number
+  /** End-to-end wall-clock latency for the path (ms). */
+  latencyMs: number
+  /** First-subtitle latency (ms) or null when the path emits no interim. */
+  firstSubtitleMs: number | null
+  /** Interim revision count (stability proxy). */
+  revisionCount: number
+  /** Source character count (drives cost metering). */
+  sourceChars: number
+  /** Estimated marginal cost for this sample in USD. */
+  costUsd: number
+  /** Whether the path stayed fully offline for this sample (privacy). */
+  isOffline: boolean
+}
+
+/** A recorded drop (segment not measured on a path). */
+export interface ShadowDrop {
+  pathId: string
+  segmentId: number
+  timestamp: number
+  reason: DropReason
+}
+
+/** A recorded processing error on a path. */
+export interface ShadowError {
+  pathId: string
+  segmentId: number
+  timestamp: number
+  message: string
+}


### PR DESCRIPTION
## Description
- Add `src/pipeline/shadow/` — a standalone `ShadowRunner` that feeds identical audio (snapshotted once per segment) to multiple engine paths in parallel and records telemetry only. Fully decoupled from `TranslationPipeline`/`EngineManager`; nothing is emitted to the UI or session.
- Per-path drop-if-busy semaphore: a busy path drops incoming segments instead of queuing them, so queue wait never corrupts measured latency. Drops are first-class telemetry (`busyDroppedCount` / `busyDropRate`).
- Local-LLM paths (shared node-llama-cpp UtilityProcess pool) default to disabled with 1-in-8 sampling when enabled, and all such paths share a single global permit so at most one runs at a time — latency stays sound under LLM contention.
- Cancellation via AbortSignal + generation counter: results resolving after `stop()` or across a restart are discarded, never recorded. `stop()` drain is bounded by `stopDrainTimeoutMs` so an uncancellable inference cannot hang shutdown.
- Multivariate telemetry report per path: latency (p50/p95/mean + first-subtitle), cost (BYOK chars metered), privacy (offline completeness), stability proxy (revision count), drop/error rates.
- Extend `benchmark/conversational-ja-en/` (#706 chrF) with `multivariate.ts`: quality (chrF + proper-noun breakage), latency, cost, privacy, and user-value axes, plus the issue's decision rule (`recommendDefault`) — on a quality tie, prefer cost/privacy/value and keep the switchable hybrid default.
- Tests: 22 new Vitest tests covering parallel dispatch, audio snapshot isolation, drop-if-busy, cancellation/stale-generation discard, global LLM serialization, 1-in-N sampling, buffer bounds, and a benchmark report smoke test.

Design verified with Codex (drop-if-busy vs queue, global LLM semaphore, runtime-vs-offline quality split). Reviewed by two parallel review agents: 0 critical, 2 warnings — both fixed (bounded stop drain, per-window segment counter).

## Related Issue
Closes #720

## Screenshots / Video
N/A (no UI changes)

## Test Checklist
- [x] Unit tests added/updated
- [ ] Tested in Chrome (N/A — main-process/benchmark code only)
- [ ] Tested in Firefox or Safari (N/A)
- [ ] Responsive: mobile (375px) and desktop (1280px+) (N/A)
- [ ] Keyboard navigation works (N/A)
- [ ] Dark mode verified (if supported) (N/A)

## Checklist
- [x] CLAUDE.md rules followed
- [x] No hardcoded strings (all externalized) (constants defined; no user-facing strings)
- [x] Error handling complete
- [x] No console.log left in production code