### PR TITLE
Add shadow JA-EN measurement paths, per-audio-minute cost model, and dev harness (#730)

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,9 @@
     "lint:fix": "eslint src/ --fix",
     "bench:stt": "cd benchmark && npm run stt",
     "bench:stt:all": "cd benchmark && npm run stt:all",
-    "bench:stt:generate": "cd benchmark && npm run stt:generate-testset"
+    "bench:stt:generate": "cd benchmark && npm run stt:generate-testset",
+    "shadow:ja-en": "LT_SHADOW_JA_EN=1 electron-vite dev",
+    "shadow:ja-en:cloud": "LT_SHADOW_JA_EN=1 LT_SHADOW_CLOUD=1 electron-vite dev"
   },
   "dependencies": {
     "@electron-toolkit/utils": "^3.0.0",

--- a/src/main/dev/README.md
+++ b/src/main/dev/README.md
@@ -1,0 +1,49 @@
+# Shadow measurement harness (dev only) — #730
+
+Runs the JA⇄EN audio testset through the Local-first cascade and the cloud realtime
+e2e path side by side, and writes a `ShadowReport` (latency p50/p95, first-subtitle
+latency, cost, offline completeness, revision stability, busy/error rates).
+
+This is the "第0歩" measurement: it exists so the investment decision between
+cascade modernization (#725) and local e2e (#724) rests on measured numbers.
+
+## Running
+
+```bash
+npm run shadow:ja-en           # cascade only, no API key needed, no cost
+npm run shadow:ja-en:cloud     # + gpt-realtime-translate (BYOK — costs real money)
+```
+
+The app opens no windows and quits when the report is written.
+
+| Env var | Default | Meaning |
+|---|---|---|
+| `LT_SHADOW_JA_EN` | — | `1` enables the harness (set by the npm scripts) |
+| `LT_SHADOW_CLOUD` | — | `1` adds the cloud path. Requires `openaiApiKey` in settings |
+| `LT_SHADOW_LIMIT` | all | Measure only the first N utterances (smoke runs) |
+| `LT_SHADOW_OUT` | `benchmark/results/shadow-ja-en.json` | Report path |
+
+## Prerequisites
+
+The audio testset (`benchmark/testset/stt-audio/`) is gitignored. Regenerate it with
+`npm run bench:stt:generate` if it is missing.
+
+## Why it runs inside Electron
+
+The cascade's real engines need `utilityProcess` (the shared slm-worker pool) and
+`app.getPath('userData')` (model resolution). The `benchmark/` package runs under
+plain tsx and keeps its own separate copies of the engines — measuring those would
+prove nothing about the code that actually ships.
+
+## Gotchas found by running it
+
+- **The STT variant must be bilingual.** `WhisperLocalEngine`'s own default is
+  kotoba-whisper-v2.0, which is JA-only and returns nothing for English — it
+  silently zeroes out half of a JA⇄EN comparison. The harness defaults to
+  `large-v3-turbo`.
+- **Both paths are warmed before measuring.** Lazy model load and Metal shader
+  compilation otherwise land entirely on the first utterance (measured: 16.3s vs a
+  2.2s steady-state median), producing a p95 that describes startup, not the path.
+- **`ありがとうございます` measures as an empty segment.** Production's
+  `filterWhisperHallucination` drops thank-you phrases as Whisper hallucinations.
+  The harness reproduces production behavior faithfully; this is not a harness bug.

--- a/src/main/dev/shadow-harness.ts
+++ b/src/main/dev/shadow-harness.ts
@@ -1,0 +1,209 @@
+/**
+ * Dev shadow harness (#730) — the "第0歩" measurement.
+ *
+ * Runs the JA⇄EN audio testset through the Local-first cascade and the cloud
+ * realtime e2e path side by side and writes a ShadowReport, so the choice between
+ * investing in cascade modernization (#725) and local e2e (#724) rests on measured
+ * latency / cost / offline-completeness rather than on intuition.
+ *
+ * DEV ONLY. Gated behind an env flag, never reachable from the production UI: the
+ * cloud path is BYOK and sends audio off-device, so it stays opt-in and explicit.
+ * It must run inside Electron main — the cascade's real engines need utilityProcess
+ * (worker pool) and app.getPath('userData') (model resolution), which is exactly
+ * why measuring the benchmark/ package's separate engine copies would prove nothing
+ * about production.
+ */
+
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'fs'
+import { join, resolve } from 'path'
+import { ShadowRunner } from '../../pipeline/shadow/ShadowRunner'
+import { CascadeShadowPath } from '../../pipeline/shadow/paths/CascadeShadowPath'
+import { E2EStreamingShadowPath } from '../../pipeline/shadow/paths/E2EStreamingShadowPath'
+import type { ShadowReport } from '../../pipeline/shadow/metrics'
+import { WhisperLocalEngine } from '../../engines/stt/WhisperLocalEngine'
+import type { WhisperVariant } from '../../engines/model-downloader'
+import { HunyuanMT15Translator } from '../../engines/translator/HunyuanMT15Translator'
+import { CloudRealtimeE2E } from '../../engines/e2e/CloudRealtimeE2E'
+import type { Language } from '../../engines/types'
+import { store } from '../store'
+import { createLogger } from '../logger'
+import { readWav } from './wav'
+
+const log = createLogger('shadow-harness')
+
+/** Published price of gpt-realtime-translate: $0.034 per audio minute. */
+const GPT_REALTIME_TRANSLATE_USD_PER_AUDIO_MINUTE = 0.034
+
+const DEFAULT_TESTSET_DIR = 'benchmark/testset'
+const MANIFEST_NAME = 'stt-manifest.jsonl'
+/** Bilingual variant — see ShadowHarnessOptions.whisperVariant. */
+const DEFAULT_WHISPER_VARIANT: WhisperVariant = 'large-v3-turbo'
+
+interface ManifestEntry {
+  id: string
+  audio_path: string
+  reference_text: string
+  language: Language
+  domain: string
+}
+
+export interface ShadowHarnessOptions {
+  /** Root of the testset (contains stt-manifest.jsonl + stt-audio/). */
+  testsetDir?: string
+  /** Where the report JSON is written. */
+  outPath?: string
+  /** Limit the number of utterances (smoke runs). */
+  limit?: number
+  /** Include the cloud path. Requires an OpenAI key; costs real money. */
+  includeCloud?: boolean
+  /**
+   * Whisper variant for the cascade's STT stage. Must be bilingual: the engine's
+   * own default (kotoba-whisper-v2.0) is JA-only and returns nothing for English,
+   * which silently zeroes out half of a JA⇄EN comparison.
+   */
+  whisperVariant?: WhisperVariant
+}
+
+function loadManifest(testsetDir: string, limit?: number): ManifestEntry[] {
+  const manifestPath = join(testsetDir, MANIFEST_NAME)
+  if (!existsSync(manifestPath)) {
+    throw new Error(
+      `Testset manifest not found at ${manifestPath}. The audio set is gitignored — regenerate it with "npm run bench:stt:generate".`
+    )
+  }
+  const entries = readFileSync(manifestPath, 'utf8')
+    .trim()
+    .split('\n')
+    .filter((line) => line.trim())
+    .map((line) => JSON.parse(line) as ManifestEntry)
+  return limit ? entries.slice(0, limit) : entries
+}
+
+/**
+ * The cloud engine fixes its output language per session, so one session cannot
+ * translate both directions. Each direction therefore gets its own path, and JA
+ * and EN utterances are submitted in separate passes.
+ */
+function buildCloudPath(apiKey: string, sourceLanguage: Language): E2EStreamingShadowPath {
+  const targetLanguage: Language = sourceLanguage === 'ja' ? 'en' : 'ja'
+  return new E2EStreamingShadowPath({
+    id: `cloud-realtime-e2e:${sourceLanguage}->${targetLanguage}`,
+    engine: new CloudRealtimeE2E({ apiKey, sourceLanguage, targetLanguage }),
+    cost: { usdPerAudioMinute: GPT_REALTIME_TRANSLATE_USD_PER_AUDIO_MINUTE }
+  })
+}
+
+/**
+ * Run one utterance through the cascade and throw the result away, so lazy model
+ * load / shader compilation is not billed to the first measured segment.
+ */
+async function warmupCascade(
+  cascade: CascadeShadowPath,
+  entries: ManifestEntry[],
+  testsetDir: string
+): Promise<void> {
+  const first = entries.find((e) => existsSync(join(testsetDir, e.audio_path)))
+  if (!first) return
+  const { samples, sampleRate } = readWav(join(testsetDir, first.audio_path))
+  log.info('Warming up cascade engines...')
+  try {
+    await cascade.process(samples, sampleRate, new AbortController().signal)
+  } catch (err) {
+    log.warn('Cascade warmup failed (continuing):', err)
+  }
+}
+
+export async function runShadowJaEnHarness(options: ShadowHarnessOptions = {}): Promise<ShadowReport> {
+  const testsetDir = resolve(options.testsetDir ?? DEFAULT_TESTSET_DIR)
+  const entries = loadManifest(testsetDir, options.limit)
+  log.info(`Loaded ${entries.length} utterances from ${testsetDir}`)
+
+  const apiKey = options.includeCloud ? store.get('openaiApiKey') : ''
+  if (options.includeCloud && !apiKey) {
+    throw new Error('Cloud path requested but no OpenAI API key is stored (BYOK).')
+  }
+
+  const stt = new WhisperLocalEngine({
+    onProgress: (msg) => log.info(msg),
+    modelVariant: options.whisperVariant ?? DEFAULT_WHISPER_VARIANT
+  })
+  const translator = new HunyuanMT15Translator({ onProgress: (msg) => log.info(msg) })
+  const cascade = new CascadeShadowPath({
+    stt,
+    translator,
+    // HY-MT1.5 runs in the shared slm-worker UtilityProcess.
+    usesLocalLlm: true
+  })
+
+  log.info('Initializing cascade engines (may download models)...')
+  await stt.initialize()
+  await translator.initialize()
+
+  const runner = new ShadowRunner()
+  // Measure every segment on both paths: the runner's local-LLM defaults thin out
+  // sampling for live use, but this is an offline run over a fixed set where each
+  // utterance is submitted only after the previous one has drained.
+  runner.register(cascade, { enabled: true, samplingInterval: 1, permits: 1 })
+
+  const cloudPaths = new Map<Language, E2EStreamingShadowPath>()
+  if (apiKey) {
+    for (const language of ['ja', 'en'] as Language[]) {
+      const path = buildCloudPath(apiKey, language)
+      cloudPaths.set(language, path)
+      runner.register(path, { enabled: true, samplingInterval: 1, permits: 1 })
+    }
+    // Open the sockets up front so the first measured segment does not carry the
+    // WebSocket handshake and skew its first-subtitle number.
+    log.info('Warming up cloud sessions...')
+    await Promise.all([...cloudPaths.values()].map((p) => p.warmup()))
+  }
+
+  // Warm the cascade on a throwaway inference before measuring. Lazy model load
+  // and Metal shader compilation land entirely on the first utterance otherwise
+  // (measured: 16.3s vs a 2.2s steady-state median), which shows up as a p95
+  // that describes startup rather than the path.
+  await warmupCascade(cascade, entries, testsetDir)
+
+  runner.start()
+  try {
+    for (const entry of entries) {
+      const wavPath = join(testsetDir, entry.audio_path)
+      if (!existsSync(wavPath)) {
+        log.warn(`Skipping ${entry.id}: audio missing at ${wavPath}`)
+        continue
+      }
+      const { samples, sampleRate } = readWav(wavPath)
+
+      // A cloud session translates into ONE fixed language, so only the path for
+      // this utterance's direction may see it. Disable the other one for this
+      // submit rather than recording a wrong-direction translation.
+      for (const [language, path] of cloudPaths) {
+        runner.setPathEnabled(path.id, language === entry.language)
+      }
+
+      runner.submit(samples, sampleRate)
+      // Submit strictly one at a time: the runner drops-if-busy, so overlapping
+      // utterances would be recorded as busy drops instead of measurements.
+      await runner.whenIdle()
+      log.info(`Measured ${entry.id} (${entry.language})`)
+    }
+  } finally {
+    await runner.stop()
+    await Promise.all([...cloudPaths.values()].map((p) => p.dispose().catch(() => undefined)))
+    await translator.dispose().catch(() => undefined)
+    await stt.dispose().catch(() => undefined)
+  }
+
+  const report = runner.getReport()
+  const outPath = resolve(options.outPath ?? join('benchmark', 'results', 'shadow-ja-en.json'))
+  mkdirSync(join(outPath, '..'), { recursive: true })
+  // Raw samples ride along with the summary, which cannot show WHICH utterance
+  // produced an outlier. They carry no transcript — ShadowSample records counts
+  // only, and reference-based quality stays in the offline benchmark by design.
+  writeFileSync(
+    outPath,
+    JSON.stringify({ ...report, samples: runner.getSamples(), errors: runner.getErrors() }, null, 2)
+  )
+  log.info(`Wrote shadow report to ${outPath}`)
+  return report
+}

--- a/src/main/dev/wav.test.ts
+++ b/src/main/dev/wav.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect, afterEach } from 'vitest'
+import { mkdtempSync, rmSync, writeFileSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import { readWav } from './wav'
+
+const dirs: string[] = []
+
+function tempFile(name: string, buffer: Buffer): string {
+  const dir = mkdtempSync(join(tmpdir(), 'wav-test-'))
+  dirs.push(dir)
+  const path = join(dir, name)
+  writeFileSync(path, buffer)
+  return path
+}
+
+/** Build a minimal RIFF/WAVE file around the given PCM16 samples. */
+function buildWav(samples: number[], { channels = 1, bitsPerSample = 16, sampleRate = 16000 } = {}): Buffer {
+  const data = Buffer.alloc(samples.length * 2)
+  samples.forEach((s, i) => data.writeInt16LE(s, i * 2))
+
+  const header = Buffer.alloc(44)
+  header.write('RIFF', 0, 'ascii')
+  header.writeUInt32LE(36 + data.length, 4)
+  header.write('WAVE', 8, 'ascii')
+  header.write('fmt ', 12, 'ascii')
+  header.writeUInt32LE(16, 16) // fmt chunk size
+  header.writeUInt16LE(1, 20) // PCM
+  header.writeUInt16LE(channels, 22)
+  header.writeUInt32LE(sampleRate, 24)
+  header.writeUInt32LE(sampleRate * channels * (bitsPerSample / 8), 28)
+  header.writeUInt16LE(channels * (bitsPerSample / 8), 32)
+  header.writeUInt16LE(bitsPerSample, 34)
+  header.write('data', 36, 'ascii')
+  header.writeUInt32LE(data.length, 40)
+  return Buffer.concat([header, data])
+}
+
+afterEach(() => {
+  while (dirs.length) rmSync(dirs.pop()!, { recursive: true, force: true })
+})
+
+describe('readWav', () => {
+  it('parses 16-bit mono PCM into normalized float samples', () => {
+    const path = tempFile('ok.wav', buildWav([0, 16384, -16384, 32767]))
+
+    const { samples, sampleRate } = readWav(path)
+
+    expect(sampleRate).toBe(16000)
+    expect(Array.from(samples)).toEqual([0, 0.5, -0.5, 32767 / 32768])
+  })
+
+  it('reads the declared sample rate rather than assuming 16kHz', () => {
+    const path = tempFile('24k.wav', buildWav([1, 2], { sampleRate: 24000 }))
+
+    expect(readWav(path).sampleRate).toBe(24000)
+  })
+
+  it('skips unknown chunks before the data chunk', () => {
+    const base = buildWav([1234])
+    // Splice a LIST chunk between "fmt " and "data" — common in real recordings.
+    const list = Buffer.alloc(12)
+    list.write('LIST', 0, 'ascii')
+    list.writeUInt32LE(4, 4)
+    list.write('INFO', 8, 'ascii')
+    const withList = Buffer.concat([base.subarray(0, 36), list, base.subarray(36)])
+    withList.writeUInt32LE(withList.length - 8, 4)
+
+    const { samples } = readWav(tempFile('list.wav', withList))
+
+    expect(Array.from(samples)).toEqual([1234 / 32768])
+  })
+
+  it('rejects non-WAV, stereo, and non-16-bit files instead of decoding garbage', () => {
+    expect(() => readWav(tempFile('small.wav', Buffer.alloc(10)))).toThrow(/too small/)
+
+    const notRiff = buildWav([1])
+    notRiff.write('JUNK', 0, 'ascii')
+    expect(() => readWav(tempFile('junk.wav', notRiff))).toThrow(/RIFF/)
+
+    expect(() => readWav(tempFile('stereo.wav', buildWav([1, 2], { channels: 2 })))).toThrow(/mono/)
+    expect(() => readWav(tempFile('8bit.wav', buildWav([1], { bitsPerSample: 8 })))).toThrow(/16-bit/)
+  })
+
+  it('does not read past the end of a file whose data chunk over-declares its size', () => {
+    const truncated = buildWav([1, 2, 3])
+    truncated.writeUInt32LE(9999, 40) // data chunk claims far more than is present
+
+    const { samples } = readWav(tempFile('truncated.wav', truncated))
+
+    expect(samples.length).toBe(3)
+  })
+})

--- a/src/main/dev/wav.ts
+++ b/src/main/dev/wav.ts
@@ -1,0 +1,60 @@
+/**
+ * Minimal 16-bit PCM mono WAV reader for the dev shadow harness (#730).
+ *
+ * The benchmark/ package deliberately keeps its own standalone copies of every
+ * helper it needs (it runs under plain tsx with a separate tsconfig and cannot
+ * import from src/). This reader is the src/-side counterpart, kept small rather
+ * than reaching across that boundary.
+ */
+
+import { readFileSync } from 'fs'
+
+export interface WavData {
+  /** Mono PCM samples in [-1, 1]. */
+  samples: Float32Array
+  sampleRate: number
+}
+
+/** Parse a 16-bit PCM mono WAV file into Float32 mono samples. */
+export function readWav(path: string): WavData {
+  const buffer = readFileSync(path)
+  if (buffer.length < 44) throw new Error(`WAV file is too small: ${path}`)
+  if (buffer.toString('ascii', 0, 4) !== 'RIFF' || buffer.toString('ascii', 8, 12) !== 'WAVE') {
+    throw new Error(`Not a RIFF/WAVE file: ${path}`)
+  }
+
+  let offset = 12
+  let sampleRate = 0
+  let channels = 0
+  let bitsPerSample = 0
+  let dataStart = -1
+  let dataLen = 0
+  while (offset + 8 <= buffer.length) {
+    const id = buffer.toString('ascii', offset, offset + 4)
+    const size = buffer.readUInt32LE(offset + 4)
+    if (id === 'fmt ') {
+      channels = buffer.readUInt16LE(offset + 10)
+      sampleRate = buffer.readUInt32LE(offset + 12)
+      bitsPerSample = buffer.readUInt16LE(offset + 22)
+    } else if (id === 'data') {
+      dataStart = offset + 8
+      dataLen = size
+      break
+    }
+    offset += 8 + size
+  }
+  if (dataStart < 0) throw new Error(`No "data" chunk in WAV: ${path}`)
+  if (bitsPerSample !== 16) {
+    throw new Error(`Only 16-bit PCM WAV is supported. Got ${bitsPerSample}-bit: ${path}`)
+  }
+  if (channels !== 1) {
+    throw new Error(`Only mono WAV is supported. Got ${channels} channels: ${path}`)
+  }
+
+  const numSamples = Math.min(dataLen, buffer.length - dataStart) / 2
+  const samples = new Float32Array(numSamples)
+  for (let i = 0; i < numSamples; i++) {
+    samples[i] = buffer.readInt16LE(dataStart + i * 2) / 32768
+  }
+  return { samples, sampleRate }
+}

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -320,6 +320,25 @@ app.whenReady().then(async () => {
   migrateLegacyTranslationEngine(migratableStore, log)
   migrateLegacyAdaptiveRoutingQualityEngine(migratableStore, log)
 
+  // #730: dev-only shadow measurement run. Builds its own engines, opens no
+  // windows, and quits when the report is written — the production pipeline and
+  // UI are never involved.
+  if (process.env.LT_SHADOW_JA_EN === '1') {
+    const { runShadowJaEnHarness } = await import('./dev/shadow-harness')
+    try {
+      await runShadowJaEnHarness({
+        includeCloud: process.env.LT_SHADOW_CLOUD === '1',
+        limit: process.env.LT_SHADOW_LIMIT ? Number(process.env.LT_SHADOW_LIMIT) : undefined,
+        outPath: process.env.LT_SHADOW_OUT
+      })
+    } catch (err) {
+      log.error('Shadow harness failed:', err)
+      process.exitCode = 1
+    }
+    app.quit()
+    return
+  }
+
   await initPipeline()
 
   // Initialize TTS manager (#508)

--- a/src/pipeline/shadow/ShadowRunner.test.ts
+++ b/src/pipeline/shadow/ShadowRunner.test.ts
@@ -4,6 +4,8 @@ import type { ShadowPath, PathSampleResult, ShadowCostModel } from './types'
 
 const OFFLINE_COST: ShadowCostModel = { usdPerMillionChars: 0 }
 const CLOUD_COST: ShadowCostModel = { usdPerMillionChars: 20 }
+/** gpt-realtime-translate is billed per audio minute, not per character. */
+const REALTIME_COST: ShadowCostModel = { usdPerAudioMinute: 0.034 }
 
 /** Deferred promise helper for controlling when a path resolves. */
 function deferred<T>(): { promise: Promise<T>; resolve: (v: T) => void; reject: (e: unknown) => void } {
@@ -278,5 +280,53 @@ describe('ShadowRunner', () => {
     expect(cloudSummary.offlineCompleteness).toBe(0)
     expect(cloudSummary.totalCostUsd).toBeCloseTo((5 / 1_000_000) * 20, 12)
     expect(cloudSummary.latency.p50).toBeGreaterThanOrEqual(0)
+  })
+
+  it('setPathEnabled gates a path mid-run and records the skips as policy drops, not saturation', async () => {
+    const both = new MockPath('both')
+    const gated = new MockPath('gated')
+    runner.register(both)
+    runner.register(gated)
+    runner.start()
+
+    runner.submit(new Float32Array([1]), 16000)
+    await runner.whenIdle()
+    runner.setPathEnabled('gated', false)
+    runner.submit(new Float32Array([1]), 16000)
+    await runner.whenIdle()
+    runner.setPathEnabled('gated', true)
+    runner.submit(new Float32Array([1]), 16000)
+    await runner.whenIdle()
+
+    const summary = runner.getReport().paths.find((p) => p.pathId === 'gated')!
+    expect(summary.processedCount).toBe(2)
+    expect(summary.droppedCount).toBe(1)
+    // A path that sat out by policy is not a saturated path.
+    expect(summary.busyDropRate).toBe(0)
+    expect(runner.getDrops()).toEqual([
+      expect.objectContaining({ pathId: 'gated', reason: 'disabled' })
+    ])
+  })
+
+  it('setPathEnabled ignores an unknown path id', () => {
+    expect(() => runner.setPathEnabled('nope', false)).not.toThrow()
+  })
+
+  it('bills a speech-metered path by submitted audio duration, not by transcript length', async () => {
+    const realtime = new MockPath('realtime', false, false, REALTIME_COST, async () => ({
+      sourceText: 'a very long transcript that would dominate a per-character bill',
+      translatedText: 'x',
+      firstSubtitleMs: 30,
+      revisionCount: 1
+    }))
+    runner.register(realtime)
+    runner.start()
+    // 48000 samples @ 16kHz = 3s = 0.05 min * $0.034/min.
+    runner.submit(new Float32Array(48000), 16000)
+    await runner.whenIdle()
+
+    const summary = runner.getReport().paths.find((p) => p.pathId === 'realtime')!
+    expect(summary.totalCostUsd).toBeCloseTo((3 / 60) * 0.034, 12)
+    expect(runner.getSamples()[0]!.audioDurationMs).toBeCloseTo(3000, 6)
   })
 })

--- a/src/pipeline/shadow/ShadowRunner.ts
+++ b/src/pipeline/shadow/ShadowRunner.ts
@@ -90,6 +90,20 @@ export class ShadowRunner {
     })
   }
 
+  /**
+   * Enable or disable a registered path mid-run. Segments submitted while a path
+   * is disabled are recorded as 'disabled' drops (policy, not saturation), so the
+   * path's busy-drop rate stays honest.
+   *
+   * Used when a path can only handle a subset of segments — a cloud realtime
+   * session fixes its output language, so the JA→EN path must sit out EN audio.
+   */
+  setPathEnabled(pathId: string, enabled: boolean): void {
+    const registered = this.paths.get(pathId)
+    if (!registered) return
+    registered.config.enabled = enabled
+  }
+
   /** Descriptors of all registered paths (for reporting on zero-sample paths). */
   get descriptors(): ShadowPathDescriptor[] {
     return [...this.paths.values()].map((r) => r.path)
@@ -234,6 +248,9 @@ export class ShadowRunner {
       if (signal.aborted || generation !== this.generation || !this.running) return
 
       const sourceChars = result.sourceText.length
+      // Bill speech-metered paths by the audio actually measured, not by how long
+      // the path took to process it.
+      const audioDurationMs = sampleRate > 0 ? (audio.length / sampleRate) * 1000 : 0
       this.recordSample({
         pathId: path.id,
         segmentId,
@@ -242,7 +259,8 @@ export class ShadowRunner {
         firstSubtitleMs: result.firstSubtitleMs,
         revisionCount: result.revisionCount,
         sourceChars,
-        costUsd: estimateCostUsd(sourceChars, path.cost.usdPerMillionChars),
+        audioDurationMs,
+        costUsd: estimateCostUsd({ sourceChars, audioDurationMs, cost: path.cost }),
         isOffline: path.isOffline
       })
     } catch (err) {

--- a/src/pipeline/shadow/index.ts
+++ b/src/pipeline/shadow/index.ts
@@ -2,7 +2,11 @@
 export { ShadowRunner } from './ShadowRunner'
 export { Semaphore } from './Semaphore'
 export { summarize, percentile, estimateCostUsd } from './metrics'
-export type { ShadowReport, PathSummary, LatencyStats } from './metrics'
+export type { ShadowReport, PathSummary, LatencyStats, CostBasis } from './metrics'
+export { CascadeShadowPath } from './paths/CascadeShadowPath'
+export type { CascadeShadowPathOptions } from './paths/CascadeShadowPath'
+export { E2EStreamingShadowPath } from './paths/E2EStreamingShadowPath'
+export type { E2EStreamingShadowPathOptions } from './paths/E2EStreamingShadowPath'
 export {
   DEFAULT_PATH_CONFIG,
   DEFAULT_LOCAL_LLM_PATH_CONFIG,

--- a/src/pipeline/shadow/metrics.test.ts
+++ b/src/pipeline/shadow/metrics.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from 'vitest'
+import { estimateCostUsd } from './metrics'
+
+const NO_AUDIO = { sourceChars: 0, audioDurationMs: 0 }
+
+describe('estimateCostUsd', () => {
+  it('bills text-metered paths per source character', () => {
+    const cost = estimateCostUsd({ ...NO_AUDIO, sourceChars: 500_000, cost: { usdPerMillionChars: 20 } })
+    expect(cost).toBeCloseTo(10, 10)
+  })
+
+  it('bills speech-metered paths per audio minute', () => {
+    // gpt-realtime-translate: $0.034/min. 30s of audio = half a minute.
+    const cost = estimateCostUsd({
+      ...NO_AUDIO,
+      audioDurationMs: 30_000,
+      cost: { usdPerAudioMinute: 0.034 }
+    })
+    expect(cost).toBeCloseTo(0.017, 10)
+  })
+
+  it('sums both dimensions for a path metered on characters AND audio', () => {
+    const cost = estimateCostUsd({
+      sourceChars: 1_000_000,
+      audioDurationMs: 60_000,
+      cost: { usdPerMillionChars: 20, usdPerAudioMinute: 0.034 }
+    })
+    expect(cost).toBeCloseTo(20.034, 10)
+  })
+
+  it('charges nothing for an offline path regardless of quantities', () => {
+    expect(estimateCostUsd({ sourceChars: 10_000, audioDurationMs: 60_000, cost: {} })).toBe(0)
+    expect(
+      estimateCostUsd({
+        sourceChars: 10_000,
+        audioDurationMs: 60_000,
+        cost: { usdPerMillionChars: 0, usdPerAudioMinute: 0 }
+      })
+    ).toBe(0)
+  })
+
+  it('ignores a dimension whose quantity is missing rather than billing it', () => {
+    // A per-minute path whose duration is unknown must not silently bill zero-rate
+    // characters or produce NaN.
+    expect(estimateCostUsd({ ...NO_AUDIO, sourceChars: 100, cost: { usdPerAudioMinute: 0.034 } })).toBe(0)
+  })
+
+  it('returns 0 rather than NaN for non-finite or negative quantities', () => {
+    const cost = { usdPerMillionChars: 20, usdPerAudioMinute: 0.034 }
+    expect(estimateCostUsd({ sourceChars: NaN, audioDurationMs: NaN, cost })).toBe(0)
+    expect(estimateCostUsd({ sourceChars: Infinity, audioDurationMs: Infinity, cost })).toBe(0)
+    expect(estimateCostUsd({ sourceChars: -5, audioDurationMs: -5, cost })).toBe(0)
+  })
+})

--- a/src/pipeline/shadow/metrics.ts
+++ b/src/pipeline/shadow/metrics.ts
@@ -9,6 +9,7 @@
  */
 
 import type {
+  ShadowCostModel,
   ShadowSample,
   ShadowDrop,
   ShadowError,
@@ -145,9 +146,30 @@ export function summarize(
   }
 }
 
-/** Estimate BYOK-metered cost in USD for a sample of `sourceChars` characters. */
-export function estimateCostUsd(sourceChars: number, usdPerMillionChars: number): number {
-  if (!Number.isFinite(sourceChars) || !Number.isFinite(usdPerMillionChars)) return 0
-  if (sourceChars <= 0 || usdPerMillionChars <= 0) return 0
-  return (sourceChars / 1_000_000) * usdPerMillionChars
+/** Billable quantities of one measured sample. */
+export interface CostBasis {
+  /** Source character count (drives text-metered pricing). */
+  sourceChars: number
+  /** Source audio duration in ms (drives speech-metered pricing). */
+  audioDurationMs: number
+  cost: ShadowCostModel
+}
+
+/**
+ * Estimate BYOK-metered cost in USD for one sample. Dimensions are summed: a path
+ * metered on both characters and audio minutes pays both. Non-finite or negative
+ * quantities contribute zero rather than poisoning the total with NaN.
+ */
+export function estimateCostUsd({ sourceChars, audioDurationMs, cost }: CostBasis): number {
+  const perChar = component(sourceChars, cost.usdPerMillionChars, 1_000_000)
+  const perMinute = component(audioDurationMs, cost.usdPerAudioMinute, 60_000)
+  return perChar + perMinute
+}
+
+/** One additive cost dimension: `quantity / unitSize * usdPerUnit`, guarded. */
+function component(quantity: number, usdPerUnit: number | undefined, unitSize: number): number {
+  if (usdPerUnit === undefined) return 0
+  if (!Number.isFinite(quantity) || !Number.isFinite(usdPerUnit)) return 0
+  if (quantity <= 0 || usdPerUnit <= 0) return 0
+  return (quantity / unitSize) * usdPerUnit
 }

--- a/src/pipeline/shadow/paths/CascadeShadowPath.test.ts
+++ b/src/pipeline/shadow/paths/CascadeShadowPath.test.ts
@@ -1,0 +1,158 @@
+import { describe, it, expect } from 'vitest'
+import { CascadeShadowPath } from './CascadeShadowPath'
+import type { Language, STTEngine, STTResult, TranslatorEngine } from '../../../engines/types'
+
+function stt(result: STTResult | null, isOffline = true): STTEngine {
+  return {
+    id: 'mock-stt',
+    name: 'Mock STT',
+    isOffline,
+    initialize: async () => undefined,
+    processAudio: async () => result,
+    dispose: async () => undefined
+  }
+}
+
+function translator(
+  translate: (text: string, from: Language, to: Language) => Promise<string>,
+  isOffline = true
+): TranslatorEngine {
+  return {
+    id: 'mock-mt',
+    name: 'Mock MT',
+    isOffline,
+    initialize: async () => undefined,
+    translate: async (text, from, to) => translate(text, from, to),
+    dispose: async () => undefined
+  }
+}
+
+function sttResult(text: string, language: Language): STTResult {
+  return { text, language, isFinal: true, timestamp: 0 }
+}
+
+const AUDIO = new Float32Array(1600)
+
+describe('CascadeShadowPath', () => {
+  it('runs STT then MT and reports the final line as its first subtitle', async () => {
+    const path = new CascadeShadowPath({
+      stt: stt(sttResult('おはようございます', 'ja')),
+      translator: translator(async () => 'Good morning')
+    })
+
+    const result = await path.process(AUDIO, 16000, new AbortController().signal)
+
+    expect(result.sourceText).toBe('おはようございます')
+    expect(result.translatedText).toBe('Good morning')
+    // A batch cascade never revises, and its only subtitle is its final one.
+    expect(result.revisionCount).toBe(0)
+    expect(result.firstSubtitleMs).toBeGreaterThanOrEqual(0)
+  })
+
+  it('translates JA to EN and EN to JA based on the detected language', async () => {
+    const seen: Array<{ from: Language; to: Language }> = []
+    const make = (language: Language): CascadeShadowPath =>
+      new CascadeShadowPath({
+        stt: stt(sttResult('text', language)),
+        translator: translator(async (_t, from, to) => {
+          seen.push({ from, to })
+          return 'out'
+        })
+      })
+
+    await make('ja').process(AUDIO, 16000, new AbortController().signal)
+    await make('en').process(AUDIO, 16000, new AbortController().signal)
+
+    expect(seen).toEqual([
+      { from: 'ja', to: 'en' },
+      { from: 'en', to: 'ja' }
+    ])
+  })
+
+  it('falls back to the default source language when STT reports outside JA/EN', async () => {
+    const seen: Array<{ from: Language; to: Language }> = []
+    const path = new CascadeShadowPath({
+      stt: stt(sttResult('text', 'zh')),
+      translator: translator(async (_t, from, to) => {
+        seen.push({ from, to })
+        return 'out'
+      }),
+      defaultSourceLanguage: 'ja'
+    })
+
+    await path.process(AUDIO, 16000, new AbortController().signal)
+
+    expect(seen).toEqual([{ from: 'ja', to: 'en' }])
+  })
+
+  it('returns an empty sample without translating when STT finds no speech', async () => {
+    let translateCalls = 0
+    const path = new CascadeShadowPath({
+      stt: stt(null),
+      translator: translator(async () => {
+        translateCalls++
+        return 'should not happen'
+      })
+    })
+
+    const result = await path.process(AUDIO, 16000, new AbortController().signal)
+
+    expect(result).toEqual({
+      sourceText: '',
+      translatedText: '',
+      firstSubtitleMs: null,
+      revisionCount: 0
+    })
+    expect(translateCalls).toBe(0)
+  })
+
+  it('treats whitespace-only STT output as no speech', async () => {
+    const path = new CascadeShadowPath({
+      stt: stt(sttResult('   ', 'ja')),
+      translator: translator(async () => 'should not happen')
+    })
+
+    const result = await path.process(AUDIO, 16000, new AbortController().signal)
+
+    expect(result.sourceText).toBe('')
+    expect(result.translatedText).toBe('')
+  })
+
+  it('is offline only when both stages are offline', () => {
+    const offlineStt = stt(sttResult('t', 'ja'), true)
+    const cloudMt = translator(async () => 'x', false)
+    const offlineMt = translator(async () => 'x', true)
+
+    expect(new CascadeShadowPath({ stt: offlineStt, translator: offlineMt }).isOffline).toBe(true)
+    // A cloud MT stage sends the transcript off-device even behind offline STT.
+    expect(new CascadeShadowPath({ stt: offlineStt, translator: cloudMt }).isOffline).toBe(false)
+    expect(new CascadeShadowPath({ stt: stt(sttResult('t', 'ja'), false), translator: offlineMt }).isOffline).toBe(false)
+  })
+
+  it('rejects when aborted before the translation stage', async () => {
+    const controller = new AbortController()
+    const path = new CascadeShadowPath({
+      stt: {
+        ...stt(sttResult('text', 'ja')),
+        processAudio: async () => {
+          controller.abort()
+          return sttResult('text', 'ja')
+        }
+      },
+      translator: translator(async () => 'should not happen')
+    })
+
+    await expect(path.process(AUDIO, 16000, controller.signal)).rejects.toThrow()
+  })
+
+  it('derives an id from its two stages and defaults to zero cost', () => {
+    const path = new CascadeShadowPath({
+      stt: stt(sttResult('t', 'ja')),
+      translator: translator(async () => 'x')
+    })
+
+    expect(path.id).toBe('cascade:mock-stt+mock-mt')
+    expect(path.kind).toBe('cascade')
+    expect(path.cost).toEqual({})
+  })
+})

--- a/src/pipeline/shadow/paths/CascadeShadowPath.ts
+++ b/src/pipeline/shadow/paths/CascadeShadowPath.ts
@@ -1,0 +1,91 @@
+/**
+ * CascadeShadowPath (#730) — measures the Local-first cascade (STT → MT) as one
+ * shadow path, so it can be compared against the speech-native e2e paths.
+ *
+ * Each segment is processed in isolation: no ContextBuffer, no TranslationCache,
+ * no glossary. Those production layers help quality but would make latency depend
+ * on the segment's neighbours, and a cache hit would record a translation the
+ * engine never actually performed.
+ */
+
+import type { Language, STTEngine, TranslatorEngine } from '../../../engines/types'
+import type { PathSampleResult, ShadowCostModel, ShadowPath, ShadowPathKind } from '../types'
+
+export interface CascadeShadowPathOptions {
+  id?: string
+  stt: STTEngine
+  translator: TranslatorEngine
+  /**
+   * True if the translator routes through the shared node-llama-cpp UtilityProcess
+   * pool (HY-MT1.5 / Hunyuan-MT / LFM2). Such paths contend for a single worker and
+   * are gated by the runner's global local-LLM semaphore.
+   */
+  usesLocalLlm?: boolean
+  cost?: ShadowCostModel
+  /**
+   * Fallback source language when the STT engine reports one outside JA/EN — e.g.
+   * a JA-only engine mislabelling English audio. Defaults to 'ja'.
+   */
+  defaultSourceLanguage?: Language
+}
+
+/** JA⇄EN only: the target is always the other side of the pair (Core Value ③). */
+function counterpart(language: Language): Language {
+  return language === 'ja' ? 'en' : 'ja'
+}
+
+export class CascadeShadowPath implements ShadowPath {
+  readonly id: string
+  readonly kind: ShadowPathKind = 'cascade'
+  readonly usesLocalLlm: boolean
+  readonly isOffline: boolean
+  readonly cost: ShadowCostModel
+
+  private readonly stt: STTEngine
+  private readonly translator: TranslatorEngine
+  private readonly defaultSourceLanguage: Language
+
+  constructor(options: CascadeShadowPathOptions) {
+    this.id = options.id ?? `cascade:${options.stt.id}+${options.translator.id}`
+    this.stt = options.stt
+    this.translator = options.translator
+    this.usesLocalLlm = options.usesLocalLlm ?? false
+    // The cascade is only offline if BOTH stages are — a cloud MT stage sends the
+    // transcript off-device regardless of where the STT ran.
+    this.isOffline = options.stt.isOffline && options.translator.isOffline
+    this.cost = options.cost ?? {}
+    this.defaultSourceLanguage = options.defaultSourceLanguage ?? 'ja'
+  }
+
+  async process(
+    audio: Float32Array,
+    sampleRate: number,
+    signal: AbortSignal
+  ): Promise<PathSampleResult> {
+    signal.throwIfAborted()
+    const startedAt = performance.now()
+
+    const stt = await this.stt.processAudio(audio, sampleRate)
+    signal.throwIfAborted()
+    // Silence / no-speech. Recorded as a zero-cost empty sample rather than an
+    // error: the path behaved correctly, there was just nothing to translate.
+    if (!stt || !stt.text.trim()) {
+      return { sourceText: '', translatedText: '', firstSubtitleMs: null, revisionCount: 0 }
+    }
+
+    const from = stt.language === 'ja' || stt.language === 'en' ? stt.language : this.defaultSourceLanguage
+    const translatedText = await this.translator.translate(stt.text, from, counterpart(from))
+    signal.throwIfAborted()
+
+    return {
+      sourceText: stt.text,
+      translatedText,
+      // A batch cascade emits no interim: its first subtitle IS its final one, so
+      // time-to-final is the honest first-subtitle latency. Recording null instead
+      // would leave the baseline path without the very metric this harness exists
+      // to compare. revisionCount 0 marks it as never-revised.
+      firstSubtitleMs: performance.now() - startedAt,
+      revisionCount: 0
+    }
+  }
+}

--- a/src/pipeline/shadow/paths/E2EStreamingShadowPath.test.ts
+++ b/src/pipeline/shadow/paths/E2EStreamingShadowPath.test.ts
@@ -1,0 +1,290 @@
+import { describe, it, expect } from 'vitest'
+import { E2EStreamingShadowPath } from './E2EStreamingShadowPath'
+import type {
+  Backpressure,
+  E2EStreamingSession,
+  E2EStreamingSink,
+  E2EStreamingStartOptions,
+  E2ETranslationEngine,
+  TranslationResult
+} from '../../../engines/types'
+
+function result(sourceText: string, translatedText: string): TranslationResult {
+  return {
+    sourceText,
+    translatedText,
+    sourceLanguage: 'ja',
+    targetLanguage: 'en',
+    timestamp: 0,
+    isInterim: false
+  }
+}
+
+function deferred<T>(): { promise: Promise<T>; resolve: (v: T) => void } {
+  let resolve!: (v: T) => void
+  const promise = new Promise<T>((res) => {
+    resolve = res
+  })
+  return { promise, resolve }
+}
+
+/** Let queued microtasks run so an in-flight process() reaches its first await. */
+const tick = (): Promise<void> => new Promise((resolve) => setImmediate(resolve))
+
+/** A scripted session: the test drives interim/final through the captured sink. */
+class FakeSession implements E2EStreamingSession {
+  sink: E2EStreamingSink | null = null
+  signal: AbortSignal | null = null
+  startCount = 0
+  stopCount = 0
+  flushCount = 0
+  pushedSamples = 0
+  pushedChunks: number[] = []
+  backpressureOnce = false
+  /** Called after the audio for a segment has been pushed. */
+  onFlush: ((sink: E2EStreamingSink) => void) | null = null
+  /** Called on each pushed chunk — how a real server responds mid-stream. */
+  onPush: ((sink: E2EStreamingSink, chunkIndex: number) => void | Promise<void>) | null = null
+
+  async start(options: E2EStreamingStartOptions): Promise<void> {
+    this.startCount++
+    this.sink = options.sink
+    this.signal = options.signal
+  }
+
+  async pushAudio(chunk: Float32Array): Promise<void | Backpressure> {
+    const index = this.pushedChunks.length
+    this.pushedSamples += chunk.length
+    this.pushedChunks.push(chunk.length)
+    if (this.sink) await this.onPush?.(this.sink, index)
+    if (this.backpressureOnce) {
+      this.backpressureOnce = false
+      return { drained: Promise.resolve() }
+    }
+  }
+
+  async flushSegment(): Promise<void> {
+    this.flushCount++
+    if (this.sink) this.onFlush?.(this.sink)
+  }
+
+  async stop(): Promise<void> {
+    this.stopCount++
+  }
+}
+
+function engineWith(session: E2EStreamingSession, isOffline = false): E2ETranslationEngine {
+  return {
+    id: 'fake-e2e',
+    name: 'Fake E2E',
+    isOffline,
+    initialize: async () => undefined,
+    processAudio: async () => null,
+    createStreamingSession: () => session,
+    dispose: async () => undefined
+  }
+}
+
+/** No pacing, no sleeps, no trailing silence — deterministic and instant. */
+function makePath(
+  session: FakeSession,
+  overrides: Partial<ConstructorParameters<typeof E2EStreamingShadowPath>[0]> = {}
+): E2EStreamingShadowPath {
+  return new E2EStreamingShadowPath({
+    engine: engineWith(session),
+    realtimePacing: false,
+    trailingSilenceMs: 0,
+    settleMs: 0,
+    sleep: async () => undefined,
+    ...overrides
+  })
+}
+
+const AUDIO = new Float32Array(16000) // 1s @ 16kHz
+
+describe('E2EStreamingShadowPath', () => {
+  it('maps interims to first-subtitle latency and revision count, and the final to the sample', async () => {
+    const session = new FakeSession()
+    // Deltas stream back while the audio is still being pushed, as they do live.
+    session.onPush = (sink, i) => {
+      if (i === 2) sink.interim(result('おはよう', 'Good'))
+      if (i === 5) sink.interim(result('おはようございます', 'Good morning'))
+    }
+    session.onFlush = (sink) => sink.final(result('おはようございます', 'Good morning'))
+    const path = makePath(session)
+
+    const sample = await path.process(AUDIO, 16000, new AbortController().signal)
+
+    expect(sample.sourceText).toBe('おはようございます')
+    expect(sample.translatedText).toBe('Good morning')
+    expect(sample.revisionCount).toBe(2)
+    expect(sample.firstSubtitleMs).toBeGreaterThanOrEqual(0)
+  })
+
+  it('reuses ONE session across segments so the handshake is not measured per segment', async () => {
+    const session = new FakeSession()
+    session.onFlush = (sink) => sink.final(result('src', 'dst'))
+    const path = makePath(session)
+
+    await path.process(AUDIO, 16000, new AbortController().signal)
+    await path.process(AUDIO, 16000, new AbortController().signal)
+    await path.process(AUDIO, 16000, new AbortController().signal)
+
+    expect(session.startCount).toBe(1)
+  })
+
+  it('warmup opens the session before any segment is measured', async () => {
+    const session = new FakeSession()
+    const path = makePath(session)
+
+    await path.warmup()
+
+    expect(session.startCount).toBe(1)
+  })
+
+  it('forces a segment boundary via flushSegment when the server sends no final', async () => {
+    const session = new FakeSession()
+    session.onFlush = (sink) => sink.final(result('src', 'flushed'))
+    const path = makePath(session)
+
+    const sample = await path.process(AUDIO, 16000, new AbortController().signal)
+
+    expect(session.flushCount).toBe(1)
+    expect(sample.translatedText).toBe('flushed')
+  })
+
+  it('returns an empty sample when a segment produces no text at all', async () => {
+    const session = new FakeSession()
+    session.onFlush = () => undefined // nothing accumulated: silence
+    const path = makePath(session)
+
+    const sample = await path.process(AUDIO, 16000, new AbortController().signal)
+
+    expect(sample).toEqual({
+      sourceText: '',
+      translatedText: '',
+      firstSubtitleMs: null,
+      revisionCount: 0
+    })
+  })
+
+  it('does not let a stale final from a settled segment resolve the next one', async () => {
+    const session = new FakeSession()
+    session.onFlush = (sink) => sink.final(result('first', 'first-out'))
+    const path = makePath(session)
+
+    const first = await path.process(AUDIO, 16000, new AbortController().signal)
+    expect(first.translatedText).toBe('first-out')
+
+    // A late final from the previous turn arrives with no segment in flight.
+    session.sink!.final(result('stale', 'stale-out'))
+
+    session.onFlush = (sink) => sink.final(result('second', 'second-out'))
+    const second = await path.process(AUDIO, 16000, new AbortController().signal)
+    expect(second.translatedText).toBe('second-out')
+  })
+
+  it('rejects concurrent segments rather than mis-correlating their finals', async () => {
+    const session = new FakeSession()
+    const held = deferred<void>()
+    // Hold the first segment inside pushAudio so a second call overlaps it.
+    session.onPush = async (_sink, i) => {
+      if (i === 0) await held.promise
+    }
+    session.onFlush = (sink) => sink.final(result('src', 'dst'))
+    const path = makePath(session)
+
+    const first = path.process(AUDIO, 16000, new AbortController().signal)
+    await tick()
+    await expect(path.process(AUDIO, 16000, new AbortController().signal)).rejects.toThrow(
+      /concurrent segments/
+    )
+
+    held.resolve()
+    await first
+  })
+
+  it('honors backpressure before pushing more audio', async () => {
+    const session = new FakeSession()
+    session.backpressureOnce = true
+    session.onFlush = (sink) => sink.final(result('src', 'dst'))
+    const path = makePath(session)
+
+    await path.process(AUDIO, 16000, new AbortController().signal)
+
+    expect(session.pushedSamples).toBe(AUDIO.length)
+  })
+
+  it('chunks audio at the realtime cadence of the capture adapter', async () => {
+    const session = new FakeSession()
+    session.onFlush = (sink) => sink.final(result('src', 'dst'))
+    const path = makePath(session, { chunkMs: 100 })
+
+    await path.process(AUDIO, 16000, new AbortController().signal)
+
+    // 1s of 16kHz audio at 100ms/chunk = 10 chunks of 1600 samples.
+    expect(session.pushedChunks).toEqual(Array(10).fill(1600))
+  })
+
+  it('appends trailing silence so the server gets a pause cue to close the turn', async () => {
+    const session = new FakeSession()
+    session.onFlush = (sink) => sink.final(result('src', 'dst'))
+    const path = makePath(session, { trailingSilenceMs: 500 })
+
+    await path.process(AUDIO, 16000, new AbortController().signal)
+
+    // 500ms @ 16kHz = 8000 samples appended after the utterance.
+    expect(session.pushedSamples).toBe(AUDIO.length + 8000)
+  })
+
+  it('rejects the in-flight segment when the run is aborted', async () => {
+    const session = new FakeSession()
+    const controller = new AbortController()
+    session.onPush = (_sink, i) => {
+      if (i === 2) controller.abort()
+    }
+    session.onFlush = (sink) => sink.final(result('src', 'dst'))
+    const path = makePath(session)
+
+    await expect(path.process(AUDIO, 16000, controller.signal)).rejects.toThrow()
+  })
+
+  it('surfaces a session error as a failed segment', async () => {
+    const session = new FakeSession()
+    session.onPush = (sink, i) => {
+      if (i === 2) sink.error(new Error('socket died'))
+    }
+    session.onFlush = (sink) => sink.final(result('src', 'dst'))
+    const path = makePath(session)
+
+    await expect(path.process(AUDIO, 16000, new AbortController().signal)).rejects.toThrow(
+      'socket died'
+    )
+  })
+
+  it('drops the session on a segment timeout so its accumulator cannot poison later segments', async () => {
+    const session = new FakeSession()
+    session.onFlush = () => undefined
+    const path = makePath(session, { settleMs: 10_000, segmentTimeoutMs: -1 })
+
+    await expect(path.process(AUDIO, 16000, new AbortController().signal)).rejects.toThrow(/timed out/)
+    expect(session.stopCount).toBe(1)
+  })
+
+  it('reports cloud descriptors and rejects engines without streaming support', () => {
+    const session = new FakeSession()
+    const path = makePath(session, { cost: { usdPerAudioMinute: 0.034 } })
+
+    expect(path.id).toBe('e2e-streaming:fake-e2e')
+    expect(path.kind).toBe('e2e-streaming')
+    expect(path.isOffline).toBe(false)
+    expect(path.cost).toEqual({ usdPerAudioMinute: 0.034 })
+
+    expect(
+      () =>
+        new E2EStreamingShadowPath({
+          engine: { ...engineWith(session), createStreamingSession: undefined }
+        })
+    ).toThrow(/does not support streaming/)
+  })
+})

--- a/src/pipeline/shadow/paths/E2EStreamingShadowPath.ts
+++ b/src/pipeline/shadow/paths/E2EStreamingShadowPath.ts
@@ -1,0 +1,316 @@
+/**
+ * E2EStreamingShadowPath (#730) — drives a continuous E2E streaming session
+ * (CloudRealtimeE2E → gpt-realtime-translate) segment by segment so it can be
+ * measured against the batch cascade.
+ *
+ * Two properties make the numbers mean anything (design verified with Codex):
+ *
+ * 1. ONE long-lived session across all segments, warmed up before measurement.
+ *    A fresh WebSocket per segment would fold the handshake into every
+ *    first-subtitle number and reflect nothing about production, where a single
+ *    session spans the whole meeting.
+ *
+ * 2. Audio is pushed at realtime cadence. Blasting a pre-recorded utterance at
+ *    disk speed distorts server-side VAD, interim emission timing and
+ *    backpressure — the path would look faster than a live speaker ever gets.
+ *
+ * Billing is per audio minute, so realtime pacing costs no more than a burst.
+ */
+
+import type { E2EStreamingSession, E2ETranslationEngine, TranslationResult } from '../../../engines/types'
+import type { PathSampleResult, ShadowCostModel, ShadowPath, ShadowPathKind } from '../types'
+
+/** Chunk size of the production realtime capture adapter (#721). */
+const DEFAULT_CHUNK_MS = 100
+/**
+ * Quiet period after the last audio chunk before we force a segment boundary.
+ * The translation endpoint exposes no turn-commit, so a segment is committed
+ * either by the server's own done event or by this settle timer — flushing the
+ * instant the audio ends would truncate translations still in flight.
+ */
+const DEFAULT_SETTLE_MS = 800
+/**
+ * Trailing silence appended to each segment. A live speaker's pause is what makes
+ * the server close a turn; a pre-recorded clip that stops dead gives it no cue.
+ */
+const DEFAULT_TRAILING_SILENCE_MS = 500
+/** Hard cap per segment so one stuck turn cannot wedge the run. */
+const DEFAULT_SEGMENT_TIMEOUT_MS = 30_000
+
+const realSleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms))
+
+export interface E2EStreamingShadowPathOptions {
+  id?: string
+  /** Must implement createStreamingSession(). */
+  engine: E2ETranslationEngine
+  cost?: ShadowCostModel
+  usesLocalLlm?: boolean
+  chunkMs?: number
+  settleMs?: number
+  trailingSilenceMs?: number
+  segmentTimeoutMs?: number
+  /** Disable realtime pacing (tests only — distorts live measurements). */
+  realtimePacing?: boolean
+  /** Injectable sleep (tests). */
+  sleep?: (ms: number) => Promise<void>
+}
+
+interface PendingSegment {
+  seq: number
+  startedAt: number
+  firstSubtitleMs: number | null
+  revisionCount: number
+  latest: TranslationResult | null
+  promise: Promise<PathSampleResult>
+  resolve: (result: PathSampleResult) => void
+  reject: (err: Error) => void
+  settled: boolean
+  /** Bumped by every interim; the settle timer only fires once deltas go quiet. */
+  lastActivityAt: number
+}
+
+export class E2EStreamingShadowPath implements ShadowPath {
+  readonly id: string
+  readonly kind: ShadowPathKind = 'e2e-streaming'
+  readonly usesLocalLlm: boolean
+  readonly isOffline: boolean
+  readonly cost: ShadowCostModel
+
+  private readonly engine: E2ETranslationEngine
+  private readonly chunkMs: number
+  private readonly settleMs: number
+  private readonly trailingSilenceMs: number
+  private readonly segmentTimeoutMs: number
+  private readonly realtimePacing: boolean
+  private readonly sleep: (ms: number) => Promise<void>
+
+  private session: E2EStreamingSession | null = null
+  private sessionAbort: AbortController | null = null
+  private pending: PendingSegment | null = null
+  private seq = 0
+
+  constructor(options: E2EStreamingShadowPathOptions) {
+    if (!options.engine.createStreamingSession) {
+      throw new Error(`Engine ${options.engine.id} does not support streaming sessions`)
+    }
+    this.id = options.id ?? `e2e-streaming:${options.engine.id}`
+    this.engine = options.engine
+    this.isOffline = options.engine.isOffline
+    this.usesLocalLlm = options.usesLocalLlm ?? false
+    this.cost = options.cost ?? {}
+    this.chunkMs = options.chunkMs ?? DEFAULT_CHUNK_MS
+    this.settleMs = options.settleMs ?? DEFAULT_SETTLE_MS
+    this.trailingSilenceMs = options.trailingSilenceMs ?? DEFAULT_TRAILING_SILENCE_MS
+    this.segmentTimeoutMs = options.segmentTimeoutMs ?? DEFAULT_SEGMENT_TIMEOUT_MS
+    this.realtimePacing = options.realtimePacing ?? true
+    this.sleep = options.sleep ?? realSleep
+  }
+
+  /**
+   * Open and warm the session up front. Optional but recommended: without it the
+   * first measured segment carries the connection handshake and shows up as a
+   * first-sample artifact in the report.
+   */
+  async warmup(): Promise<void> {
+    await this.ensureSession()
+  }
+
+  async process(
+    audio: Float32Array,
+    sampleRate: number,
+    signal: AbortSignal
+  ): Promise<PathSampleResult> {
+    signal.throwIfAborted()
+    // The runner enforces one in-flight segment per path (permits=1), but the
+    // "next final resolves the pending segment" correlation silently breaks if
+    // that ever changes — so assert it here rather than trusting the caller.
+    if (this.pending) {
+      throw new Error(`${this.id} does not support concurrent segments`)
+    }
+
+    const session = await this.ensureSession()
+    signal.throwIfAborted()
+
+    const pending = this.createPending()
+    try {
+      await this.pushPaced(session, audio, sampleRate, signal)
+      return await this.awaitSegment(session, pending, signal)
+    } finally {
+      this.clearPending(pending.seq)
+    }
+  }
+
+  /** Release the pending slot, but only if it is still the segment we started. */
+  private clearPending(seq: number): void {
+    if (this.pending && this.pending.seq === seq) this.pending = null
+  }
+
+  /** Tear the session down. Safe to call repeatedly. */
+  async dispose(): Promise<void> {
+    this.failPending(new Error('Session disposed'))
+    const session = this.session
+    this.session = null
+    this.sessionAbort?.abort()
+    this.sessionAbort = null
+    // Never flush on teardown: a trailing line here belongs to no segment.
+    if (session) await session.stop({ flush: false }).catch(() => undefined)
+  }
+
+  // --- internals ---
+
+  private async ensureSession(): Promise<E2EStreamingSession> {
+    if (this.session) return this.session
+    const session = this.engine.createStreamingSession!()
+    const abort = new AbortController()
+    this.sessionAbort = abort
+    await session.start({ signal: abort.signal, sink: this.buildSink() })
+    this.session = session
+    return session
+  }
+
+  private buildSink(): { interim: (r: TranslationResult) => void; final: (r: TranslationResult) => void; error: (e: Error) => void } {
+    return {
+      interim: (result) => {
+        const pending = this.pending
+        if (!pending || pending.settled) return
+        pending.revisionCount++
+        pending.latest = result
+        pending.lastActivityAt = performance.now()
+        pending.firstSubtitleMs ??= pending.lastActivityAt - pending.startedAt
+      },
+      final: (result) => {
+        const pending = this.pending
+        if (!pending || pending.settled) return
+        pending.latest = result
+        this.settle(pending, result)
+      },
+      error: (err) => this.failPending(err)
+    }
+  }
+
+  private createPending(): PendingSegment {
+    const now = performance.now()
+    let resolve!: (result: PathSampleResult) => void
+    let reject!: (err: Error) => void
+    const promise = new Promise<PathSampleResult>((res, rej) => {
+      resolve = res
+      reject = rej
+    })
+    const pending: PendingSegment = {
+      seq: ++this.seq,
+      startedAt: now,
+      firstSubtitleMs: null,
+      revisionCount: 0,
+      latest: null,
+      promise,
+      resolve,
+      reject,
+      settled: false,
+      lastActivityAt: now
+    }
+    // A rejection is surfaced by awaitSegment; this keeps a reject that lands
+    // before anyone awaits from becoming an unhandled rejection.
+    promise.catch(() => undefined)
+    this.pending = pending
+    return pending
+  }
+
+  private settle(pending: PendingSegment, result: TranslationResult): void {
+    if (pending.settled) return
+    pending.settled = true
+    pending.resolve({
+      sourceText: result.sourceText,
+      translatedText: result.translatedText,
+      firstSubtitleMs: pending.firstSubtitleMs,
+      // A final that arrived with no preceding interim is still one subtitle.
+      revisionCount: pending.revisionCount
+    })
+  }
+
+  private failPending(err: Error): void {
+    const pending = this.pending
+    if (!pending || pending.settled) return
+    pending.settled = true
+    this.pending = null
+    pending.reject(err)
+  }
+
+  /** Push audio at (optionally) realtime cadence, honoring backpressure and abort. */
+  private async pushPaced(
+    session: E2EStreamingSession,
+    audio: Float32Array,
+    sampleRate: number,
+    signal: AbortSignal
+  ): Promise<void> {
+    const frame = Math.max(1, Math.round((this.chunkMs / 1000) * sampleRate))
+    for (let offset = 0; offset < audio.length; offset += frame) {
+      signal.throwIfAborted()
+      const chunk = audio.subarray(offset, Math.min(offset + frame, audio.length))
+      const backpressure = await session.pushAudio(chunk)
+      if (backpressure) await backpressure.drained
+      if (this.realtimePacing) await this.sleep((chunk.length / sampleRate) * 1000)
+    }
+
+    if (this.trailingSilenceMs > 0) {
+      const silence = new Float32Array(Math.round((this.trailingSilenceMs / 1000) * sampleRate))
+      signal.throwIfAborted()
+      await session.pushAudio(silence)
+      if (this.realtimePacing) await this.sleep(this.trailingSilenceMs)
+    }
+  }
+
+  /**
+   * Resolve the segment on whichever comes first: the server's own final, a
+   * quiet period (we then force the boundary via flushSegment), or the timeout.
+   */
+  private async awaitSegment(
+    session: E2EStreamingSession,
+    pending: PendingSegment,
+    signal: AbortSignal
+  ): Promise<PathSampleResult> {
+    const deadline = performance.now() + this.segmentTimeoutMs
+    const onAbort = (): void => this.failPending(new Error('Aborted'))
+    signal.addEventListener('abort', onAbort, { once: true })
+
+    try {
+      while (!pending.settled) {
+        if (performance.now() > deadline) {
+          // A stuck turn poisons the session's accumulator for every later
+          // segment, so drop the connection instead of carrying it forward.
+          await this.dispose()
+          throw new Error(`Segment timed out after ${this.segmentTimeoutMs}ms`)
+        }
+        const quietFor = performance.now() - pending.lastActivityAt
+        if (quietFor >= this.settleMs) {
+          // flushSegment() commits whatever the session accumulated, which lands
+          // in sink.final and settles `promise` below.
+          await session.flushSegment?.()
+          if (!pending.settled) {
+            // Nothing accumulated at all: the server never produced text for this
+            // segment (silence, or a turn it declined to translate).
+            this.settleEmpty(pending)
+          }
+          break
+        }
+        await Promise.race([
+          pending.promise.catch(() => undefined),
+          this.sleep(Math.min(this.settleMs - quietFor, this.settleMs))
+        ])
+      }
+      return await pending.promise
+    } finally {
+      signal.removeEventListener('abort', onAbort)
+    }
+  }
+
+  private settleEmpty(pending: PendingSegment): void {
+    if (pending.settled) return
+    pending.settled = true
+    pending.resolve({
+      sourceText: pending.latest?.sourceText ?? '',
+      translatedText: '',
+      firstSubtitleMs: pending.firstSubtitleMs,
+      revisionCount: pending.revisionCount
+    })
+  }
+}

--- a/src/pipeline/shadow/types.ts
+++ b/src/pipeline/shadow/types.ts
@@ -10,12 +10,25 @@
 export type ShadowPathKind = 'cascade' | 'e2e' | 'e2e-streaming'
 
 /**
- * Cost model for a path (BYOK metered). Offline paths have zero marginal cost;
- * cloud paths are billed per source character.
+ * Cost model for a path (BYOK metered). Offline paths have zero marginal cost.
+ *
+ * Dimensions are ADDITIVE and independent, not mutually exclusive: a text MT API
+ * bills per source character, a realtime speech API bills per audio minute, and
+ * a future engine may well do both. An omitted dimension contributes nothing, so
+ * `{}` is a valid zero-cost (offline) model.
+ *
+ * This is a normalized variable-cost estimate. It deliberately ignores per-request
+ * minimum billing increments and idle connection time — the shadow harness bills
+ * a path for the audio it actually measured.
  */
 export interface ShadowCostModel {
-  /** USD per 1,000,000 source characters. 0 for fully offline paths. */
-  usdPerMillionChars: number
+  /** USD per 1,000,000 source characters (text-metered APIs). */
+  usdPerMillionChars?: number
+  /**
+   * USD per minute of source AUDIO duration (speech-metered APIs) — not wall-clock
+   * session time, which the harness never bills.
+   */
+  usdPerAudioMinute?: number
 }
 
 /** Static description of a measurable path. */
@@ -127,8 +140,10 @@ export interface ShadowSample {
   firstSubtitleMs: number | null
   /** Interim revision count (stability proxy). */
   revisionCount: number
-  /** Source character count (drives cost metering). */
+  /** Source character count (drives text-metered cost). */
   sourceChars: number
+  /** Source audio duration in ms (drives speech-metered cost). */
+  audioDurationMs: number
   /** Estimated marginal cost for this sample in USD. */
   costUsd: number
   /** Whether the path stayed fully offline for this sample (privacy). */


### PR DESCRIPTION
## Description

Wires `ShadowRunner` (#720) to real engines and lands the dev harness that produces the "第0歩" JA⇄EN measurement — the numbers that decide the investment balance between cascade modernization (#725) and local e2e (#724).

- **`CascadeShadowPath`** — wraps the app's real `STTEngine` → `TranslatorEngine` as one path. Each segment is processed in isolation (no `ContextBuffer` / `TranslationCache`): a cache hit would record a translation the engine never performed, and context would make latency depend on a segment's neighbours. `isOffline` is true only when *both* stages are — a cloud MT stage sends the transcript off-device regardless of where STT ran.
- **`E2EStreamingShadowPath`** — drives `CloudRealtimeE2E` over **one long-lived session**, warmed up before measurement. A fresh WebSocket per segment would fold the handshake into every first-subtitle number and reflect nothing about production, where one session spans the meeting. Audio is pushed at **realtime cadence** (bursting distorts server-side VAD and interim timing; billing is per audio-minute, so pacing costs nothing extra). Guards: pending-segment assertion + sequence so a stale `final` cannot resolve the next segment, per-segment timeout that drops the poisoned session, backpressure await, abort teardown.
- **Cost model** — `ShadowCostModel` gains **additive optional dimensions** (`usdPerMillionChars` + `usdPerAudioMinute`) rather than a discriminated union: real services combine bases (audio minutes + output tokens), which a union makes awkward. `ShadowRunner` bills speech-metered paths by submitted audio duration, so gpt-realtime-translate's $0.034/min is counted correctly.
- **`setPathEnabled`** — the cloud session fixes its output language, so the JA→EN path must sit out EN audio. Skips record as `disabled` drops (policy), keeping `busyDropRate` honest.
- **Dev harness** (`src/main/dev/`) — env-gated in `whenReady` (following the `SKIP_ONBOARDING` precedent), opens no windows, quits when the report is written. Never reachable from production UI: the cloud path is BYOK and sends audio off-device.

Design cross-reviewed with Codex per CLAUDE.md (session lifetime + cost model shape).

### Scope correction

The issue specifies reusing `benchmark/conversational-ja-en`, but that set is **text-only** (25 utterances + reference translations, no audio). The actual JA⇄EN audio set is `benchmark/testset/stt-audio` (40 wav, 20 JA / 20 EN, 16 kHz mono PCM16) via `stt-manifest.jsonl`, which is what the harness uses.

It runs inside Electron because the cascade's real engines need `utilityProcess` and `app.getPath('userData')`. The `benchmark/` package runs under plain tsx against its own separate engine copies — measuring those would prove nothing about shipped code.

## Verified by actually running it

`npm run shadow:ja-en` over the full 40-utterance set: **40/40 processed, 0 errors, 0 drops**, `offlineCompleteness: 1`, `totalCostUsd: 0`.

| metric | cascade (whisper-local large-v3-turbo + HY-MT1.5) |
|---|---|
| latency p50 / p95 | 2368 ms / 2555 ms |
| first-subtitle p50 / p95 | 2386 ms / 2583 ms |

Two bugs that only running it surfaced, both fixed here:

1. **STT variant must be bilingual.** `WhisperLocalEngine`'s own default is kotoba-whisper-v2.0 — JA-only, returns nothing for English. The first run silently zeroed out all 20 EN utterances (12/40 empty transcripts). The harness now defaults to `large-v3-turbo`; EN went from 0 chars to 26–59 chars, 39/40 non-empty.
2. **Both paths need warming.** Lazy model load + Metal shader compilation landed entirely on the first utterance: p95 16336 ms vs a 2202 ms median. With a warmup pass, p95 is 2555 ms — describing the path instead of startup.

### Known / out of scope

- **Cloud path measured only against a fake session.** The real `gpt-realtime-translate` leg (`npm run shadow:ja-en:cloud`) needs a live OpenAI key and bills real money; it is unit-tested against a scripted session but **not yet run live**. #722 AC#4 stays open until that run happens.
- `ありがとうございます` measures as an empty segment — production's `filterWhisperHallucination` drops thank-you phrases. Faithful reproduction of production, not a harness bug (arguably a filter false-positive worth its own issue).
- `[slm-worker] createContext failed` logs once at `app.quit()` teardown, after the report is written. Does not affect results (errors: 0).
- 10 `VirtualMicManager` tests fail **locally only** (they also fail on `main`); CI is green. The tests read the host's real virtual audio devices, so they pass on a CI box that has none. Unrelated to this PR and untouched — a test-isolation issue, not a production bug.

## Related Issue
#730 (Closes #730). Unblocks #722 AC#4 pending the live cloud run.

## Screenshots / Video
N/A — dev CLI harness, JSON output.

## Test Checklist
- [x] Unit tests added/updated — 48 tests in the touched modules (both adapters incl. stale-final/timeout/abort/backpressure/pacing, additive cost model, `setPathEnabled`, WAV reader). Full suite: 435 passing, 10 pre-existing unrelated failures.
- [ ] Tested in Chrome — N/A (Electron main-process harness)
- [ ] Tested in Firefox or Safari — N/A
- [ ] Responsive: mobile (375px) and desktop (1280px+) — N/A (no UI)
- [ ] Keyboard navigation works — N/A (no UI)
- [ ] Dark mode verified — N/A (no UI)

## Checklist
- [x] CLAUDE.md rules followed (local-first default untouched, JA⇄EN focus, research-first + Codex cross-review, ran it rather than trusting green tests)
- [x] No hardcoded strings — testset path / output / limits are env-configurable
- [x] Error handling complete — path errors are recorded as telemetry, never crash the run; harness sets exit code on failure
- [x] No console.log left in production code — uses `createLogger`
- typecheck: 0 errors · eslint: 0 errors

