### PR TITLE
#721 Cloud realtime 100ms continuous PCM audio input mode

### DIFF
--- a/src/main/audio-handlers.test.ts
+++ b/src/main/audio-handlers.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// Capture ipcMain handlers registered by registerAudioHandlers
+const handlers = new Map<string, (event: unknown, arg: unknown) => unknown>()
+
+vi.mock('electron', () => ({
+  ipcMain: {
+    handle: (channel: string, fn: (event: unknown, arg: unknown) => unknown) => {
+      handlers.set(channel, fn)
+    }
+  }
+}))
+
+vi.mock('./logger', () => ({
+  createLogger: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })
+}))
+
+vi.mock('./error-utils', () => ({
+  sanitizeErrorMessage: (m: string) => m
+}))
+
+import { registerAudioHandlers } from './audio-handlers'
+import { resetRealtimeAudioDispatcher } from './realtime-audio'
+import type { AppContext } from './app-context'
+
+// Flush the microtask queue so the realtime promise chain settles
+const flush = (): Promise<void> => new Promise((resolve) => setImmediate(resolve))
+
+function makePipeline(): {
+  running: boolean
+  process: ReturnType<typeof vi.fn>
+  processStreaming: ReturnType<typeof vi.fn>
+  finalizeStreaming: ReturnType<typeof vi.fn>
+  pushRealtimeAudio: ReturnType<typeof vi.fn>
+  onSpeechBoundary: ReturnType<typeof vi.fn>
+} {
+  return {
+    running: true,
+    process: vi.fn().mockResolvedValue(null),
+    processStreaming: vi.fn().mockResolvedValue(null),
+    finalizeStreaming: vi.fn().mockResolvedValue(null),
+    pushRealtimeAudio: vi.fn().mockResolvedValue(undefined),
+    onSpeechBoundary: vi.fn().mockResolvedValue(undefined)
+  }
+}
+
+describe('registerAudioHandlers (#721)', () => {
+  let pipeline: ReturnType<typeof makePipeline>
+  let ctx: AppContext
+
+  beforeEach(() => {
+    handlers.clear()
+    resetRealtimeAudioDispatcher() // isolate the shared realtime chain between cases
+    pipeline = makePipeline()
+    ctx = { pipeline, mainWindow: { webContents: { send: vi.fn() } } } as unknown as AppContext
+    registerAudioHandlers(ctx)
+  })
+
+  it('routes a sub-0.5s realtime chunk to pushRealtimeAudio (bypasses the 8000-sample minimum)', async () => {
+    const chunk = Array.from(new Float32Array(1600).fill(0.5)) // 100ms at 16kHz
+    await handlers.get('push-realtime-audio')!(null, chunk)
+    await flush()
+
+    expect(pipeline.pushRealtimeAudio).toHaveBeenCalledTimes(1)
+    const arg = pipeline.pushRealtimeAudio.mock.calls[0][0]
+    expect(arg).toBeInstanceOf(Float32Array)
+    expect(arg.length).toBe(1600)
+    // Realtime audio must not leak into the cascade STT path
+    expect(pipeline.processStreaming).not.toHaveBeenCalled()
+  })
+
+  it('preserves order across many realtime chunks via the sequential chain', async () => {
+    for (let i = 0; i < 5; i++) {
+      await handlers.get('push-realtime-audio')!(null, Array.from(new Float32Array(1600).fill(i / 10)))
+    }
+    await flush()
+    expect(pipeline.pushRealtimeAudio).toHaveBeenCalledTimes(5)
+  })
+
+  it('keeps pushing after a rejected chunk (per-link catch, no chain poisoning)', async () => {
+    pipeline.pushRealtimeAudio.mockRejectedValueOnce(new Error('boom'))
+    await handlers.get('push-realtime-audio')!(null, Array.from(new Float32Array(1600)))
+    await handlers.get('push-realtime-audio')!(null, Array.from(new Float32Array(1600)))
+    await flush()
+    expect(pipeline.pushRealtimeAudio).toHaveBeenCalledTimes(2)
+  })
+
+  it('finalizes the segment only on a speech-end boundary hint', async () => {
+    await handlers.get('speech-boundary')!(null, 'start')
+    expect(pipeline.onSpeechBoundary).not.toHaveBeenCalled()
+    await handlers.get('speech-boundary')!(null, 'end')
+    expect(pipeline.onSpeechBoundary).toHaveBeenCalledTimes(1)
+  })
+
+  it('cascade regression: streaming chunks below the 0.5s minimum are still dropped', async () => {
+    const short = Array.from(new Float32Array(1600).fill(0.5))
+    await handlers.get('process-audio-streaming')!(null, short)
+    expect(pipeline.processStreaming).not.toHaveBeenCalled()
+  })
+
+  it('cascade regression: a valid streaming chunk still reaches processStreaming', async () => {
+    const valid = Array.from(new Float32Array(8000).fill(0.5))
+    await handlers.get('process-audio-streaming')!(null, valid)
+    expect(pipeline.processStreaming).toHaveBeenCalledTimes(1)
+  })
+
+  it('ignores realtime audio when the pipeline is not running', async () => {
+    pipeline.running = false
+    await handlers.get('push-realtime-audio')!(null, Array.from(new Float32Array(1600)))
+    await flush()
+    expect(pipeline.pushRealtimeAudio).not.toHaveBeenCalled()
+  })
+})

--- a/src/main/audio-handlers.ts
+++ b/src/main/audio-handlers.ts
@@ -3,6 +3,7 @@ import { sanitizeErrorMessage } from './error-utils'
 import { createLogger } from './logger'
 import { SAMPLE_RATE } from './constants'
 import { MIN_AUDIO_CHUNK_SAMPLES, SILENCE_THRESHOLD } from './audio-constants'
+import { getRealtimeAudioDispatcher } from './realtime-audio'
 import type { AppContext } from './app-context'
 
 const log = createLogger('audio')
@@ -45,6 +46,20 @@ function toValidAudioChunk(audioData: unknown): Float32Array | null {
   const chunk = toFloat32Array(audioData)
   if (!chunk || chunk.length < MIN_AUDIO_CHUNK_SAMPLES) return null
   return chunk
+}
+
+/**
+ * Convert realtime IPC audio data to Float32Array (#721). IPC always delivers a
+ * plain number[]; unlike {@link toValidAudioChunk} this applies neither the 0.5s
+ * minimum nor silence gating, since cloud realtime APIs expect a continuous
+ * stream where 100ms chunks and silence are part of the provider's own turn
+ * detection.
+ */
+function toRealtimeChunk(audioData: unknown): Float32Array | null {
+  if (audioData instanceof Float32Array) return audioData
+  if (Array.isArray(audioData)) return new Float32Array(audioData)
+  log.error('Unknown realtime audio data type:', typeof audioData)
+  return null
 }
 
 /** Register audio processing IPC handlers */
@@ -103,6 +118,18 @@ export function registerAudioHandlers(ctx: AppContext): void {
     } finally {
       processingStreaming = false
     }
+  })
+
+  // #721: Realtime cloud e2e — continuous 100ms PCM chunks and VAD turn-boundary
+  // hints are serialized through the shared dispatcher (ordering, bounded
+  // backpressure, and session isolation live there — see realtime-audio.ts).
+  const realtime = getRealtimeAudioDispatcher()
+  ipcMain.handle('push-realtime-audio', (_event, audioData: unknown) => {
+    const chunk = toRealtimeChunk(audioData)
+    if (chunk) realtime.pushAudio(ctx, chunk)
+  })
+  ipcMain.handle('speech-boundary', (_event, boundary: unknown) => {
+    realtime.signalBoundary(ctx, boundary)
   })
 
   // Finalize streaming (speech segment ended)

--- a/src/main/audio-port.ts
+++ b/src/main/audio-port.ts
@@ -2,6 +2,7 @@ import { MessageChannelMain } from 'electron'
 import { createLogger } from './logger'
 import { SAMPLE_RATE } from './constants'
 import { MIN_AUDIO_CHUNK_SAMPLES, SILENCE_THRESHOLD } from './audio-constants'
+import { getRealtimeAudioDispatcher } from './realtime-audio'
 import type { AppContext } from './app-context'
 
 const log = createLogger('audio-port')
@@ -31,6 +32,10 @@ export function setupAudioPort(ctx: AppContext): void {
     let processingAudio = false
     let processingStreaming = false
     let processingFinalize = false
+    // #721: realtime chunks are serialized through the shared dispatcher, the
+    // same instance the IPC transport uses, so audio and turn-boundary hints
+    // keep a single global order regardless of which transport carries them.
+    const realtime = getRealtimeAudioDispatcher()
 
     // Main process receives audio on port1
     port1.on('message', (event) => {
@@ -47,6 +52,13 @@ export function setupAudioPort(ctx: AppContext): void {
         )
       } else {
         log.error('Unexpected audio data type on MessagePort:', typeof audio)
+        return
+      }
+
+      // #721: realtime chunks bypass the 0.5s minimum and silence gate —
+      // continuity matters and silence is part of the provider's turn detection.
+      if (type === 'push-realtime-audio') {
+        realtime.pushAudio(ctx, chunk)
         return
       }
 

--- a/src/main/ipc/pipeline-ipc.ts
+++ b/src/main/ipc/pipeline-ipc.ts
@@ -13,6 +13,7 @@ import type { EngineConfig } from '../../engines/types'
 import { sanitizeErrorMessage } from '../error-utils'
 import { createLogger } from '../logger'
 import { getMdmConfig } from '../mdm-config'
+import { resetRealtimeAudioDispatcher } from '../realtime-audio'
 import { recordSessionEnd } from '../../logger/UsageAnalytics'
 import type { LiveSessionMetrics } from '../../logger/UsageAnalytics'
 
@@ -52,6 +53,8 @@ export function registerPipelineIpc(ctx: AppContext): void {
     if (ctx.pipeline.active) {
       await ctx.pipeline.stop() // Auto-stop before restart
     }
+    // #721: new session generation — invalidate any realtime chunks queued from a prior run
+    resetRealtimeAudioDispatcher()
 
     try {
       // #519: Apply MDM admin locks — override user-selected engine if locked
@@ -269,6 +272,8 @@ export function registerPipelineIpc(ctx: AppContext): void {
     }
 
     await ctx.pipeline?.stop()
+    // #721: drop any realtime chunks still queued for the stopped session
+    resetRealtimeAudioDispatcher()
     ctx.logger?.endSession()
     const logPath = ctx.logger?.getLogPath()
     ctx.logger = null

--- a/src/main/realtime-audio.test.ts
+++ b/src/main/realtime-audio.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+vi.mock('./logger', () => ({
+  createLogger: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })
+}))
+
+import { RealtimeAudioDispatcher } from './realtime-audio'
+import type { AppContext } from './app-context'
+
+const flush = (): Promise<void> => new Promise((resolve) => setImmediate(resolve))
+
+function makeCtx(): { ctx: AppContext; pushRealtimeAudio: ReturnType<typeof vi.fn>; onSpeechBoundary: ReturnType<typeof vi.fn>; setRunning: (v: boolean) => void } {
+  const pushRealtimeAudio = vi.fn().mockResolvedValue(undefined)
+  const onSpeechBoundary = vi.fn().mockResolvedValue(undefined)
+  const pipeline = { running: true, pushRealtimeAudio, onSpeechBoundary }
+  const ctx = { pipeline } as unknown as AppContext
+  return { ctx, pushRealtimeAudio, onSpeechBoundary, setRunning: (v) => { pipeline.running = v } }
+}
+
+const chunk = (): Float32Array => new Float32Array(1600).fill(0.1)
+
+describe('RealtimeAudioDispatcher (#721)', () => {
+  let d: RealtimeAudioDispatcher
+
+  beforeEach(() => {
+    d = new RealtimeAudioDispatcher(4) // small cap for testability
+  })
+
+  it('forwards chunks in order to pushRealtimeAudio', async () => {
+    const { ctx, pushRealtimeAudio } = makeCtx()
+    for (let i = 0; i < 3; i++) d.pushAudio(ctx, chunk())
+    await flush()
+    expect(pushRealtimeAudio).toHaveBeenCalledTimes(3)
+  })
+
+  it('drops chunks past the pending cap instead of growing unbounded', async () => {
+    const { ctx, pushRealtimeAudio } = makeCtx()
+    // Enqueue synchronously: pending increments before any chain link drains, so
+    // only `cap` (4) chunks are accepted and the remaining 6 are dropped.
+    for (let i = 0; i < 10; i++) d.pushAudio(ctx, chunk())
+    await flush()
+    expect(pushRealtimeAudio).toHaveBeenCalledTimes(4)
+  })
+
+  it('ignores audio when the pipeline is not running', async () => {
+    const { ctx, pushRealtimeAudio, setRunning } = makeCtx()
+    setRunning(false)
+    d.pushAudio(ctx, chunk())
+    await flush()
+    expect(pushRealtimeAudio).not.toHaveBeenCalled()
+  })
+
+  it('ignores empty chunks', async () => {
+    const { ctx, pushRealtimeAudio } = makeCtx()
+    d.pushAudio(ctx, new Float32Array(0))
+    await flush()
+    expect(pushRealtimeAudio).not.toHaveBeenCalled()
+  })
+
+  it('finalizes a segment only on an end boundary, sequenced after queued audio', async () => {
+    const { ctx, pushRealtimeAudio, onSpeechBoundary } = makeCtx()
+    const order: string[] = []
+    pushRealtimeAudio.mockImplementation(async () => { order.push('audio') })
+    onSpeechBoundary.mockImplementation(async () => { order.push('boundary') })
+
+    d.pushAudio(ctx, chunk())
+    d.pushAudio(ctx, chunk())
+    d.signalBoundary(ctx, 'start') // no-op
+    d.signalBoundary(ctx, 'end')
+    await flush()
+
+    expect(onSpeechBoundary).toHaveBeenCalledTimes(1)
+    expect(order).toEqual(['audio', 'audio', 'boundary']) // boundary never precedes its audio
+  })
+
+  it('reset() invalidates chunks queued for a superseded session', async () => {
+    const { ctx, pushRealtimeAudio } = makeCtx()
+    d.pushAudio(ctx, chunk()) // queued for the old generation
+    d.pushAudio(ctx, chunk())
+    d.reset()                 // new session generation — old chunks are stale
+    await flush()
+    // Both queued chunks carry the old epoch, so neither reaches the pipeline
+    expect(pushRealtimeAudio).not.toHaveBeenCalled()
+  })
+})

--- a/src/main/realtime-audio.ts
+++ b/src/main/realtime-audio.ts
@@ -1,0 +1,97 @@
+import { createLogger } from './logger'
+import type { AppContext } from './app-context'
+
+const log = createLogger('realtime-audio')
+
+/**
+ * Upper bound on in-flight realtime chunks (~5s at 100ms). Cloud realtime APIs
+ * expect a continuous stream, but if the session stalls we must not let the
+ * queue (and its captured PCM buffers) grow without limit — new chunks are
+ * dropped past this bound rather than accumulating unbounded latency/memory.
+ */
+const MAX_PENDING_CHUNKS = 50
+
+/**
+ * Serializes realtime (cloud e2e) audio pushes and turn-boundary signals onto a
+ * single ordered promise chain (#721).
+ *
+ * Why a shared chain:
+ * - Ordering: audio may arrive via the MessagePort transport while the
+ *   turn-boundary hint arrives via IPC. Routing both through one chain keeps
+ *   `onSpeechBoundary()` sequenced after the audio it follows, so a segment is
+ *   never flushed before its trailing chunks reach the session.
+ * - Backpressure: each push awaits the session's `drained` signal internally;
+ *   the bounded `pending` counter caps how far the producer can run ahead.
+ * - Session isolation: `epoch` invalidates any chunks still queued from a prior
+ *   session, so stale audio can never bleed into a freshly started session.
+ */
+export class RealtimeAudioDispatcher {
+  private chain: Promise<void> = Promise.resolve()
+  private pending = 0
+  private epoch = 0
+  private dropped = 0
+
+  constructor(private readonly maxPending: number = MAX_PENDING_CHUNKS) {}
+
+  /** Queue a realtime PCM chunk for the active e2e session. */
+  pushAudio(ctx: AppContext, chunk: Float32Array): void {
+    if (!ctx.pipeline?.running || chunk.length === 0) return
+
+    if (this.pending >= this.maxPending) {
+      this.dropped++
+      // Log the first drop and then periodically to avoid flooding.
+      if (this.dropped === 1 || this.dropped % this.maxPending === 0) {
+        log.warn(`Realtime backlog saturated (${this.pending} pending); dropping chunk (total dropped: ${this.dropped})`)
+      }
+      return
+    }
+
+    const epoch = this.epoch
+    this.pending++
+    this.chain = this.chain
+      .then(() => {
+        // Drop work belonging to a superseded session.
+        if (epoch !== this.epoch || !ctx.pipeline?.running) return
+        return ctx.pipeline.pushRealtimeAudio(chunk)
+      })
+      .catch((err) => log.error('Realtime audio push error:', err))
+      .finally(() => { this.pending = Math.max(0, this.pending - 1) })
+  }
+
+  /** Queue a turn-boundary hint; only 'end' finalizes the current segment. */
+  signalBoundary(ctx: AppContext, boundary: unknown): void {
+    if (boundary !== 'end' || !ctx.pipeline?.running) return
+
+    const epoch = this.epoch
+    this.chain = this.chain
+      .then(() => {
+        if (epoch !== this.epoch || !ctx.pipeline?.running) return
+        return ctx.pipeline.onSpeechBoundary()
+      })
+      .catch((err) => log.error('Speech boundary error:', err))
+  }
+
+  /**
+   * Start a new session generation: detaches the current chain and invalidates
+   * any queued chunks. Call on pipeline start and stop.
+   */
+  reset(): void {
+    this.epoch++
+    this.chain = Promise.resolve()
+    this.pending = 0
+    this.dropped = 0
+  }
+}
+
+let dispatcher: RealtimeAudioDispatcher | null = null
+
+/** Shared dispatcher instance used by every realtime audio transport. */
+export function getRealtimeAudioDispatcher(): RealtimeAudioDispatcher {
+  if (!dispatcher) dispatcher = new RealtimeAudioDispatcher()
+  return dispatcher
+}
+
+/** Invalidate queued realtime work on session start/stop. */
+export function resetRealtimeAudioDispatcher(): void {
+  dispatcher?.reset()
+}

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -4,6 +4,8 @@ export interface ElectronAPI {
   processAudio: (audioData: number[]) => Promise<unknown>
   processAudioStreaming: (audioData: number[]) => Promise<unknown>
   finalizeStreaming: (audioData: number[]) => Promise<unknown>
+  pushRealtimeAudio: (audioData: number[]) => Promise<unknown>
+  speechBoundary: (boundary: 'start' | 'end') => Promise<unknown>
   onTranslationResult: (callback: (data: unknown) => void) => (() => void)
   onInterimResult: (callback: (data: unknown) => void) => (() => void)
   onDraftResult: (callback: (data: unknown) => void) => (() => void)

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -7,6 +7,9 @@ contextBridge.exposeInMainWorld('api', {
   processAudio: (audioData: number[]) => ipcRenderer.invoke('process-audio', audioData),
   processAudioStreaming: (audioData: number[]) => ipcRenderer.invoke('process-audio-streaming', audioData),
   finalizeStreaming: (audioData: number[]) => ipcRenderer.invoke('finalize-streaming', audioData),
+  // Cloud realtime e2e streaming (#721)
+  pushRealtimeAudio: (audioData: number[]) => ipcRenderer.invoke('push-realtime-audio', audioData),
+  speechBoundary: (boundary: 'start' | 'end') => ipcRenderer.invoke('speech-boundary', boundary),
 
   // Translation results
   onTranslationResult: (callback: (data: unknown) => void) => {

--- a/src/renderer/hooks/realtimeChunker.test.ts
+++ b/src/renderer/hooks/realtimeChunker.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect } from 'vitest'
+import { RealtimeChunker } from './realtimeChunker'
+
+const CHUNK = 1600 // 100ms at 16kHz
+
+function collect(): { chunks: Float32Array[]; onChunk: (c: Float32Array) => void } {
+  const chunks: Float32Array[] = []
+  return { chunks, onChunk: (c) => chunks.push(c) }
+}
+
+describe('RealtimeChunker', () => {
+  it('emits fixed-size chunks from larger-than-chunk frames, carrying the remainder', () => {
+    const { chunks, onChunk } = collect()
+    const chunker = new RealtimeChunker(CHUNK, onChunk)
+
+    // A frame larger than one chunk (4000 samples) yields multiple chunks
+    chunker.push(new Float32Array(4000).fill(0.5))
+    expect(chunks).toHaveLength(2) // 3200 emitted, 800 carried
+    expect(chunks.every((c) => c.length === CHUNK)).toBe(true)
+
+    chunker.push(new Float32Array(2400).fill(0.5))
+    expect(chunks).toHaveLength(4) // 800 + 2400 = 3200 -> two more chunks
+  })
+
+  it('accumulates sub-chunk frames until a full chunk is available (continuity)', () => {
+    const { chunks, onChunk } = collect()
+    const chunker = new RealtimeChunker(CHUNK, onChunk)
+
+    // Feed 20 small frames of 512 samples = 10240 samples
+    for (let i = 0; i < 20; i++) chunker.push(new Float32Array(512).fill(1))
+    // 10240 / 1600 = 6 full chunks, 640 carried
+    expect(chunks).toHaveLength(6)
+  })
+
+  it('preserves every sample in order across chunk boundaries', () => {
+    const { chunks, onChunk } = collect()
+    const chunker = new RealtimeChunker(CHUNK, onChunk)
+
+    // Build a ramp so we can verify no sample is dropped/duplicated/reordered
+    const total = CHUNK * 3 + 500
+    const source = new Float32Array(total)
+    for (let i = 0; i < total; i++) source[i] = i
+
+    // Push in irregular frame sizes
+    let offset = 0
+    for (const size of [700, 1600, 300, 2500, total - 700 - 1600 - 300 - 2500]) {
+      chunker.push(source.subarray(offset, offset + size))
+      offset += size
+    }
+
+    expect(chunks).toHaveLength(3) // 500 samples carried, not emitted
+    const flat = new Float32Array(chunks.length * CHUNK)
+    chunks.forEach((c, i) => flat.set(c, i * CHUNK))
+    for (let i = 0; i < flat.length; i++) expect(flat[i]).toBe(i)
+  })
+
+  it('reset() drops the buffered remainder', () => {
+    const { chunks, onChunk } = collect()
+    const chunker = new RealtimeChunker(CHUNK, onChunk)
+
+    chunker.push(new Float32Array(1000))
+    chunker.reset()
+    chunker.push(new Float32Array(700)) // 700, not 1700 — remainder was dropped
+    expect(chunks).toHaveLength(0)
+  })
+
+  it('ignores empty frames', () => {
+    const { chunks, onChunk } = collect()
+    const chunker = new RealtimeChunker(CHUNK, onChunk)
+    chunker.push(new Float32Array(0))
+    expect(chunks).toHaveLength(0)
+  })
+
+  it('rejects a non-positive chunk size', () => {
+    expect(() => new RealtimeChunker(0, () => {})).toThrow()
+  })
+})

--- a/src/renderer/hooks/realtimeChunker.ts
+++ b/src/renderer/hooks/realtimeChunker.ts
@@ -1,0 +1,59 @@
+/**
+ * Repackages a stream of variable-length PCM frames into fixed-size chunks.
+ *
+ * Cloud realtime translation APIs (OpenAI realtime, Gemini Live) expect audio
+ * appended as fixed ~100ms PCM chunks, but the VAD emits frames of a different
+ * cadence (~96ms at 16kHz). This buffers incoming frames and emits exactly
+ * `chunkSamples`-long chunks, carrying the remainder to the next push so no
+ * sample is dropped or duplicated. Chunk boundaries are driven purely by sample
+ * count, never by a timer, to keep the stream continuous and gap-free.
+ */
+export class RealtimeChunker {
+  private pending: Float32Array[] = []
+  private pendingLength = 0
+
+  constructor(
+    private readonly chunkSamples: number,
+    private readonly onChunk: (chunk: Float32Array) => void
+  ) {
+    if (chunkSamples <= 0) throw new Error('chunkSamples must be positive')
+  }
+
+  /** Append a frame; emits zero or more fixed-size chunks as capacity fills. */
+  push(frame: Float32Array): void {
+    if (frame.length === 0) return
+    this.pending.push(frame)
+    this.pendingLength += frame.length
+
+    while (this.pendingLength >= this.chunkSamples) {
+      this.onChunk(this.take(this.chunkSamples))
+    }
+  }
+
+  /** Drop any buffered partial samples without emitting (e.g. on stop/reset). */
+  reset(): void {
+    this.pending = []
+    this.pendingLength = 0
+  }
+
+  /** Consume exactly `count` samples from the front of the pending buffers. */
+  private take(count: number): Float32Array {
+    const out = new Float32Array(count)
+    let filled = 0
+    while (filled < count) {
+      const head = this.pending[0]
+      const remaining = count - filled
+      if (head.length <= remaining) {
+        out.set(head, filled)
+        filled += head.length
+        this.pending.shift()
+      } else {
+        out.set(head.subarray(0, remaining), filled)
+        this.pending[0] = head.subarray(remaining)
+        filled += remaining
+      }
+    }
+    this.pendingLength -= count
+    return out
+  }
+}

--- a/src/renderer/hooks/useAudioCapture.ts
+++ b/src/renderer/hooks/useAudioCapture.ts
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { MicVAD } from '@ricky0123/vad-web'
+import { RealtimeChunker } from './realtimeChunker'
 
 export interface AudioDevice {
   deviceId: string
@@ -8,6 +9,17 @@ export interface AudioDevice {
 
 /** Audio source mode: microphone only, system audio (loopback), or both mixed (#501) */
 export type AudioSource = 'microphone' | 'system' | 'both'
+
+/**
+ * Audio delivery mode (#721):
+ * - 'cascade': VAD-gated 800ms rolling-buffer resend (STT → translator pipeline)
+ * - 'realtime': continuous ~100ms PCM chunks for cloud e2e streaming; VAD is
+ *   demoted to a turn-boundary hint and does not gate the stream.
+ */
+export type CaptureMode = 'cascade' | 'realtime'
+
+/** Speech turn boundary hint emitted by VAD in realtime mode (#721) */
+export type SpeechBoundary = 'start' | 'end'
 
 export interface UseAudioCaptureReturn {
   devices: AudioDevice[]
@@ -19,7 +31,7 @@ export interface UseAudioCaptureReturn {
   volume: number // 0-1 for level meter
   permissionError: string | null // #48: mic permission error
   hasVirtualAudioDevice: boolean // #125: BlackHole/Soundflower detected
-  start: () => Promise<void>
+  start: (options?: { captureMode?: CaptureMode }) => Promise<void>
   stop: () => void
   /** Callback for VAD-detected complete speech segments (legacy mode). Returns unsubscribe function. */
   onAudioChunk: (callback: (chunk: Float32Array) => void) => () => void
@@ -27,6 +39,10 @@ export interface UseAudioCaptureReturn {
   onStreamingChunk: (callback: (buffer: Float32Array) => void) => () => void
   /** Callback when speech segment ends (streaming mode finalization). Returns unsubscribe function. */
   onSpeechSegmentEnd: (callback: (finalBuffer: Float32Array) => void) => () => void
+  /** Callback for continuous ~100ms PCM chunks in realtime mode (#721). Returns unsubscribe function. */
+  onRealtimeChunk: (callback: (chunk: Float32Array) => void) => () => void
+  /** Callback for VAD turn-boundary hints in realtime mode (#721). Returns unsubscribe function. */
+  onSpeechBoundary: (callback: (boundary: SpeechBoundary) => void) => () => void
 }
 
 /** Optional noise suppression preprocessor injected from the parent component */
@@ -37,6 +53,8 @@ export interface NoiseSuppressionProcessor {
 
 const DEFAULT_STREAMING_INTERVAL_MS = 800
 const SAMPLE_RATE = 16000
+/** Fixed PCM chunk size for realtime cloud streaming: 100ms at 16kHz (#721) */
+const REALTIME_CHUNK_SAMPLES = Math.floor(SAMPLE_RATE * 0.1)
 const MAX_ROLLING_BUFFER_SECONDS = 3
 /** Overlap from previous chunk to prevent word boundary cutting (200ms at 16kHz) */
 const CHUNK_OVERLAP_SAMPLES = Math.floor(SAMPLE_RATE * 0.2)
@@ -96,6 +114,12 @@ export function useAudioCapture(noiseSuppression?: NoiseSuppressionProcessor, st
   const chunkCallbackRef = useRef<((chunk: Float32Array) => void) | null>(null)
   const streamingCallbackRef = useRef<((buffer: Float32Array) => void) | null>(null)
   const speechEndCallbackRef = useRef<((finalBuffer: Float32Array) => void) | null>(null)
+
+  // #721: Realtime cloud streaming mode state
+  const captureModeRef = useRef<CaptureMode>('cascade')
+  const realtimeChunkCallbackRef = useRef<((chunk: Float32Array) => void) | null>(null)
+  const speechBoundaryCallbackRef = useRef<((boundary: SpeechBoundary) => void) | null>(null)
+  const realtimeChunkerRef = useRef<RealtimeChunker | null>(null)
 
   // #501: Track loopback and mixer resources for cleanup
   const loopbackStreamRef = useRef<MediaStream | null>(null)
@@ -229,6 +253,9 @@ export function useAudioCapture(noiseSuppression?: NoiseSuppressionProcessor, st
     rollingBufferIndexRef.current = 0
     rollingBufferFullRef.current = false
     prevChunkTailRef.current = null
+    // #721: drop any buffered realtime remainder
+    realtimeChunkerRef.current?.reset()
+    realtimeChunkerRef.current = null
   }, [])
 
   // #501: Acquire system audio loopback stream via electron-audio-loopback
@@ -269,12 +296,18 @@ export function useAudioCapture(noiseSuppression?: NoiseSuppressionProcessor, st
     return dest.stream
   }, [])
 
-  const start = useCallback(async () => {
+  const start = useCallback(async (options?: { captureMode?: CaptureMode }) => {
     if (isCapturing) return
 
     try {
       const deviceId = selectedDevice
       const currentAudioSource = audioSource
+      const captureMode = options?.captureMode ?? 'cascade'
+      captureModeRef.current = captureMode
+      // #721: build the 100ms chunker only for realtime mode
+      realtimeChunkerRef.current = captureMode === 'realtime'
+        ? new RealtimeChunker(REALTIME_CHUNK_SAMPLES, (chunk) => realtimeChunkCallbackRef.current?.(chunk))
+        : null
       const vad = await MicVAD.new({
         getStream: async () => {
           // #313: Request 48 kHz when DeepFilterNet3 is active (it requires 48 kHz);
@@ -336,6 +369,17 @@ export function useAudioCapture(noiseSuppression?: NoiseSuppressionProcessor, st
           const rms = Math.sqrt(sum / frame.length)
           setVolume(Math.min(1, rms * 5))
 
+          // #721: In realtime mode, forward every frame as continuous 100ms PCM
+          // chunks regardless of speech state — do not gate on VAD or accumulate
+          // the cascade rolling buffer. Copy the frame: the VAD reuses the same
+          // backing buffer across callbacks (see the cascade branch below), so
+          // frames the chunker holds until a full chunk would otherwise be
+          // overwritten before they are consumed.
+          if (captureModeRef.current === 'realtime') {
+            realtimeChunkerRef.current?.push(new Float32Array(frame))
+            return
+          }
+
           // #53: accumulate frames in circular buffer during speech (#361: reduced from 5s to 3s)
           if (isSpeakingRef.current) {
             const maxFrames = Math.floor((MAX_ROLLING_BUFFER_SECONDS * SAMPLE_RATE) / frame.length)
@@ -358,9 +402,16 @@ export function useAudioCapture(noiseSuppression?: NoiseSuppressionProcessor, st
         onSpeechEnd: (audio: Float32Array) => {
           // audio is 16kHz Float32Array from VAD
           console.log(`[audio-capture] VAD speech segment: ${audio.length} samples (${(audio.length / SAMPLE_RATE).toFixed(1)}s)`)
+          isSpeakingRef.current = false
+
+          // #721: In realtime mode the stream is never gated by VAD; the segment
+          // end is only a turn-boundary hint for the cloud e2e session.
+          if (captureModeRef.current === 'realtime') {
+            speechBoundaryCallbackRef.current?.('end')
+            return
+          }
 
           // Finalize streaming with the VAD-provided segment
-          isSpeakingRef.current = false
           speechEndCallbackRef.current?.(audio)
           rollingBufferRef.current = []
           rollingBufferIndexRef.current = 0
@@ -373,6 +424,13 @@ export function useAudioCapture(noiseSuppression?: NoiseSuppressionProcessor, st
         onSpeechStart: () => {
           console.log('[audio-capture] VAD speech start')
           isSpeakingRef.current = true
+
+          // #721: realtime mode — forward speech start as a turn-boundary hint only.
+          if (captureModeRef.current === 'realtime') {
+            speechBoundaryCallbackRef.current?.('start')
+            return
+          }
+
           rollingBufferRef.current = []
           rollingBufferIndexRef.current = 0
           rollingBufferFullRef.current = false
@@ -381,6 +439,7 @@ export function useAudioCapture(noiseSuppression?: NoiseSuppressionProcessor, st
         onVADMisfire: () => {
           console.log('[audio-capture] VAD misfire (speech too short)')
           isSpeakingRef.current = false
+          if (captureModeRef.current === 'realtime') return
           rollingBufferRef.current = []
           rollingBufferIndexRef.current = 0
           rollingBufferFullRef.current = false
@@ -390,9 +449,13 @@ export function useAudioCapture(noiseSuppression?: NoiseSuppressionProcessor, st
 
       vadRef.current = vad
       vad.start()
-      startStreamingTimer()
+      // #721: the 800ms rolling-buffer resend is cascade-only; realtime mode
+      // streams continuous 100ms chunks from onFrameProcessed instead.
+      if (captureMode === 'cascade') {
+        startStreamingTimer()
+      }
       setIsCapturing(true)
-      console.log('[audio-capture] VAD started with streaming')
+      console.log(`[audio-capture] VAD started (${captureMode} mode)`)
     } catch (err) {
       // #381: Clean up streaming timer and VAD if start fails partway through
       console.error('[audio-capture] Failed to start:', err)
@@ -454,6 +517,16 @@ export function useAudioCapture(noiseSuppression?: NoiseSuppressionProcessor, st
     return () => { speechEndCallbackRef.current = null }
   }, [])
 
+  const onRealtimeChunk = useCallback((callback: (chunk: Float32Array) => void) => {
+    realtimeChunkCallbackRef.current = callback
+    return () => { realtimeChunkCallbackRef.current = null }
+  }, [])
+
+  const onSpeechBoundary = useCallback((callback: (boundary: SpeechBoundary) => void) => {
+    speechBoundaryCallbackRef.current = callback
+    return () => { speechBoundaryCallbackRef.current = null }
+  }, [])
+
   return {
     devices,
     selectedDevice,
@@ -468,6 +541,8 @@ export function useAudioCapture(noiseSuppression?: NoiseSuppressionProcessor, st
     stop,
     onAudioChunk,
     onStreamingChunk,
-    onSpeechSegmentEnd
+    onSpeechSegmentEnd,
+    onRealtimeChunk,
+    onSpeechBoundary
   }
 }

--- a/src/renderer/hooks/useSessionSettings.ts
+++ b/src/renderer/hooks/useSessionSettings.ts
@@ -141,6 +141,8 @@ export function useSessionSettings(): SessionSettingsState {
         window.api.processAudioStreaming(arr)
       } else if (type === 'finalize-streaming') {
         window.api.finalizeStreaming(arr)
+      } else if (type === 'push-realtime-audio') {
+        window.api.pushRealtimeAudio(arr)
       }
     }
   }, [])
@@ -156,11 +158,20 @@ export function useSessionSettings(): SessionSettingsState {
     const unsub3 = audio.onSpeechSegmentEnd((finalBuffer) => {
       sendAudio('finalize-streaming', finalBuffer)
     })
+    // #721: realtime cloud e2e — continuous 100ms chunks + VAD turn-boundary hints
+    const unsub4 = audio.onRealtimeChunk((chunk) => {
+      sendAudio('push-realtime-audio', chunk)
+    })
+    const unsub5 = audio.onSpeechBoundary((boundary) => {
+      window.api.speechBoundary(boundary)
+    })
 
     return () => {
       unsub1()
       unsub2()
       unsub3()
+      unsub4()
+      unsub5()
     }
   }, [sendAudio])
 

--- a/src/renderer/hooks/useSettingsState.ts
+++ b/src/renderer/hooks/useSettingsState.ts
@@ -225,7 +225,9 @@ export function useSettingsState(): SettingsState {
         return
       }
 
-      await session.audio.start()
+      // #721: cloud e2e pipelines consume a continuous 100ms PCM stream; cascade
+      // pipelines use the VAD-segmented rolling buffer.
+      await session.audio.start({ captureMode: config.mode === 'e2e' ? 'realtime' : 'cascade' })
       session.setIsRunning(true)
       session.startSessionTimer()
       session.setStatus('Listening...')
@@ -268,7 +270,9 @@ export function useSettingsState(): SettingsState {
         session.setIsStarting(false)
         return
       }
-      await session.audio.start()
+      // #721: preserve the resumed session's capture mode
+      const resumeMode = (session.crashedSession.config as { mode?: string }).mode === 'e2e' ? 'realtime' : 'cascade'
+      await session.audio.start({ captureMode: resumeMode })
       session.setIsRunning(true)
       session.setCrashedSession(null)
       session.startSessionTimer()


### PR DESCRIPTION
## Description
Adds a cloud-realtime audio input path alongside the existing VAD-segmented cascade path, branched by `captureMode` on `useAudioCapture.start()`.

- **Renderer**: new `realtime` mode streams continuous ~100ms PCM chunks (`RealtimeChunker`, sample-count based, carries remainder) via a new `onRealtimeChunk` callback, regardless of speech state. VAD is demoted to a turn-boundary hint surfaced through `onSpeechBoundary` — it no longer gates the stream. Frames are copied before buffering (VAD reuses its frame buffer). The 800ms rolling-buffer resend and rolling accumulation are skipped in realtime mode. Cascade mode is behaviorally unchanged.
- **Transport**: realtime chunks flow over the existing MessagePort (zero-copy) or IPC fallback (`Array.from` → `new Float32Array`), bypassing the 0.5s minimum and silence gate (continuity matters; silence drives provider-side turn detection).
- **Main**: a shared `RealtimeAudioDispatcher` serializes audio pushes and boundary hints onto a single ordered promise chain across both transports — bounded queue (drops past `MAX_PENDING_CHUNKS` to cap memory/latency), per-link catch, and epoch-based session isolation reset on pipeline start/stop. Routes to the `pushRealtimeAudio`/`onSpeechBoundary` e2e path (no-op outside e2e mode).
- Mode is selected from `config.mode === 'e2e'` at pipeline start/resume.

## Related Issue
Closes #721

## Test Checklist
- [x] Unit tests added/updated

## Checklist
- [x] CLAUDE.md rules followed
- [x] Error handling complete

## Tests
Vitest: `RealtimeChunker` (100ms continuity, remainder carry, reset), `RealtimeAudioDispatcher` (ordering, bounded-drop, epoch invalidation, boundary sequencing), and `registerAudioHandlers` (realtime bypasses the 8000-sample minimum, cascade regression, boundary mapping). Full suite: 370 pass; the 10 pre-existing `virtual-mic-manager` failures are environmental (PortAudio) and unrelated. Typecheck clean; lint clean on changed files.

Note: runtime end-to-end drive is not possible yet because cloud e2e mode has no UI entry point (`buildEngineConfig` never emits `mode: 'e2e'` — a separate M0 issue); behavior is verified at each seam via unit tests.