### PR TITLE
Add GeminiLiveE2E BYOK second cloud realtime path (#723)

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "bench:stt:all": "cd benchmark && npm run stt:all",
     "bench:stt:generate": "cd benchmark && npm run stt:generate-testset",
     "shadow:ja-en": "LT_SHADOW_JA_EN=1 electron-vite dev",
-    "shadow:ja-en:cloud": "LT_SHADOW_JA_EN=1 LT_SHADOW_CLOUD=1 electron-vite dev"
+    "shadow:ja-en:cloud": "LT_SHADOW_JA_EN=1 LT_SHADOW_CLOUD=1 electron-vite dev",
+    "shadow:ja-en:cloud-all": "LT_SHADOW_JA_EN=1 LT_SHADOW_CLOUD=1 LT_SHADOW_GEMINI_LIVE=1 electron-vite dev"
   },
   "dependencies": {
     "@electron-toolkit/utils": "^3.0.0",

--- a/src/engines/e2e/GeminiLiveE2E.test.ts
+++ b/src/engines/e2e/GeminiLiveE2E.test.ts
@@ -1,0 +1,412 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import {
+  GeminiLiveE2E,
+  GeminiLiveSession,
+  type GeminiLiveSocket,
+  type GeminiLiveSocketFactory
+} from './GeminiLiveE2E'
+import type { E2EStreamingSink } from '../types'
+
+/** The client→server frames this session is expected to produce. */
+interface ClientMessage {
+  setup?: {
+    model: string
+    generationConfig: {
+      responseModalities: string[]
+      inputAudioTranscription: Record<string, never>
+      outputAudioTranscription: Record<string, never>
+      translationConfig: { targetLanguageCode: string; echoTargetLanguage: boolean }
+    }
+  }
+  realtimeInput?: { audio?: { data: string; mimeType: string } }
+}
+
+class MockGeminiSocket implements GeminiLiveSocket {
+  sent: string[] = []
+  bufferedAmount = 0
+  closed = false
+  private openCb?: () => void
+  private msgCb?: (d: string) => void
+  private errCb?: (e: Error) => void
+  private closeCb?: (c: number) => void
+
+  send(data: string): void {
+    this.sent.push(data)
+  }
+  close(): void {
+    this.closed = true
+  }
+  onOpen(cb: () => void): void {
+    this.openCb = cb
+  }
+  onMessage(cb: (d: string) => void): void {
+    this.msgCb = cb
+  }
+  onError(cb: (e: Error) => void): void {
+    this.errCb = cb
+  }
+  onClose(cb: (c: number) => void): void {
+    this.closeCb = cb
+  }
+
+  // --- test drivers ---
+  emitOpen(): void {
+    this.openCb?.()
+  }
+  emitJson(obj: unknown): void {
+    this.msgCb?.(JSON.stringify(obj))
+  }
+  emitRaw(s: string): void {
+    this.msgCb?.(s)
+  }
+  emitError(msg = 'socket error'): void {
+    this.errCb?.(new Error(msg))
+  }
+  emitClose(code = 1006): void {
+    this.closeCb?.(code)
+  }
+  parsed(): ClientMessage[] {
+    return this.sent.map((s) => JSON.parse(s) as ClientMessage)
+  }
+  setupMessage(): ClientMessage | undefined {
+    return this.parsed().find((e) => e.setup)
+  }
+  audioMessages(): ClientMessage[] {
+    return this.parsed().filter((e) => e.realtimeInput?.audio)
+  }
+}
+
+function makeHarness(overrides: Record<string, unknown> = {}): {
+  sink: { interim: ReturnType<typeof vi.fn>; final: ReturnType<typeof vi.fn>; error: ReturnType<typeof vi.fn> }
+  controller: AbortController
+  session: GeminiLiveSession
+  sockets: MockGeminiSocket[]
+  urls: string[]
+  keys: string[]
+} {
+  const sockets: MockGeminiSocket[] = []
+  const urls: string[] = []
+  const keys: string[] = []
+  const factory: GeminiLiveSocketFactory = (url, apiKey) => {
+    urls.push(url)
+    keys.push(apiKey)
+    const s = new MockGeminiSocket()
+    sockets.push(s)
+    return s
+  }
+  const sink = { interim: vi.fn(), final: vi.fn(), error: vi.fn() }
+  const controller = new AbortController()
+  const session = new GeminiLiveSession({
+    apiKey: 'test-key',
+    targetLanguage: 'en',
+    socketFactory: factory,
+    reconnectBaseDelayMs: 1,
+    ...overrides
+  })
+  return { sink, controller, session, sockets, urls, keys }
+}
+
+/** Drive the full handshake: socket open → setup sent → setupComplete acked. */
+async function startReady(h: ReturnType<typeof makeHarness>): Promise<MockGeminiSocket> {
+  await h.session.start({ sink: h.sink as unknown as E2EStreamingSink, signal: h.controller.signal })
+  h.sockets[0].emitOpen()
+  h.sockets[0].emitJson({ setupComplete: {} })
+  return h.sockets[0]
+}
+
+describe('GeminiLiveE2E engine', () => {
+  it('throws without an API key', () => {
+    expect(() => new GeminiLiveE2E({ apiKey: '' })).toThrow(/Gemini API key/)
+  })
+
+  it('is a non-offline streaming engine and returns a session', () => {
+    const engine = new GeminiLiveE2E({ apiKey: 'k' })
+    expect(engine.isOffline).toBe(false)
+    expect(engine.id).toBe('gemini-live-e2e')
+    expect(engine.createStreamingSession()).toBeInstanceOf(GeminiLiveSession)
+  })
+
+  it('does not support single-shot processAudio', async () => {
+    const engine = new GeminiLiveE2E({ apiKey: 'k' })
+    expect(await engine.processAudio(new Float32Array(1600), 16000)).toBeNull()
+  })
+})
+
+describe('GeminiLiveSession setup handshake', () => {
+  beforeEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('sends the BidiGenerateContent setup message with the preview model on open', async () => {
+    const h = makeHarness()
+    await h.session.start({ sink: h.sink as unknown as E2EStreamingSink, signal: h.controller.signal })
+    h.sockets[0].emitOpen()
+    const setup = h.sockets[0].setupMessage()!.setup!
+    expect(setup.model).toBe('models/gemini-3.5-live-translate-preview')
+    expect(setup.generationConfig.responseModalities).toEqual(['AUDIO'])
+    expect(setup.generationConfig.inputAudioTranscription).toEqual({})
+    expect(setup.generationConfig.outputAudioTranscription).toEqual({})
+  })
+
+  it('sets the target language and echoes same-language speech instead of going silent', async () => {
+    const h = makeHarness({ targetLanguage: 'ja' })
+    await h.session.start({ sink: h.sink as unknown as E2EStreamingSink, signal: h.controller.signal })
+    h.sockets[0].emitOpen()
+    const cfg = h.sockets[0].setupMessage()!.setup!.generationConfig.translationConfig
+    expect(cfg.targetLanguageCode).toBe('ja')
+    expect(cfg.echoTargetLanguage).toBe(true)
+  })
+
+  it('passes the key to the factory separately and keeps it out of the endpoint URL', async () => {
+    const h = makeHarness({ apiKey: 'secret-key' })
+    await h.session.start({ sink: h.sink as unknown as E2EStreamingSink, signal: h.controller.signal })
+    expect(h.urls[0]).toContain('BidiGenerateContent')
+    expect(h.urls[0]).not.toContain('secret-key')
+    expect(h.urls[0]).not.toContain('key=')
+    expect(h.keys[0]).toBe('secret-key')
+  })
+
+  it('withholds audio until setupComplete, then flushes it as realtimeInput', async () => {
+    const h = makeHarness()
+    await h.session.start({ sink: h.sink as unknown as E2EStreamingSink, signal: h.controller.signal })
+    await h.session.pushAudio(new Float32Array(1600))
+    h.sockets[0].emitOpen()
+    await h.session.pushAudio(new Float32Array(1600))
+
+    // Setup sent, but no audio may flow before the handshake is acked.
+    expect(h.sockets[0].audioMessages().length).toBe(0)
+
+    h.sockets[0].emitJson({ setupComplete: {} })
+    const audio = h.sockets[0].audioMessages()
+    expect(audio.length).toBe(2)
+    expect(audio[0].realtimeInput!.audio!.mimeType).toBe('audio/pcm;rate=16000')
+    expect(typeof audio[0].realtimeInput!.audio!.data).toBe('string')
+  })
+})
+
+describe('GeminiLiveSession transcript mapping', () => {
+  beforeEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('maps outputTranscription to interim results (accumulating)', async () => {
+    const h = makeHarness()
+    const socket = await startReady(h)
+    socket.emitJson({ serverContent: { outputTranscription: { text: 'Hello' } } })
+    socket.emitJson({ serverContent: { outputTranscription: { text: ' world' } } })
+
+    expect(h.sink.interim).toHaveBeenCalledTimes(2)
+    const last = h.sink.interim.mock.calls[1][0]
+    expect(last.translatedText).toBe('Hello world')
+    expect(last.isInterim).toBe(true)
+    expect(last.targetLanguage).toBe('en')
+  })
+
+  it('includes inputTranscription as sourceText', async () => {
+    const h = makeHarness()
+    const socket = await startReady(h)
+    socket.emitJson({ serverContent: { inputTranscription: { text: 'こんにちは' } } })
+    socket.emitJson({ serverContent: { outputTranscription: { text: 'Hello' } } })
+    expect(h.sink.interim.mock.calls[0][0].sourceText).toBe('こんにちは')
+  })
+
+  it('maps turnComplete to a final result and resets buffers', async () => {
+    const h = makeHarness()
+    const socket = await startReady(h)
+    socket.emitJson({ serverContent: { outputTranscription: { text: 'Hello world' } } })
+    socket.emitJson({ serverContent: { turnComplete: true } })
+
+    expect(h.sink.final).toHaveBeenCalledTimes(1)
+    const finalArg = h.sink.final.mock.calls[0][0]
+    expect(finalArg.translatedText).toBe('Hello world')
+    expect(finalArg.isInterim).toBe(false)
+
+    // Buffers reset — a new delta starts fresh.
+    socket.emitJson({ serverContent: { outputTranscription: { text: 'Next' } } })
+    expect(h.sink.interim.mock.calls.at(-1)![0].translatedText).toBe('Next')
+  })
+
+  it('accepts a transcript and turnComplete arriving in the same frame', async () => {
+    const h = makeHarness()
+    const socket = await startReady(h)
+    socket.emitJson({ serverContent: { outputTranscription: { text: 'One shot' }, turnComplete: true } })
+    expect(h.sink.final).toHaveBeenCalledTimes(1)
+    expect(h.sink.final.mock.calls[0][0].translatedText).toBe('One shot')
+  })
+
+  it('accepts proto snake_case field spellings (preview JSON mapping)', async () => {
+    const h = makeHarness()
+    await h.session.start({ sink: h.sink as unknown as E2EStreamingSink, signal: h.controller.signal })
+    h.sockets[0].emitOpen()
+    h.sockets[0].emitJson({ setup_complete: {} })
+    h.sockets[0].emitJson({
+      server_content: { input_transcription: { text: 'やあ' }, output_transcription: { text: 'Hi' } }
+    })
+    h.sockets[0].emitJson({ server_content: { turn_complete: true } })
+
+    expect(h.sink.interim.mock.calls[0][0].sourceText).toBe('やあ')
+    expect(h.sink.final).toHaveBeenCalledTimes(1)
+    expect(h.sink.final.mock.calls[0][0].translatedText).toBe('Hi')
+  })
+
+  it('does not emit a final for a turnComplete with no accumulated translation', async () => {
+    const h = makeHarness()
+    const socket = await startReady(h)
+    socket.emitJson({ serverContent: { turnComplete: true } })
+    expect(h.sink.final).not.toHaveBeenCalled()
+  })
+
+  it('ignores synthesized audio parts (subtitles only, no TTS)', async () => {
+    const h = makeHarness()
+    const socket = await startReady(h)
+    socket.emitJson({
+      serverContent: { modelTurn: { parts: [{ inlineData: { data: 'AAAA', mimeType: 'audio/pcm;rate=24000' } }] } }
+    })
+    expect(h.sink.interim).not.toHaveBeenCalled()
+    expect(h.sink.final).not.toHaveBeenCalled()
+  })
+
+  it('labels ja as the source language for an en-target session', async () => {
+    const h = makeHarness({ targetLanguage: 'en' })
+    const socket = await startReady(h)
+    socket.emitJson({ serverContent: { outputTranscription: { text: 'Hello' } } })
+    expect(h.sink.interim.mock.calls[0][0].sourceLanguage).toBe('ja')
+  })
+
+  it('flushSegment finalizes the accumulated interim translation', async () => {
+    const h = makeHarness()
+    const socket = await startReady(h)
+    socket.emitJson({ serverContent: { outputTranscription: { text: 'partial line' } } })
+    await h.session.flushSegment()
+    expect(h.sink.final).toHaveBeenCalledTimes(1)
+    expect(h.sink.final.mock.calls[0][0].translatedText).toBe('partial line')
+  })
+
+  it('stop({flush}) finalizes buffered interim and closes the socket', async () => {
+    const h = makeHarness()
+    const socket = await startReady(h)
+    socket.emitJson({ serverContent: { outputTranscription: { text: 'buffered' } } })
+    await h.session.stop({ flush: true })
+    expect(h.sink.final).toHaveBeenCalledTimes(1)
+    expect(h.sink.final.mock.calls[0][0].translatedText).toBe('buffered')
+    expect(socket.closed).toBe(true)
+  })
+
+  it('reports API error events to the sink', async () => {
+    const h = makeHarness()
+    const socket = await startReady(h)
+    socket.emitJson({ error: { message: 'boom' } })
+    expect(h.sink.error).toHaveBeenCalledTimes(1)
+    expect(h.sink.error.mock.calls[0][0].message).toBe('boom')
+  })
+
+  it('surfaces goAway as a status notice without erroring the sink', async () => {
+    const statuses: string[] = []
+    const h = makeHarness({ onStatus: (m: string) => statuses.push(m) })
+    const socket = await startReady(h)
+    socket.emitJson({ goAway: { timeLeft: '5s' } })
+    expect(h.sink.error).not.toHaveBeenCalled()
+    expect(statuses.some((s) => /session ending/i.test(s))).toBe(true)
+  })
+
+  it('stops emitting after the abort signal fires', async () => {
+    const h = makeHarness()
+    const socket = await startReady(h)
+    h.controller.abort()
+    socket.emitJson({ serverContent: { outputTranscription: { text: 'late' } } })
+    socket.emitJson({ serverContent: { turnComplete: true } })
+    expect(h.sink.interim).not.toHaveBeenCalled()
+    expect(h.sink.final).not.toHaveBeenCalled()
+  })
+
+  it('ignores malformed JSON frames', async () => {
+    const h = makeHarness()
+    const socket = await startReady(h)
+    expect(() => socket.emitRaw('not-json')).not.toThrow()
+    expect(h.sink.interim).not.toHaveBeenCalled()
+  })
+
+  it('does not reconnect after an intentional stop', async () => {
+    const h = makeHarness()
+    const socket = await startReady(h)
+    await h.session.stop()
+    socket.emitClose(1000)
+    expect(h.sockets.length).toBe(1)
+  })
+
+  it('skips empty audio chunks (no realtimeInput sent)', async () => {
+    const h = makeHarness()
+    const socket = await startReady(h)
+    await h.session.pushAudio(new Float32Array(0))
+    expect(socket.audioMessages().length).toBe(0)
+  })
+
+  it('flushSegment does not emit after abort', async () => {
+    const h = makeHarness()
+    const socket = await startReady(h)
+    socket.emitJson({ serverContent: { outputTranscription: { text: 'partial' } } })
+    h.controller.abort()
+    await h.session.flushSegment()
+    expect(h.sink.final).not.toHaveBeenCalled()
+  })
+
+  it('flushSegment does not emit after stop (closedByUs guard)', async () => {
+    const h = makeHarness()
+    const socket = await startReady(h)
+    socket.emitJson({ serverContent: { outputTranscription: { text: 'partial' } } })
+    await h.session.stop() // no flush
+    h.sink.final.mockClear()
+    await h.session.flushSegment()
+    expect(h.sink.final).not.toHaveBeenCalled()
+  })
+
+  it('stop({flush}) after abort intentionally drops the trailing line', async () => {
+    const h = makeHarness()
+    const socket = await startReady(h)
+    socket.emitJson({ serverContent: { outputTranscription: { text: 'trailing' } } })
+    h.controller.abort()
+    await h.session.stop({ flush: true })
+    expect(h.sink.final).not.toHaveBeenCalled()
+  })
+})
+
+describe('GeminiLiveSession reconnect policy', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  it('reconnects on unexpected close up to the cap, then errors', async () => {
+    const h = makeHarness({ maxReconnectAttempts: 2, reconnectBaseDelayMs: 1 })
+    await h.session.start({ sink: h.sink as unknown as E2EStreamingSink, signal: h.controller.signal })
+    h.sockets[0].emitOpen()
+    h.sockets[0].emitJson({ setupComplete: {} })
+
+    h.sockets[0].emitClose(1006)
+    vi.advanceTimersByTime(5)
+    expect(h.sockets.length).toBe(2)
+
+    h.sockets[1].emitClose(1006)
+    vi.advanceTimersByTime(5)
+    expect(h.sockets.length).toBe(3)
+
+    // Cap exhausted → sink.error, no new socket, session torn down.
+    h.sockets[2].emitClose(1006)
+    vi.advanceTimersByTime(5)
+    expect(h.sockets.length).toBe(3)
+    expect(h.sink.error).toHaveBeenCalledTimes(1)
+    expect(h.sink.error.mock.calls[0][0].message).toMatch(/connection lost/)
+    expect(h.sockets[2].closed).toBe(true)
+  })
+
+  it('re-runs the setup handshake on each reconnect', async () => {
+    const h = makeHarness({ maxReconnectAttempts: 1, reconnectBaseDelayMs: 1 })
+    await h.session.start({ sink: h.sink as unknown as E2EStreamingSink, signal: h.controller.signal })
+    h.sockets[0].emitOpen()
+    h.sockets[0].emitJson({ setupComplete: {} })
+
+    h.sockets[0].emitClose(1006)
+    vi.advanceTimersByTime(5)
+    h.sockets[1].emitOpen()
+    expect(h.sockets[1].setupMessage()).toBeDefined()
+  })
+})

--- a/src/engines/e2e/GeminiLiveE2E.test.ts
+++ b/src/engines/e2e/GeminiLiveE2E.test.ts
@@ -322,6 +322,16 @@ describe('GeminiLiveSession transcript mapping', () => {
     expect(h.sink.error.mock.calls[0][0].message).toBe('boom')
   })
 
+  it('redacts the API key from server-sent error events before they reach the sink', async () => {
+    const h = makeHarness({ apiKey: 'AIza-super-secret' })
+    const socket = await startReady(h)
+    socket.emitJson({
+      error: { message: 'invalid request to /ws?key=AIza-super-secret' }
+    })
+    expect(h.sink.error.mock.calls[0][0].message).not.toContain('AIza-super-secret')
+    expect(h.sink.error.mock.calls[0][0].message).toContain('***')
+  })
+
   it('surfaces goAway as a status notice without erroring the sink', async () => {
     const statuses: string[] = []
     const h = makeHarness({ onStatus: (m: string) => statuses.push(m) })

--- a/src/engines/e2e/GeminiLiveE2E.test.ts
+++ b/src/engines/e2e/GeminiLiveE2E.test.ts
@@ -157,6 +157,28 @@ describe('GeminiLiveSession setup handshake', () => {
     expect(cfg.echoTargetLanguage).toBe(true)
   })
 
+  it('opens no socket at all when start() is given an already-aborted signal', async () => {
+    const h = makeHarness()
+    h.controller.abort()
+    await h.session.start({ sink: h.sink as unknown as E2EStreamingSink, signal: h.controller.signal })
+    // An already-aborted signal never fires 'abort', so nothing would tear a socket
+    // down — the key and setup handshake must never leave the process.
+    expect(h.sockets.length).toBe(0)
+    await h.session.pushAudio(new Float32Array(1600))
+    expect(h.sockets.length).toBe(0)
+  })
+
+  it('redacts the API key from socket error messages before logging or status', async () => {
+    const statuses: string[] = []
+    const h = makeHarness({ apiKey: 'AIza-super-secret', onStatus: (m: string) => statuses.push(m) })
+    await h.session.start({ sink: h.sink as unknown as E2EStreamingSink, signal: h.controller.signal })
+    // A ws error that echoes the request target carries the ?key= query verbatim.
+    h.sockets[0].emitError('connect ECONNREFUSED wss://host/path?key=AIza-super-secret')
+    // The error status is followed by a reconnect notice; no status may carry the key.
+    expect(statuses.some((s) => s.includes('AIza-super-secret'))).toBe(false)
+    expect(statuses[0]).toContain('***')
+  })
+
   it('passes the key to the factory separately and keeps it out of the endpoint URL', async () => {
     const h = makeHarness({ apiKey: 'secret-key' })
     await h.session.start({ sink: h.sink as unknown as E2EStreamingSink, signal: h.controller.signal })

--- a/src/engines/e2e/GeminiLiveE2E.ts
+++ b/src/engines/e2e/GeminiLiveE2E.ts
@@ -1,0 +1,469 @@
+import WebSocket from 'ws'
+import type {
+  Backpressure,
+  E2EStreamingSession,
+  E2EStreamingSink,
+  E2EStreamingStartOptions,
+  E2EStreamingStopOptions,
+  E2ETranslationEngine,
+  Language,
+  SourceLanguage,
+  TranslationResult
+} from '../types'
+import { encodePcm16Base64, SOURCE_SAMPLE_RATE } from './audioEncoding'
+import { createLogger } from '../../main/logger'
+
+const log = createLogger('gemini-live-e2e')
+
+/**
+ * BidiGenerateContent WebSocket endpoint. The API key is NOT part of this
+ * constant: Gemini authenticates via a `?key=` query parameter (unlike OpenAI's
+ * Authorization header), and the key is appended by the socket factory so it
+ * never reaches a log line or a test assertion on the endpoint.
+ * https://ai.google.dev/gemini-api/docs/live-api/live-translate
+ */
+const ENDPOINT =
+  'wss://generativelanguage.googleapis.com/ws/google.ai.generativelanguage.v1beta.GenerativeService.BidiGenerateContent'
+
+/** Preview model — see GeminiLiveE2E docstring for why this is never a default. */
+const MODEL = 'models/gemini-3.5-live-translate-preview'
+
+/**
+ * Live Translate takes raw 16-bit PCM at 16 kHz mono LE, which is exactly what the
+ * #721 capture adapter emits — so encodePcm16Base64 resamples nothing on this path.
+ */
+const INPUT_SAMPLE_RATE = 16000
+const INPUT_MIME_TYPE = `audio/pcm;rate=${INPUT_SAMPLE_RATE}`
+
+/** Socket send-buffer high-water mark (bytes) that triggers backpressure. */
+const MAX_BUFFERED_BYTES = 1 << 20 // 1 MB
+/** Cap on audio chunks queued before the session is ready (~5s at 100ms/chunk). */
+const MAX_PENDING_PREOPEN = 50
+/** Bounded reconnect policy for unexpected mid-session disconnects. */
+const DEFAULT_MAX_RECONNECT_ATTEMPTS = 3
+const DEFAULT_RECONNECT_BASE_DELAY_MS = 500
+/** Poll interval while awaiting the send buffer to drain. */
+const DRAIN_POLL_MS = 20
+
+/**
+ * Minimal socket abstraction so the session can be unit-tested without a live
+ * WebSocket. Deliberately a separate declaration from CloudRealtimeE2E's rather
+ * than a shared one: the two cloud paths are independent (one preview, one M1
+ * default) and a common abstraction would have to be designed against exactly two
+ * samples, one of which may change under us.
+ */
+export interface GeminiLiveSocket {
+  send(data: string): void
+  close(code?: number): void
+  readonly bufferedAmount: number
+  onOpen(cb: () => void): void
+  onMessage(cb: (data: string) => void): void
+  onError(cb: (err: Error) => void): void
+  onClose(cb: (code: number) => void): void
+}
+
+export type GeminiLiveSocketFactory = (url: string, apiKey: string) => GeminiLiveSocket
+
+function defaultSocketFactory(url: string, apiKey: string): GeminiLiveSocket {
+  const ws = new WebSocket(`${url}?key=${encodeURIComponent(apiKey)}`)
+  return {
+    send: (data) => ws.send(data),
+    close: (code) => ws.close(code),
+    get bufferedAmount(): number {
+      return ws.bufferedAmount
+    },
+    onOpen: (cb) => ws.on('open', cb),
+    onMessage: (cb) => ws.on('message', (data: WebSocket.RawData) => cb(data.toString())),
+    onError: (cb) => ws.on('error', cb),
+    onClose: (cb) => ws.on('close', (code: number) => cb(code))
+  }
+}
+
+export interface GeminiLiveE2EOptions {
+  /** User's Google AI (Gemini) API key with Live API access (BYOK). Required. */
+  apiKey: string
+  /** Source language of the speaker (used for result labelling only). */
+  sourceLanguage?: SourceLanguage
+  /**
+   * Target output language (BCP-47). Live Translate fixes the output language per
+   * session via translationConfig, so bidirectional JA⇄EN auto-switching is not
+   * supported in a single session — the session translates everything into this
+   * language.
+   */
+  targetLanguage?: Language
+  /** Sample rate of chunks passed to pushAudio (default 16 kHz, from #721 adapter). */
+  sourceSampleRate?: number
+  /** Injectable socket factory for testing. */
+  socketFactory?: GeminiLiveSocketFactory
+  /** Status callback surfaced to the renderer (reconnect notices, errors). */
+  onStatus?: (msg: string) => void
+  maxReconnectAttempts?: number
+  reconnectBaseDelayMs?: number
+}
+
+/** Shape of the BidiGenerateContent server messages this session consumes. */
+interface TranscriptionPayload {
+  text?: unknown
+}
+interface ServerContent {
+  inputTranscription?: TranscriptionPayload
+  input_transcription?: TranscriptionPayload
+  outputTranscription?: TranscriptionPayload
+  output_transcription?: TranscriptionPayload
+  turnComplete?: unknown
+  turn_complete?: unknown
+}
+interface ServerMessage {
+  setupComplete?: unknown
+  setup_complete?: unknown
+  serverContent?: ServerContent
+  server_content?: ServerContent
+  goAway?: unknown
+  go_away?: unknown
+  error?: { message?: string }
+}
+
+/**
+ * End-to-end cloud realtime speech-translation engine backed by Google's Gemini
+ * Live API (gemini-3.5-live-translate-preview, BYOK). Second cloud path alongside
+ * CloudRealtimeE2E, provided for shadow-mode comparison and redundancy.
+ *
+ * The model is Preview: spec and SLA may change without notice, so this is never a
+ * production default (M1 prefers gpt-realtime-translate) and is surfaced in the UI
+ * as experimental. Cloud, opt-in — never the offline default.
+ */
+export class GeminiLiveE2E implements E2ETranslationEngine {
+  readonly id = 'gemini-live-e2e'
+  readonly name = 'Gemini Live (gemini-3.5-live-translate-preview)'
+  readonly isOffline = false
+
+  private readonly options: GeminiLiveE2EOptions
+
+  constructor(options: GeminiLiveE2EOptions) {
+    if (!options.apiKey) {
+      throw new Error('GeminiLiveE2E requires a Gemini API key')
+    }
+    this.options = options
+  }
+
+  async initialize(): Promise<void> {
+    // No local model to load; the key was validated in the constructor.
+    // A live handshake is deferred to session start to avoid holding a socket open while idle.
+  }
+
+  /** Single-shot batch translation is not supported — this engine is streaming-only. */
+  async processAudio(_audioChunk: Float32Array, _sampleRate: number): Promise<TranslationResult | null> {
+    return null
+  }
+
+  createStreamingSession(): E2EStreamingSession {
+    return new GeminiLiveSession(this.options)
+  }
+
+  async dispose(): Promise<void> {
+    // Sessions own their sockets and are torn down via stop()/abort.
+  }
+}
+
+/**
+ * A single live translation session. Lifecycle:
+ * start() → pushAudio()* [→ flushSegment()]* → stop().
+ * Honors the AbortSignal from start(): once aborted, no further sink emissions.
+ */
+export class GeminiLiveSession implements E2EStreamingSession {
+  private readonly options: GeminiLiveE2EOptions
+  private readonly socketFactory: GeminiLiveSocketFactory
+  private readonly maxReconnects: number
+  private readonly reconnectBaseDelay: number
+
+  private socket: GeminiLiveSocket | null = null
+  private sink: E2EStreamingSink | null = null
+  private signal: AbortSignal | null = null
+  /**
+   * BidiGenerateContent requires the `setup` message to be acknowledged by
+   * `setupComplete` before content flows, so audio is gated on this rather than on
+   * socket open (the OpenAI path has no such handshake).
+   */
+  private ready = false
+  private closedByUs = false
+  private reconnectAttempts = 0
+  private reconnectTimer: ReturnType<typeof setTimeout> | null = null
+
+  /** Accumulated interim source-language transcript (for the current segment). */
+  private inputBuffer = ''
+  /** Accumulated interim translated-text delta (for the current segment). */
+  private outputBuffer = ''
+  /** Base64 audio chunks captured before the setup handshake completed. */
+  private pendingAudio: string[] = []
+
+  constructor(options: GeminiLiveE2EOptions) {
+    this.options = options
+    this.socketFactory = options.socketFactory ?? defaultSocketFactory
+    this.maxReconnects = options.maxReconnectAttempts ?? DEFAULT_MAX_RECONNECT_ATTEMPTS
+    this.reconnectBaseDelay = options.reconnectBaseDelayMs ?? DEFAULT_RECONNECT_BASE_DELAY_MS
+  }
+
+  async start(options: E2EStreamingStartOptions): Promise<void> {
+    this.sink = options.sink
+    this.signal = options.signal
+    this.closedByUs = false
+    this.signal.addEventListener('abort', () => this.teardown(), { once: true })
+    this.connect()
+  }
+
+  async pushAudio(chunk: Float32Array): Promise<void | Backpressure> {
+    if (this.signal?.aborted || this.closedByUs || chunk.length === 0) return
+    const encoded = encodePcm16Base64(chunk, this.options.sourceSampleRate ?? SOURCE_SAMPLE_RATE, INPUT_SAMPLE_RATE)
+
+    if (!this.ready || !this.socket) {
+      // Queue a bounded amount of audio until setup completes; drop the oldest
+      // beyond the cap so a slow handshake can't grow memory unbounded.
+      if (this.pendingAudio.length >= MAX_PENDING_PREOPEN) this.pendingAudio.shift()
+      this.pendingAudio.push(encoded)
+      return
+    }
+
+    this.sendAudio(encoded)
+
+    if (this.socket.bufferedAmount > MAX_BUFFERED_BYTES) {
+      return { drained: this.waitForDrain() }
+    }
+  }
+
+  /**
+   * Boundary hint from the capture layer (detected speech pause). Gemini's own
+   * automatic activity detection also emits turnComplete, but that boundary is the
+   * model's, not the capture layer's — finalizing here keeps the overlay's
+   * committed line in step with the local VAD, as the OpenAI path does.
+   */
+  async flushSegment(): Promise<void> {
+    if (this.signal?.aborted || this.closedByUs) return
+    if (this.outputBuffer) this.emitFinal(this.outputBuffer)
+  }
+
+  async stop(options?: E2EStreamingStopOptions): Promise<void> {
+    // A flush only surfaces while the session is still live: emitFinal (and the
+    // pipeline's sink adapter) both gate on the abort signal, so a stop({flush})
+    // issued after abort intentionally drops the trailing line rather than
+    // emitting stale output across a generation switch.
+    if (options?.flush && this.outputBuffer) this.emitFinal(this.outputBuffer)
+    this.teardown()
+  }
+
+  // --- internals ---
+
+  private connect(): void {
+    // Close any prior (dead) socket before replacing it, mirroring teardown().
+    try {
+      this.socket?.close()
+    } catch {
+      // ignore
+    }
+    const socket = this.socketFactory(ENDPOINT, this.options.apiKey)
+    this.socket = socket
+
+    // Guard so a socket that fires both 'error' and 'close' only triggers one
+    // reconnect decision for this connection attempt.
+    let terminated = false
+    const terminate = (): void => {
+      if (terminated) return
+      terminated = true
+      this.onConnectionTerminated()
+    }
+
+    socket.onOpen(() => this.sendSetup())
+    socket.onMessage((data) => this.handleMessage(data))
+    socket.onError((err) => {
+      log.warn('Gemini Live socket error:', err.message)
+      this.options.onStatus?.(`Gemini Live error: ${err.message}`)
+      terminate()
+    })
+    socket.onClose(() => terminate())
+  }
+
+  private onConnectionTerminated(): void {
+    this.ready = false
+    if (this.closedByUs || this.signal?.aborted) return
+
+    if (this.reconnectAttempts < this.maxReconnects) {
+      this.reconnectAttempts++
+      const delay = this.reconnectBaseDelay * this.reconnectAttempts
+      this.options.onStatus?.(
+        `Gemini Live connection lost — reconnecting (${this.reconnectAttempts}/${this.maxReconnects})...`
+      )
+      this.reconnectTimer = setTimeout(() => {
+        this.reconnectTimer = null
+        if (!this.closedByUs && !this.signal?.aborted) this.connect()
+      }, delay)
+    } else {
+      // Reconnect budget exhausted — surface the error and fully tear down so any
+      // pending waitForDrain() resolves instead of hanging on a dead socket.
+      this.emitError(new Error('Gemini Live translation connection lost'))
+      this.teardown()
+    }
+  }
+
+  private sendSetup(): void {
+    // Verbatim schema from the Live Translate guide. responseModalities must be
+    // AUDIO — the translate model supports no TEXT modality — so the model also
+    // speaks the translation; we consume outputAudioTranscription for subtitles
+    // and drop the synthesized audio parts unread (TTS is out of scope).
+    // echoTargetLanguage defaults to false, which makes the model stay SILENT when
+    // the speaker is already using the target language; for a meeting overlay that
+    // would drop those lines entirely, so it is turned on.
+    const payload = {
+      setup: {
+        model: MODEL,
+        generationConfig: {
+          responseModalities: ['AUDIO'],
+          inputAudioTranscription: {},
+          outputAudioTranscription: {},
+          translationConfig: {
+            targetLanguageCode: this.options.targetLanguage ?? 'en',
+            echoTargetLanguage: true
+          }
+        }
+      }
+    }
+    this.trySend(JSON.stringify(payload))
+  }
+
+  private sendAudio(base64Audio: string): void {
+    this.trySend(
+      JSON.stringify({ realtimeInput: { audio: { data: base64Audio, mimeType: INPUT_MIME_TYPE } } })
+    )
+  }
+
+  private trySend(data: string): void {
+    try {
+      this.socket?.send(data)
+    } catch (err) {
+      log.warn('Gemini Live send failed:', err instanceof Error ? err.message : String(err))
+    }
+  }
+
+  private flushPendingAudio(): void {
+    if (this.pendingAudio.length === 0) return
+    for (const audio of this.pendingAudio) this.sendAudio(audio)
+    this.pendingAudio = []
+  }
+
+  private handleMessage(data: string): void {
+    if (this.signal?.aborted || this.closedByUs) return
+
+    let event: ServerMessage
+    try {
+      event = JSON.parse(data) as ServerMessage
+    } catch {
+      return
+    }
+
+    // The endpoint is Preview and its JSON mapping may surface either the proto
+    // field names or their lowerCamelCase form, so both spellings are accepted
+    // rather than betting the subtitle path on one of them.
+    if (event.setupComplete ?? event.setup_complete) {
+      this.ready = true
+      this.reconnectAttempts = 0
+      this.flushPendingAudio()
+      return
+    }
+
+    if (event.goAway ?? event.go_away) {
+      // Server is about to disconnect; the ensuing close drives the reconnect path.
+      log.info('Gemini Live server sent goAway — expecting reconnect')
+      this.options.onStatus?.('Gemini Live session ending — reconnecting...')
+      return
+    }
+
+    if (event.error) {
+      this.emitError(new Error(event.error.message ?? 'Gemini Live translation error'))
+      return
+    }
+
+    const content = event.serverContent ?? event.server_content
+    if (!content) return
+
+    const inputText = (content.inputTranscription ?? content.input_transcription)?.text
+    if (typeof inputText === 'string') this.inputBuffer += inputText
+
+    const outputText = (content.outputTranscription ?? content.output_transcription)?.text
+    if (typeof outputText === 'string' && outputText) {
+      this.outputBuffer += outputText
+      this.emitInterim(this.outputBuffer)
+    }
+
+    if (content.turnComplete ?? content.turn_complete) {
+      this.emitFinal(this.outputBuffer)
+    }
+  }
+
+  private buildResult(translatedText: string, isInterim: boolean): TranslationResult {
+    const targetLanguage = this.options.targetLanguage ?? 'en'
+    const sourceLanguage =
+      this.options.sourceLanguage && this.options.sourceLanguage !== 'auto'
+        ? this.options.sourceLanguage
+        : targetLanguage === 'en'
+          ? 'ja'
+          : 'en'
+    return {
+      sourceText: this.inputBuffer,
+      translatedText,
+      sourceLanguage,
+      targetLanguage,
+      timestamp: Date.now(),
+      isInterim
+    }
+  }
+
+  private emitInterim(text: string): void {
+    if (this.signal?.aborted || !text) return
+    this.sink?.interim(this.buildResult(text, true))
+  }
+
+  private emitFinal(text: string): void {
+    if (this.signal?.aborted || !text) return
+    this.sink?.final(this.buildResult(text, false))
+    // Reset per-segment accumulators for the next utterance.
+    this.outputBuffer = ''
+    this.inputBuffer = ''
+  }
+
+  private emitError(err: Error): void {
+    if (this.signal?.aborted) return
+    this.sink?.error(err)
+  }
+
+  private waitForDrain(): Promise<void> {
+    return new Promise((resolve) => {
+      const check = (): void => {
+        if (
+          this.signal?.aborted ||
+          this.closedByUs ||
+          !this.socket ||
+          this.socket.bufferedAmount <= MAX_BUFFERED_BYTES
+        ) {
+          resolve()
+          return
+        }
+        setTimeout(check, DRAIN_POLL_MS)
+      }
+      check()
+    })
+  }
+
+  private teardown(): void {
+    this.closedByUs = true
+    this.ready = false
+    this.pendingAudio = []
+    if (this.reconnectTimer) {
+      clearTimeout(this.reconnectTimer)
+      this.reconnectTimer = null
+    }
+    try {
+      this.socket?.close()
+    } catch {
+      // ignore close errors during teardown
+    }
+    this.socket = null
+  }
+}

--- a/src/engines/e2e/GeminiLiveE2E.ts
+++ b/src/engines/e2e/GeminiLiveE2E.ts
@@ -207,6 +207,13 @@ export class GeminiLiveSession implements E2EStreamingSession {
     this.sink = options.sink
     this.signal = options.signal
     this.closedByUs = false
+    // An already-aborted signal never fires 'abort', so the listener below would
+    // never run: opening a socket here would send the key and the setup handshake
+    // for a session that was cancelled before it began.
+    if (this.signal.aborted) {
+      this.closedByUs = true
+      return
+    }
     this.signal.addEventListener('abort', () => this.teardown(), { once: true })
     this.connect()
   }
@@ -274,8 +281,9 @@ export class GeminiLiveSession implements E2EStreamingSession {
     socket.onOpen(() => this.sendSetup())
     socket.onMessage((data) => this.handleMessage(data))
     socket.onError((err) => {
-      log.warn('Gemini Live socket error:', err.message)
-      this.options.onStatus?.(`Gemini Live error: ${err.message}`)
+      const message = this.redactKey(err.message)
+      log.warn('Gemini Live socket error:', message)
+      this.options.onStatus?.(`Gemini Live error: ${message}`)
       terminate()
     })
     socket.onClose(() => terminate())
@@ -338,8 +346,19 @@ export class GeminiLiveSession implements E2EStreamingSession {
     try {
       this.socket?.send(data)
     } catch (err) {
-      log.warn('Gemini Live send failed:', err instanceof Error ? err.message : String(err))
+      log.warn('Gemini Live send failed:', this.redactKey(err instanceof Error ? err.message : String(err)))
     }
+  }
+
+  /**
+   * Because this endpoint authenticates via a `?key=` query parameter, a socket
+   * error that echoes the request target (redirects, proxy and TLS failures) can
+   * carry the raw key. Scrub it locally before it reaches a log file or the
+   * renderer — the main process sanitizer only covers the onStatus path.
+   */
+  private redactKey(message: string): string {
+    if (!this.options.apiKey) return message
+    return message.split(this.options.apiKey).join('***')
   }
 
   private flushPendingAudio(): void {
@@ -363,6 +382,9 @@ export class GeminiLiveSession implements E2EStreamingSession {
     // rather than betting the subtitle path on one of them.
     if (event.setupComplete ?? event.setup_complete) {
       this.ready = true
+      // Reset on setupComplete rather than on socket open: a socket that opens and
+      // then dies mid-handshake has not proven the connection usable, and must not
+      // refund the reconnect budget that bounds a failing endpoint.
       this.reconnectAttempts = 0
       this.flushPendingAudio()
       return

--- a/src/engines/e2e/GeminiLiveE2E.ts
+++ b/src/engines/e2e/GeminiLiveE2E.ts
@@ -398,7 +398,9 @@ export class GeminiLiveSession implements E2EStreamingSession {
     }
 
     if (event.error) {
-      this.emitError(new Error(event.error.message ?? 'Gemini Live translation error'))
+      this.emitError(
+        new Error(this.redactKey(event.error.message ?? 'Gemini Live translation error'))
+      )
       return
     }
 

--- a/src/main/dev/README.md
+++ b/src/main/dev/README.md
@@ -1,7 +1,7 @@
 # Shadow measurement harness (dev only) — #730
 
 Runs the JA⇄EN audio testset through the Local-first cascade and the cloud realtime
-e2e path side by side, and writes a `ShadowReport` (latency p50/p95, first-subtitle
+e2e paths side by side, and writes a `ShadowReport` (latency p50/p95, first-subtitle
 latency, cost, offline completeness, revision stability, busy/error rates).
 
 This is the "第0歩" measurement: it exists so the investment decision between
@@ -12,6 +12,7 @@ cascade modernization (#725) and local e2e (#724) rests on measured numbers.
 ```bash
 npm run shadow:ja-en           # cascade only, no API key needed, no cost
 npm run shadow:ja-en:cloud     # + gpt-realtime-translate (BYOK — costs real money)
+npm run shadow:ja-en:cloud-all # + gemini-3.5-live-translate-preview too (#723, BYOK — costs real money)
 ```
 
 The app opens no windows and quits when the report is written.
@@ -19,7 +20,8 @@ The app opens no windows and quits when the report is written.
 | Env var | Default | Meaning |
 |---|---|---|
 | `LT_SHADOW_JA_EN` | — | `1` enables the harness (set by the npm scripts) |
-| `LT_SHADOW_CLOUD` | — | `1` adds the cloud path. Requires `openaiApiKey` in settings |
+| `LT_SHADOW_CLOUD` | — | `1` adds the gpt-realtime-translate path. Requires `openaiApiKey` in settings |
+| `LT_SHADOW_GEMINI_LIVE` | — | `1` adds the Gemini Live path (#723). Requires `geminiLiveApiKey` in settings |
 | `LT_SHADOW_LIMIT` | all | Measure only the first N utterances (smoke runs) |
 | `LT_SHADOW_OUT` | `benchmark/results/shadow-ja-en.json` | Report path |
 

--- a/src/main/dev/shadow-harness.ts
+++ b/src/main/dev/shadow-harness.ts
@@ -175,6 +175,10 @@ export async function runShadowJaEnHarness(options: ShadowHarnessOptions = {}): 
 
   // One path per (cloud engine × direction): a session's output language is fixed,
   // so the direction is baked in and the submit loop enables only the matching one.
+  // With both cloud engines keyed, each utterance therefore runs through two live
+  // cloud sockets at once — that concurrency is the point (head-to-head comparison
+  // on identical audio), but it also means both vendors are billed for every
+  // utterance in the run.
   const cloudPaths: Array<{ language: Language; path: E2EStreamingShadowPath }> = []
   for (const language of ['ja', 'en'] as Language[]) {
     if (apiKey) cloudPaths.push({ language, path: buildOpenaiCloudPath(apiKey, language) })

--- a/src/main/dev/shadow-harness.ts
+++ b/src/main/dev/shadow-harness.ts
@@ -24,6 +24,7 @@ import { WhisperLocalEngine } from '../../engines/stt/WhisperLocalEngine'
 import type { WhisperVariant } from '../../engines/model-downloader'
 import { HunyuanMT15Translator } from '../../engines/translator/HunyuanMT15Translator'
 import { CloudRealtimeE2E } from '../../engines/e2e/CloudRealtimeE2E'
+import { GeminiLiveE2E } from '../../engines/e2e/GeminiLiveE2E'
 import type { Language } from '../../engines/types'
 import { store } from '../store'
 import { createLogger } from '../logger'
@@ -33,6 +34,17 @@ const log = createLogger('shadow-harness')
 
 /** Published price of gpt-realtime-translate: $0.034 per audio minute. */
 const GPT_REALTIME_TRANSLATE_USD_PER_AUDIO_MINUTE = 0.034
+
+/**
+ * Gemini Live translate meters input and output audio separately ($0.0053/min in,
+ * $0.0315/min out), which does not decompose into ShadowCostModel's single
+ * usdPerAudioMinute. Rather than widen the model for one provider, we bill the
+ * effective blended rate Google itself publishes for this model — $0.0368 per
+ * minute — which already assumes the ~1:1 output-to-input audio ratio that
+ * speech-to-speech translation produces.
+ * https://ai.google.dev/gemini-api/docs/pricing
+ */
+const GEMINI_LIVE_TRANSLATE_USD_PER_AUDIO_MINUTE = 0.0368
 
 const DEFAULT_TESTSET_DIR = 'benchmark/testset'
 const MANIFEST_NAME = 'stt-manifest.jsonl'
@@ -54,8 +66,10 @@ export interface ShadowHarnessOptions {
   outPath?: string
   /** Limit the number of utterances (smoke runs). */
   limit?: number
-  /** Include the cloud path. Requires an OpenAI key; costs real money. */
+  /** Include the OpenAI cloud path. Requires an OpenAI key; costs real money. */
   includeCloud?: boolean
+  /** Include the Gemini Live cloud path (#723). Requires a Gemini Live key; costs real money. */
+  includeGeminiLive?: boolean
   /**
    * Whisper variant for the cascade's STT stage. Must be bilingual: the engine's
    * own default (kotoba-whisper-v2.0) is JA-only and returns nothing for English,
@@ -80,16 +94,26 @@ function loadManifest(testsetDir: string, limit?: number): ManifestEntry[] {
 }
 
 /**
- * The cloud engine fixes its output language per session, so one session cannot
+ * Both cloud engines fix their output language per session, so one session cannot
  * translate both directions. Each direction therefore gets its own path, and JA
  * and EN utterances are submitted in separate passes.
  */
-function buildCloudPath(apiKey: string, sourceLanguage: Language): E2EStreamingShadowPath {
+function buildOpenaiCloudPath(apiKey: string, sourceLanguage: Language): E2EStreamingShadowPath {
   const targetLanguage: Language = sourceLanguage === 'ja' ? 'en' : 'ja'
   return new E2EStreamingShadowPath({
     id: `cloud-realtime-e2e:${sourceLanguage}->${targetLanguage}`,
     engine: new CloudRealtimeE2E({ apiKey, sourceLanguage, targetLanguage }),
     cost: { usdPerAudioMinute: GPT_REALTIME_TRANSLATE_USD_PER_AUDIO_MINUTE }
+  })
+}
+
+/** #723: second cloud path, measured head-to-head against the OpenAI one. */
+function buildGeminiLivePath(apiKey: string, sourceLanguage: Language): E2EStreamingShadowPath {
+  const targetLanguage: Language = sourceLanguage === 'ja' ? 'en' : 'ja'
+  return new E2EStreamingShadowPath({
+    id: `gemini-live-e2e:${sourceLanguage}->${targetLanguage}`,
+    engine: new GeminiLiveE2E({ apiKey, sourceLanguage, targetLanguage }),
+    cost: { usdPerAudioMinute: GEMINI_LIVE_TRANSLATE_USD_PER_AUDIO_MINUTE }
   })
 }
 
@@ -122,6 +146,10 @@ export async function runShadowJaEnHarness(options: ShadowHarnessOptions = {}): 
   if (options.includeCloud && !apiKey) {
     throw new Error('Cloud path requested but no OpenAI API key is stored (BYOK).')
   }
+  const geminiLiveApiKey = options.includeGeminiLive ? store.get('geminiLiveApiKey') : ''
+  if (options.includeGeminiLive && !geminiLiveApiKey) {
+    throw new Error('Gemini Live path requested but no Gemini Live API key is stored (BYOK).')
+  }
 
   const stt = new WhisperLocalEngine({
     onProgress: (msg) => log.info(msg),
@@ -145,17 +173,21 @@ export async function runShadowJaEnHarness(options: ShadowHarnessOptions = {}): 
   // utterance is submitted only after the previous one has drained.
   runner.register(cascade, { enabled: true, samplingInterval: 1, permits: 1 })
 
-  const cloudPaths = new Map<Language, E2EStreamingShadowPath>()
-  if (apiKey) {
-    for (const language of ['ja', 'en'] as Language[]) {
-      const path = buildCloudPath(apiKey, language)
-      cloudPaths.set(language, path)
+  // One path per (cloud engine × direction): a session's output language is fixed,
+  // so the direction is baked in and the submit loop enables only the matching one.
+  const cloudPaths: Array<{ language: Language; path: E2EStreamingShadowPath }> = []
+  for (const language of ['ja', 'en'] as Language[]) {
+    if (apiKey) cloudPaths.push({ language, path: buildOpenaiCloudPath(apiKey, language) })
+    if (geminiLiveApiKey) cloudPaths.push({ language, path: buildGeminiLivePath(geminiLiveApiKey, language) })
+  }
+  if (cloudPaths.length > 0) {
+    for (const { path } of cloudPaths) {
       runner.register(path, { enabled: true, samplingInterval: 1, permits: 1 })
     }
     // Open the sockets up front so the first measured segment does not carry the
     // WebSocket handshake and skew its first-subtitle number.
-    log.info('Warming up cloud sessions...')
-    await Promise.all([...cloudPaths.values()].map((p) => p.warmup()))
+    log.info(`Warming up ${cloudPaths.length} cloud session(s)...`)
+    await Promise.all(cloudPaths.map(({ path }) => path.warmup()))
   }
 
   // Warm the cascade on a throwaway inference before measuring. Lazy model load
@@ -177,7 +209,7 @@ export async function runShadowJaEnHarness(options: ShadowHarnessOptions = {}): 
       // A cloud session translates into ONE fixed language, so only the path for
       // this utterance's direction may see it. Disable the other one for this
       // submit rather than recording a wrong-direction translation.
-      for (const [language, path] of cloudPaths) {
+      for (const { language, path } of cloudPaths) {
         runner.setPathEnabled(path.id, language === entry.language)
       }
 
@@ -189,7 +221,7 @@ export async function runShadowJaEnHarness(options: ShadowHarnessOptions = {}): 
     }
   } finally {
     await runner.stop()
-    await Promise.all([...cloudPaths.values()].map((p) => p.dispose().catch(() => undefined)))
+    await Promise.all(cloudPaths.map(({ path }) => path.dispose().catch(() => undefined)))
     await translator.dispose().catch(() => undefined)
     await stt.dispose().catch(() => undefined)
   }

--- a/src/main/error-utils.ts
+++ b/src/main/error-utils.ts
@@ -8,7 +8,8 @@ export function sanitizeErrorMessage(message: string): string {
     settings.deeplApiKey,
     settings.geminiApiKey,
     settings.microsoftApiKey,
-    settings.openaiApiKey
+    settings.openaiApiKey,
+    settings.geminiLiveApiKey
   ].filter((s): s is string => typeof s === 'string' && s.length > 8)
 
   let sanitized = message

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -328,6 +328,7 @@ app.whenReady().then(async () => {
     try {
       await runShadowJaEnHarness({
         includeCloud: process.env.LT_SHADOW_CLOUD === '1',
+        includeGeminiLive: process.env.LT_SHADOW_GEMINI_LIVE === '1',
         limit: process.env.LT_SHADOW_LIMIT ? Number(process.env.LT_SHADOW_LIMIT) : undefined,
         outPath: process.env.LT_SHADOW_OUT
       })

--- a/src/main/ipc/pipeline-ipc.ts
+++ b/src/main/ipc/pipeline-ipc.ts
@@ -7,6 +7,7 @@ import { ApiRotationController } from '../../engines/translator/ApiRotationContr
 import type { ProviderConfig, QuotaStore } from '../../engines/translator/ApiRotationController'
 import { HunyuanMT15Translator } from '../../engines/translator/HunyuanMT15Translator'
 import { CloudRealtimeE2E } from '../../engines/e2e/CloudRealtimeE2E'
+import { GeminiLiveE2E } from '../../engines/e2e/GeminiLiveE2E'
 import { TranscriptLogger } from '../../logger/TranscriptLogger'
 import { store } from '../store'
 import type { AppContext } from '../app-context'
@@ -47,6 +48,8 @@ interface PipelineStartConfig extends EngineConfig {
   microsoftRegion?: string
   /** OpenAI API key for cloud realtime e2e translation (BYOK, #722) */
   openaiApiKey?: string
+  /** Gemini Live API key for the second cloud realtime e2e path (BYOK, #723) */
+  geminiLiveApiKey?: string
 }
 
 /** Register pipeline control IPC handlers */
@@ -91,6 +94,10 @@ export function registerPipelineIpc(ctx: AppContext): void {
       if (mdm.managedOpenaiApiKey && !config.openaiApiKey) {
         config.openaiApiKey = mdm.managedOpenaiApiKey
       }
+      // #723: inject managed Gemini Live key for the second cloud realtime path
+      if (mdm.managedGeminiLiveApiKey && !config.geminiLiveApiKey) {
+        config.geminiLiveApiKey = mdm.managedGeminiLiveApiKey
+      }
 
       // #722: register the cloud realtime e2e engine when selected (BYOK)
       if (config.mode === 'e2e' && config.e2eEngineId === 'cloud-realtime-e2e') {
@@ -101,6 +108,24 @@ export function registerPipelineIpc(ctx: AppContext): void {
         ctx.pipeline.registerE2E('cloud-realtime-e2e', () =>
           new CloudRealtimeE2E({
             apiKey: openaiKey,
+            sourceLanguage: store.get('sourceLanguage'),
+            targetLanguage: store.get('targetLanguage'),
+            // Scrub any BYOK key that might surface in a status/error string before it reaches the renderer
+            onStatus: (msg) => ctx.mainWindow?.webContents.send('status-update', sanitizeErrorMessage(msg))
+          })
+        )
+      }
+
+      // #723: register the Gemini Live e2e engine when selected (BYOK). Second cloud
+      // path; the renderer only selects it when the OpenAI path is not also enabled.
+      if (config.mode === 'e2e' && config.e2eEngineId === 'gemini-live-e2e') {
+        if (!config.geminiLiveApiKey) {
+          return { error: 'Gemini Live translation requires a Gemini Live API key' }
+        }
+        const geminiLiveKey = config.geminiLiveApiKey
+        ctx.pipeline.registerE2E('gemini-live-e2e', () =>
+          new GeminiLiveE2E({
+            apiKey: geminiLiveKey,
             sourceLanguage: store.get('sourceLanguage'),
             targetLanguage: store.get('targetLanguage'),
             // Scrub any BYOK key that might surface in a status/error string before it reaches the renderer

--- a/src/main/ipc/settings-ipc.ts
+++ b/src/main/ipc/settings-ipc.ts
@@ -27,6 +27,8 @@ export function registerSettingsIpc(ctx: AppContext): void {
       microsoftRegion: store.get('microsoftRegion'),
       openaiApiKey: store.get('openaiApiKey'),
       cloudRealtimeEnabled: store.get('cloudRealtimeEnabled'),
+      geminiLiveApiKey: store.get('geminiLiveApiKey'),
+      geminiLiveEnabled: store.get('geminiLiveEnabled'),
       sttEngine: store.get('sttEngine'),
       selectedMicrophone: store.get('selectedMicrophone'),
       selectedDisplay: store.get('selectedDisplay'),

--- a/src/main/mdm-config.ts
+++ b/src/main/mdm-config.ts
@@ -23,6 +23,8 @@ export interface MdmConfig {
   managedMicrosoftRegion: string | null
   /** Managed OpenAI API key for cloud realtime translation (#722) */
   managedOpenaiApiKey: string | null
+  /** Managed Gemini Live API key for realtime translation (#723) */
+  managedGeminiLiveApiKey: string | null
   /** Custom organization name shown in UI */
   organizationName: string | null
   /** Disable auto-update (enterprise may manage updates via MDM) */
@@ -101,6 +103,7 @@ export function loadMdmConfig(): MdmConfig {
     managedMicrosoftApiKey: readManagedPref('managedMicrosoftApiKey'),
     managedMicrosoftRegion: readManagedPref('managedMicrosoftRegion'),
     managedOpenaiApiKey: readManagedPref('managedOpenaiApiKey'),
+    managedGeminiLiveApiKey: readManagedPref('managedGeminiLiveApiKey'),
     organizationName: readManagedPref('organizationName'),
     autoUpdateDisabled: readManagedPref('autoUpdateDisabled') === '1'
   }
@@ -116,6 +119,7 @@ export function loadMdmConfig(): MdmConfig {
   if (config.managedMicrosoftApiKey) managed.push('managedMicrosoftApiKey=***')
   if (config.managedMicrosoftRegion) managed.push(`managedMicrosoftRegion=${config.managedMicrosoftRegion}`)
   if (config.managedOpenaiApiKey) managed.push('managedOpenaiApiKey=***')
+  if (config.managedGeminiLiveApiKey) managed.push('managedGeminiLiveApiKey=***')
   if (config.organizationName) managed.push(`org=${config.organizationName}`)
   if (config.autoUpdateDisabled) managed.push('autoUpdateDisabled')
 

--- a/src/main/store.ts
+++ b/src/main/store.ts
@@ -59,8 +59,19 @@ export interface AppSettings {
   geminiApiKey: string
   /** OpenAI API key for cloud realtime speech translation (BYOK, #722) */
   openaiApiKey: string
+  /**
+   * Google AI key for the Gemini Live API (BYOK, #723). Separate from geminiApiKey:
+   * the Live API is separately billed and gated, so a key that works for the
+   * cascade Gemini translator can still 403 on Live.
+   */
+  geminiLiveApiKey: string
   /** Opt-in cloud realtime interpretation via gpt-realtime-translate (#722). Off = local-first default. */
   cloudRealtimeEnabled: boolean
+  /**
+   * Opt-in Gemini Live realtime interpretation (#723). Preview model — never a
+   * default, and yields to cloudRealtimeEnabled when both are on.
+   */
+  geminiLiveEnabled: boolean
   selectedMicrophone: string
   sttEngine: string
   selectedDisplay: number
@@ -157,7 +168,9 @@ export const store = new Store<AppSettings>({
     deeplApiKey: '',
     geminiApiKey: '',
     openaiApiKey: '',
+    geminiLiveApiKey: '',
     cloudRealtimeEnabled: false,
+    geminiLiveEnabled: false,
     sttEngine: 'mlx-whisper',
     selectedMicrophone: '',
     selectedDisplay: 0,

--- a/src/renderer/components/SettingsPanel.tsx
+++ b/src/renderer/components/SettingsPanel.tsx
@@ -199,6 +199,10 @@ function SettingsPanel(): React.JSX.Element {
             onOpenaiApiKeyChange={s.setOpenaiApiKey}
             cloudRealtimeEnabled={s.cloudRealtimeEnabled}
             onCloudRealtimeEnabledChange={s.setCloudRealtimeEnabled}
+            geminiLiveApiKey={s.geminiLiveApiKey}
+            onGeminiLiveApiKeyChange={s.setGeminiLiveApiKey}
+            geminiLiveEnabled={s.geminiLiveEnabled}
+            onGeminiLiveEnabledChange={s.setGeminiLiveEnabled}
             showApiOptions={s.showApiOptions}
             onShowApiOptionsChange={s.setShowApiOptions}
             glossaryTerms={s.glossaryTerms}

--- a/src/renderer/components/settings/TranslatorSettings.tsx
+++ b/src/renderer/components/settings/TranslatorSettings.tsx
@@ -497,7 +497,9 @@ export function TranslatorSettings({
         </label>
         {geminiLiveEnabled && hasGeminiLiveKey && geminiLiveSupersededByOpenai && (
           <div style={{ fontSize: '11px', color: '#f59e0b', padding: '4px 0 0 24px' }}>
-            Inactive — &quot;Realtime Interpretation (Cloud)&quot; takes precedence. Turn that off to run Gemini Live.
+            {hasOpenaiKey
+              ? 'Inactive — "Realtime Interpretation (Cloud)" takes precedence. Turn that off to run Gemini Live.'
+              : 'Inactive — "Realtime Interpretation (Cloud)" is on but has no API key, so the offline engine is translating. Turn that off to run Gemini Live.'}
           </div>
         )}
         {geminiLiveEnabled && hasGeminiLiveKey && !geminiLiveSupersededByOpenai && (

--- a/src/renderer/components/settings/TranslatorSettings.tsx
+++ b/src/renderer/components/settings/TranslatorSettings.tsx
@@ -118,10 +118,11 @@ export function TranslatorSettings({
 
   // #723: the Gemini Live path needs its own Live-enabled key (BYOK)
   const hasGeminiLiveKey = !!geminiLiveApiKey
-  // Only one e2e path can own a session and gpt-realtime-translate wins, so when
-  // that path is live the preview toggle is inert — mirror buildEngineConfig's
-  // precedence in the UI rather than letting the checkbox imply it has an effect.
-  const geminiLiveSupersededByOpenai = cloudRealtimeEnabled && hasOpenaiKey
+  // Only one e2e path can own a session and the cloud realtime toggle owns the
+  // decision outright when set (see buildEngineConfig), so the preview toggle is
+  // inert while it is on — mirror that here rather than letting the checkbox imply
+  // it has an effect.
+  const geminiLiveSupersededByOpenai = cloudRealtimeEnabled
 
   return (
     <>

--- a/src/renderer/components/settings/TranslatorSettings.tsx
+++ b/src/renderer/components/settings/TranslatorSettings.tsx
@@ -45,6 +45,11 @@ interface TranslatorSettingsProps {
   onOpenaiApiKeyChange: (v: string) => void
   cloudRealtimeEnabled: boolean
   onCloudRealtimeEnabledChange: (v: boolean) => void
+  // Gemini Live realtime interpretation (#723, BYOK, preview)
+  geminiLiveApiKey: string
+  onGeminiLiveApiKeyChange: (v: string) => void
+  geminiLiveEnabled: boolean
+  onGeminiLiveEnabledChange: (v: boolean) => void
   // API options visibility (controlled by parent for settings restore)
   showApiOptions: boolean
   onShowApiOptionsChange: (v: boolean) => void
@@ -92,6 +97,10 @@ export function TranslatorSettings({
   onOpenaiApiKeyChange,
   cloudRealtimeEnabled,
   onCloudRealtimeEnabledChange,
+  geminiLiveApiKey,
+  onGeminiLiveApiKeyChange,
+  geminiLiveEnabled,
+  onGeminiLiveEnabledChange,
   showApiOptions,
   onShowApiOptionsChange,
   glossaryTerms,
@@ -106,6 +115,13 @@ export function TranslatorSettings({
 
   // #722: cloud realtime interpretation needs an OpenAI key (BYOK)
   const hasOpenaiKey = !!openaiApiKey
+
+  // #723: the Gemini Live path needs its own Live-enabled key (BYOK)
+  const hasGeminiLiveKey = !!geminiLiveApiKey
+  // Only one e2e path can own a session and gpt-realtime-translate wins, so when
+  // that path is live the preview toggle is inert — mirror buildEngineConfig's
+  // precedence in the UI rather than letting the checkbox imply it has an effect.
+  const geminiLiveSupersededByOpenai = cloudRealtimeEnabled && hasOpenaiKey
 
   return (
     <>
@@ -396,6 +412,15 @@ export function TranslatorSettings({
                 style={inputStyle}
                 disabled={disabled}
               />
+              <input
+                type="password"
+                value={geminiLiveApiKey}
+                onChange={(e) => onGeminiLiveApiKeyChange(e.target.value)}
+                placeholder="Gemini Live API key (realtime interpretation)"
+                aria-label="Gemini Live API key"
+                style={inputStyle}
+                disabled={disabled}
+              />
             </div>
           )}
         </div>
@@ -428,6 +453,55 @@ export function TranslatorSettings({
         {cloudRealtimeEnabled && hasOpenaiKey && (
           <div style={{ fontSize: '11px', color: '#f59e0b', padding: '4px 0 0 24px' }}>
             Cloud mode active — the offline engine selection above is bypassed while this is on.
+          </div>
+        )}
+      </Section>
+
+      {/* #723: second cloud realtime path, for comparison against gpt-realtime-translate.
+          Preview model — flagged experimental and never a default. */}
+      <Section
+        label="Realtime Interpretation (Gemini Live)"
+        helpText="Experimental second cloud path via Google's gemini-3.5-live-translate-preview. Preview models can change or break without notice, so this is for comparison — not for production meetings. Requires a Gemini Live API key and sends audio to the cloud."
+      >
+        <div
+          style={{
+            display: 'inline-block',
+            fontSize: '10px',
+            fontWeight: 700,
+            letterSpacing: '0.5px',
+            color: '#f59e0b',
+            border: '1px solid #f59e0b',
+            borderRadius: '3px',
+            padding: '1px 5px',
+            marginBottom: '6px'
+          }}
+        >
+          EXPERIMENTAL · PREVIEW
+        </div>
+        <label style={{ ...radioLabelStyle, opacity: hasGeminiLiveKey ? 1 : 0.5 }}>
+          <input
+            type="checkbox"
+            checked={geminiLiveEnabled}
+            onChange={(e) => onGeminiLiveEnabledChange(e.target.checked)}
+            disabled={disabled || !hasGeminiLiveKey}
+          />
+          <div>
+            <div style={{ fontWeight: 500 }}>Enable Gemini Live interpretation (BYOK, preview)</div>
+            <div style={{ fontSize: '12px', color: '#94a3b8' }}>
+              {hasGeminiLiveKey
+                ? 'Preview model — quality and availability may change without notice. Cloud — audio leaves your device. ~$0.0368/min. Output language follows your target-language setting.'
+                : 'Add a Gemini Live API key in "API Keys" above to enable this experimental path.'}
+            </div>
+          </div>
+        </label>
+        {geminiLiveEnabled && hasGeminiLiveKey && geminiLiveSupersededByOpenai && (
+          <div style={{ fontSize: '11px', color: '#f59e0b', padding: '4px 0 0 24px' }}>
+            Inactive — &quot;Realtime Interpretation (Cloud)&quot; takes precedence. Turn that off to run Gemini Live.
+          </div>
+        )}
+        {geminiLiveEnabled && hasGeminiLiveKey && !geminiLiveSupersededByOpenai && (
+          <div style={{ fontSize: '11px', color: '#f59e0b', padding: '4px 0 0 24px' }}>
+            Preview cloud mode active — the offline engine selection above is bypassed while this is on.
           </div>
         )}
       </Section>

--- a/src/renderer/components/settings/shared.test.ts
+++ b/src/renderer/components/settings/shared.test.ts
@@ -119,3 +119,64 @@ describe('resolveEngineMode (#702)', () => {
     expect(resolveEngineMode('auto', withRegion, { hasGpu: false })).toBe('rotation')
   })
 })
+
+describe('buildEngineConfig realtime e2e precedence (#723)', () => {
+  const OPENAI_KEYS = { ...NO_KEYS, openaiApiKey: 'sk-test' }
+  const GEMINI_LIVE_KEYS = { ...NO_KEYS, geminiLiveApiKey: 'AIza-test' }
+  const BOTH_KEYS = { ...NO_KEYS, openaiApiKey: 'sk-test', geminiLiveApiKey: 'AIza-test' }
+
+  it('selects the OpenAI realtime path when only cloud realtime is enabled', () => {
+    expect(buildEngineConfig('offline-hymt15', STT, OPENAI_KEYS, true, false)).toEqual({
+      mode: 'e2e',
+      e2eEngineId: 'cloud-realtime-e2e',
+      openaiApiKey: 'sk-test'
+    })
+  })
+
+  it('selects the Gemini Live path when only Gemini Live is enabled', () => {
+    expect(buildEngineConfig('offline-hymt15', STT, GEMINI_LIVE_KEYS, false, true)).toEqual({
+      mode: 'e2e',
+      e2eEngineId: 'gemini-live-e2e',
+      geminiLiveApiKey: 'AIza-test'
+    })
+  })
+
+  it('prefers gpt-realtime-translate over the Gemini Live preview when both are enabled', () => {
+    expect(buildEngineConfig('offline-hymt15', STT, BOTH_KEYS, true, true)).toEqual({
+      mode: 'e2e',
+      e2eEngineId: 'cloud-realtime-e2e',
+      openaiApiKey: 'sk-test'
+    })
+  })
+
+  it('falls through to Gemini Live when cloud realtime is enabled but has no OpenAI key', () => {
+    expect(buildEngineConfig('offline-hymt15', STT, GEMINI_LIVE_KEYS, true, true)).toEqual({
+      mode: 'e2e',
+      e2eEngineId: 'gemini-live-e2e',
+      geminiLiveApiKey: 'AIza-test'
+    })
+  })
+
+  it('never leaks the other path\'s key into the selected e2e config', () => {
+    const openai = buildEngineConfig('offline-hymt15', STT, BOTH_KEYS, true, false)
+    expect(openai).not.toHaveProperty('geminiLiveApiKey')
+    const gemini = buildEngineConfig('offline-hymt15', STT, BOTH_KEYS, false, true)
+    expect(gemini).not.toHaveProperty('openaiApiKey')
+  })
+
+  it('stays on the local-first cascade when a toggle is on but its key is missing', () => {
+    expect(buildEngineConfig('offline-hymt15', STT, NO_KEYS, true, true)).toEqual({
+      mode: 'cascade',
+      sttEngineId: STT,
+      translatorEngineId: 'hunyuan-mt-15'
+    })
+  })
+
+  it('stays on the local-first cascade when both toggles are off despite keys present', () => {
+    expect(buildEngineConfig('offline-hymt15', STT, BOTH_KEYS, false, false)).toEqual({
+      mode: 'cascade',
+      sttEngineId: STT,
+      translatorEngineId: 'hunyuan-mt-15'
+    })
+  })
+})

--- a/src/renderer/components/settings/shared.test.ts
+++ b/src/renderer/components/settings/shared.test.ts
@@ -124,9 +124,12 @@ describe('buildEngineConfig realtime e2e precedence (#723)', () => {
   const OPENAI_KEYS = { ...NO_KEYS, openaiApiKey: 'sk-test' }
   const GEMINI_LIVE_KEYS = { ...NO_KEYS, geminiLiveApiKey: 'AIza-test' }
   const BOTH_KEYS = { ...NO_KEYS, openaiApiKey: 'sk-test', geminiLiveApiKey: 'AIza-test' }
+  const CASCADE = { mode: 'cascade', sttEngineId: STT, translatorEngineId: 'hunyuan-mt-15' }
 
   it('selects the OpenAI realtime path when only cloud realtime is enabled', () => {
-    expect(buildEngineConfig('offline-hymt15', STT, OPENAI_KEYS, true, false)).toEqual({
+    expect(
+      buildEngineConfig('offline-hymt15', STT, OPENAI_KEYS, { cloudRealtimeEnabled: true })
+    ).toEqual({
       mode: 'e2e',
       e2eEngineId: 'cloud-realtime-e2e',
       openaiApiKey: 'sk-test'
@@ -134,7 +137,9 @@ describe('buildEngineConfig realtime e2e precedence (#723)', () => {
   })
 
   it('selects the Gemini Live path when only Gemini Live is enabled', () => {
-    expect(buildEngineConfig('offline-hymt15', STT, GEMINI_LIVE_KEYS, false, true)).toEqual({
+    expect(
+      buildEngineConfig('offline-hymt15', STT, GEMINI_LIVE_KEYS, { geminiLiveEnabled: true })
+    ).toEqual({
       mode: 'e2e',
       e2eEngineId: 'gemini-live-e2e',
       geminiLiveApiKey: 'AIza-test'
@@ -142,41 +147,56 @@ describe('buildEngineConfig realtime e2e precedence (#723)', () => {
   })
 
   it('prefers gpt-realtime-translate over the Gemini Live preview when both are enabled', () => {
-    expect(buildEngineConfig('offline-hymt15', STT, BOTH_KEYS, true, true)).toEqual({
+    expect(
+      buildEngineConfig('offline-hymt15', STT, BOTH_KEYS, {
+        cloudRealtimeEnabled: true,
+        geminiLiveEnabled: true
+      })
+    ).toEqual({
       mode: 'e2e',
       e2eEngineId: 'cloud-realtime-e2e',
       openaiApiKey: 'sk-test'
     })
   })
 
-  it('falls through to Gemini Live when cloud realtime is enabled but has no OpenAI key', () => {
-    expect(buildEngineConfig('offline-hymt15', STT, GEMINI_LIVE_KEYS, true, true)).toEqual({
-      mode: 'e2e',
-      e2eEngineId: 'gemini-live-e2e',
-      geminiLiveApiKey: 'AIza-test'
-    })
+  // Privacy: a misconfigured OpenAI path must never redirect the user's audio to
+  // Google. "Enabled but keyless" falls back to local, never sideways to the other
+  // vendor — even though the Gemini toggle is on and its key is present.
+  it('falls back to the local cascade — not to Gemini — when cloud realtime is enabled without an OpenAI key', () => {
+    expect(
+      buildEngineConfig('offline-hymt15', STT, GEMINI_LIVE_KEYS, {
+        cloudRealtimeEnabled: true,
+        geminiLiveEnabled: true
+      })
+    ).toEqual(CASCADE)
   })
 
-  it('never leaks the other path\'s key into the selected e2e config', () => {
-    const openai = buildEngineConfig('offline-hymt15', STT, BOTH_KEYS, true, false)
+  it("never leaks the other path's key into the selected e2e config", () => {
+    const openai = buildEngineConfig('offline-hymt15', STT, BOTH_KEYS, { cloudRealtimeEnabled: true })
     expect(openai).not.toHaveProperty('geminiLiveApiKey')
-    const gemini = buildEngineConfig('offline-hymt15', STT, BOTH_KEYS, false, true)
+    const gemini = buildEngineConfig('offline-hymt15', STT, BOTH_KEYS, { geminiLiveEnabled: true })
     expect(gemini).not.toHaveProperty('openaiApiKey')
   })
 
   it('stays on the local-first cascade when a toggle is on but its key is missing', () => {
-    expect(buildEngineConfig('offline-hymt15', STT, NO_KEYS, true, true)).toEqual({
-      mode: 'cascade',
-      sttEngineId: STT,
-      translatorEngineId: 'hunyuan-mt-15'
-    })
+    expect(
+      buildEngineConfig('offline-hymt15', STT, NO_KEYS, {
+        cloudRealtimeEnabled: true,
+        geminiLiveEnabled: true
+      })
+    ).toEqual(CASCADE)
   })
 
   it('stays on the local-first cascade when both toggles are off despite keys present', () => {
-    expect(buildEngineConfig('offline-hymt15', STT, BOTH_KEYS, false, false)).toEqual({
-      mode: 'cascade',
-      sttEngineId: STT,
-      translatorEngineId: 'hunyuan-mt-15'
-    })
+    expect(
+      buildEngineConfig('offline-hymt15', STT, BOTH_KEYS, {
+        cloudRealtimeEnabled: false,
+        geminiLiveEnabled: false
+      })
+    ).toEqual(CASCADE)
+  })
+
+  it('stays on the local-first cascade when no realtime options are passed at all', () => {
+    expect(buildEngineConfig('offline-hymt15', STT, BOTH_KEYS)).toEqual(CASCADE)
   })
 })

--- a/src/renderer/components/settings/shared.ts
+++ b/src/renderer/components/settings/shared.ts
@@ -222,29 +222,33 @@ export function buildEngineConfig(
     openaiApiKey?: string
     geminiLiveApiKey?: string
   },
-  cloudRealtimeEnabled = false,
-  geminiLiveEnabled = false
+  /**
+   * Realtime cloud toggles. An object rather than positional booleans: these route
+   * where a user's audio is sent, and two adjacent same-typed flags are swappable
+   * at a call site without any type error.
+   */
+  realtime: { cloudRealtimeEnabled?: boolean; geminiLiveEnabled?: boolean } = {}
 ): Record<string, unknown> {
   // #722/#723: Cloud realtime interpretation is a separate capability axis, not an
   // extra translation engine — when enabled (with the matching BYOK key) it
   // overrides the cascade engine selection and runs a speech-native e2e path.
   // Both default off, keeping the local-first cascade as Core Value ①.
   //
-  // Only ONE e2e path can own a session, so the precedence below is deliberate and
-  // fixed by tests rather than left to declaration order: gpt-realtime-translate
-  // wins whenever both toggles are on, because Gemini Live is a Preview model whose
-  // spec and SLA may change without notice (#723). The Gemini branch therefore
-  // requires cloudRealtime to be off OR unusable (no OpenAI key), so a user who
-  // enables both never silently lands on the preview path.
-  if (cloudRealtimeEnabled && apiKeys.openaiApiKey) {
-    return {
-      mode: 'e2e' as const,
-      e2eEngineId: 'cloud-realtime-e2e',
-      openaiApiKey: apiKeys.openaiApiKey
+  // Only ONE e2e path can own a session. gpt-realtime-translate outranks Gemini
+  // Live, whose model is Preview and may change or break without notice, so its
+  // toggle is checked first and owns the decision outright: a cloudRealtime user
+  // whose OpenAI key is missing falls back to the LOCAL cascade, never sideways to
+  // the other vendor. "Enabled but unusable" is a misconfiguration, not consent to
+  // ship audio to a cloud the user did not choose.
+  if (realtime.cloudRealtimeEnabled) {
+    if (apiKeys.openaiApiKey) {
+      return {
+        mode: 'e2e' as const,
+        e2eEngineId: 'cloud-realtime-e2e',
+        openaiApiKey: apiKeys.openaiApiKey
+      }
     }
-  }
-
-  if (geminiLiveEnabled && apiKeys.geminiLiveApiKey) {
+  } else if (realtime.geminiLiveEnabled && apiKeys.geminiLiveApiKey) {
     return {
       mode: 'e2e' as const,
       e2eEngineId: 'gemini-live-e2e',

--- a/src/renderer/components/settings/shared.ts
+++ b/src/renderer/components/settings/shared.ts
@@ -213,18 +213,42 @@ export function resolveEngineMode(
 export function buildEngineConfig(
   resolvedMode: EngineMode,
   sttEngine: SttEngineType,
-  apiKeys: { apiKey: string; deeplApiKey: string; geminiApiKey: string; microsoftApiKey: string; microsoftRegion: string; openaiApiKey?: string },
-  cloudRealtimeEnabled = false
+  apiKeys: {
+    apiKey: string
+    deeplApiKey: string
+    geminiApiKey: string
+    microsoftApiKey: string
+    microsoftRegion: string
+    openaiApiKey?: string
+    geminiLiveApiKey?: string
+  },
+  cloudRealtimeEnabled = false,
+  geminiLiveEnabled = false
 ): Record<string, unknown> {
-  // #722: Cloud realtime interpretation is a separate capability axis, not a 5th
-  // translation engine — when enabled (with a BYOK OpenAI key) it overrides the
-  // cascade engine selection and runs the speech-native e2e path. Default off
-  // keeps the local-first cascade as Core Value ①.
+  // #722/#723: Cloud realtime interpretation is a separate capability axis, not an
+  // extra translation engine — when enabled (with the matching BYOK key) it
+  // overrides the cascade engine selection and runs a speech-native e2e path.
+  // Both default off, keeping the local-first cascade as Core Value ①.
+  //
+  // Only ONE e2e path can own a session, so the precedence below is deliberate and
+  // fixed by tests rather than left to declaration order: gpt-realtime-translate
+  // wins whenever both toggles are on, because Gemini Live is a Preview model whose
+  // spec and SLA may change without notice (#723). The Gemini branch therefore
+  // requires cloudRealtime to be off OR unusable (no OpenAI key), so a user who
+  // enables both never silently lands on the preview path.
   if (cloudRealtimeEnabled && apiKeys.openaiApiKey) {
     return {
       mode: 'e2e' as const,
       e2eEngineId: 'cloud-realtime-e2e',
       openaiApiKey: apiKeys.openaiApiKey
+    }
+  }
+
+  if (geminiLiveEnabled && apiKeys.geminiLiveApiKey) {
+    return {
+      mode: 'e2e' as const,
+      e2eEngineId: 'gemini-live-e2e',
+      geminiLiveApiKey: apiKeys.geminiLiveApiKey
     }
   }
 

--- a/src/renderer/hooks/useEngineSettings.ts
+++ b/src/renderer/hooks/useEngineSettings.ts
@@ -23,6 +23,11 @@ export interface EngineSettingsState {
   setOpenaiApiKey: (v: string) => void
   cloudRealtimeEnabled: boolean
   setCloudRealtimeEnabled: (v: boolean) => void
+  // Gemini Live realtime interpretation (#723, BYOK, preview)
+  geminiLiveApiKey: string
+  setGeminiLiveApiKey: (v: string) => void
+  geminiLiveEnabled: boolean
+  setGeminiLiveEnabled: (v: boolean) => void
 
   slmKvCacheQuant: boolean
   setSlmKvCacheQuant: (v: boolean) => void
@@ -64,6 +69,8 @@ export function useEngineSettings(init: EngineSettingsInit): EngineSettingsState
   const [microsoftRegion, setMicrosoftRegion] = useState('')
   const [openaiApiKey, setOpenaiApiKey] = useState('')
   const [cloudRealtimeEnabled, setCloudRealtimeEnabled] = useState(false)
+  const [geminiLiveApiKey, setGeminiLiveApiKey] = useState('')
+  const [geminiLiveEnabled, setGeminiLiveEnabled] = useState(false)
   const [slmKvCacheQuant, setSlmKvCacheQuant] = useState(true)
   const [slmSpeculativeDecoding, setSlmSpeculativeDecoding] = useState(false)
   const [simulMtEnabled, setSimulMtEnabled] = useState(false)
@@ -92,6 +99,8 @@ export function useEngineSettings(init: EngineSettingsInit): EngineSettingsState
       if (s.microsoftRegion) setMicrosoftRegion(str(s.microsoftRegion, ''))
       if (s.openaiApiKey) setOpenaiApiKey(str(s.openaiApiKey, ''))
       if (s.cloudRealtimeEnabled !== undefined) setCloudRealtimeEnabled(bool(s.cloudRealtimeEnabled, false))
+      if (s.geminiLiveApiKey) setGeminiLiveApiKey(str(s.geminiLiveApiKey, ''))
+      if (s.geminiLiveEnabled !== undefined) setGeminiLiveEnabled(bool(s.geminiLiveEnabled, false))
       if (s.slmKvCacheQuant !== undefined) setSlmKvCacheQuant(bool(s.slmKvCacheQuant, true))
       if (s.slmSpeculativeDecoding !== undefined) setSlmSpeculativeDecoding(bool(s.slmSpeculativeDecoding, false))
       if (s.glossaryTerms) setGlossaryTerms(arr<{ source: string; target: string }>(s.glossaryTerms, []))
@@ -136,6 +145,8 @@ export function useEngineSettings(init: EngineSettingsInit): EngineSettingsState
     microsoftRegion, setMicrosoftRegion,
     openaiApiKey, setOpenaiApiKey,
     cloudRealtimeEnabled, setCloudRealtimeEnabled,
+    geminiLiveApiKey, setGeminiLiveApiKey,
+    geminiLiveEnabled, setGeminiLiveEnabled,
     slmKvCacheQuant, setSlmKvCacheQuant,
     slmSpeculativeDecoding, setSlmSpeculativeDecoding,
     simulMtEnabled, setSimulMtEnabled,

--- a/src/renderer/hooks/useSettingsState.ts
+++ b/src/renderer/hooks/useSettingsState.ts
@@ -53,6 +53,11 @@ export interface SettingsState {
   setOpenaiApiKey: (v: string) => void
   cloudRealtimeEnabled: boolean
   setCloudRealtimeEnabled: (v: boolean) => void
+  // Gemini Live realtime interpretation (#723, BYOK, preview)
+  geminiLiveApiKey: string
+  setGeminiLiveApiKey: (v: string) => void
+  geminiLiveEnabled: boolean
+  setGeminiLiveEnabled: (v: boolean) => void
 
   // Display
   displays: DisplayInfo[]
@@ -183,7 +188,8 @@ export function useSettingsState(): SettingsState {
     geminiApiKey: engine.geminiApiKey,
     microsoftApiKey: engine.microsoftApiKey,
     microsoftRegion: engine.microsoftRegion,
-    openaiApiKey: engine.openaiApiKey
+    openaiApiKey: engine.openaiApiKey,
+    geminiLiveApiKey: engine.geminiLiveApiKey
   }
 
   const handleStart = async (): Promise<void> => {
@@ -202,6 +208,8 @@ export function useSettingsState(): SettingsState {
         microsoftRegion: engine.microsoftRegion,
         openaiApiKey: engine.openaiApiKey,
         cloudRealtimeEnabled: engine.cloudRealtimeEnabled,
+        geminiLiveApiKey: engine.geminiLiveApiKey,
+        geminiLiveEnabled: engine.geminiLiveEnabled,
         selectedMicrophone: session.audio.selectedDevice,
         selectedDisplay: display.selectedDisplay,
         sttEngine: language.sttEngine,
@@ -224,7 +232,13 @@ export function useSettingsState(): SettingsState {
       }), 10_000, 'saveSettings')
 
       const resolvedMode = resolveEngineMode(engine.engineMode, apiKeys, engine.gpuInfo)
-      const config = buildEngineConfig(resolvedMode, language.sttEngine, apiKeys, engine.cloudRealtimeEnabled)
+      const config = buildEngineConfig(
+      resolvedMode,
+      language.sttEngine,
+      apiKeys,
+      engine.cloudRealtimeEnabled,
+      engine.geminiLiveEnabled
+    )
 
       const result = await withIpcTimeout(window.api.pipelineStart(config), 120_000, 'pipelineStart')
       if (result.error) {
@@ -326,6 +340,8 @@ export function useSettingsState(): SettingsState {
     microsoftRegion: engine.microsoftRegion, setMicrosoftRegion: engine.setMicrosoftRegion,
     openaiApiKey: engine.openaiApiKey, setOpenaiApiKey: engine.setOpenaiApiKey,
     cloudRealtimeEnabled: engine.cloudRealtimeEnabled, setCloudRealtimeEnabled: engine.setCloudRealtimeEnabled,
+    geminiLiveApiKey: engine.geminiLiveApiKey, setGeminiLiveApiKey: engine.setGeminiLiveApiKey,
+    geminiLiveEnabled: engine.geminiLiveEnabled, setGeminiLiveEnabled: engine.setGeminiLiveEnabled,
     slmKvCacheQuant: engine.slmKvCacheQuant, setSlmKvCacheQuant: engine.setSlmKvCacheQuant,
     slmSpeculativeDecoding: engine.slmSpeculativeDecoding, setSlmSpeculativeDecoding: engine.setSlmSpeculativeDecoding,
     simulMtEnabled: engine.simulMtEnabled, setSimulMtEnabled: engine.setSimulMtEnabled,

--- a/src/renderer/hooks/useSettingsState.ts
+++ b/src/renderer/hooks/useSettingsState.ts
@@ -232,13 +232,10 @@ export function useSettingsState(): SettingsState {
       }), 10_000, 'saveSettings')
 
       const resolvedMode = resolveEngineMode(engine.engineMode, apiKeys, engine.gpuInfo)
-      const config = buildEngineConfig(
-      resolvedMode,
-      language.sttEngine,
-      apiKeys,
-      engine.cloudRealtimeEnabled,
-      engine.geminiLiveEnabled
-    )
+      const config = buildEngineConfig(resolvedMode, language.sttEngine, apiKeys, {
+        cloudRealtimeEnabled: engine.cloudRealtimeEnabled,
+        geminiLiveEnabled: engine.geminiLiveEnabled
+      })
 
       const result = await withIpcTimeout(window.api.pipelineStart(config), 120_000, 'pipelineStart')
       if (result.error) {


### PR DESCRIPTION
## Summary

Adds `GeminiLiveE2E` — a second BYOK cloud realtime speech-translation path via Google's Gemini Live API (`gemini-3.5-live-translate-preview`), alongside the existing `CloudRealtimeE2E` (gpt-realtime-translate). It exists as a **comparison / redundancy path**, not a production default: the model is Preview, so its spec and SLA can change without notice.

Closes #723

## Protocol sources (Research-First — no guessing)

All protocol details were read from the official docs before implementation:

- https://ai.google.dev/gemini-api/docs/live-api/live-translate — model id, endpoint, `setup` schema, `translationConfig`, `realtimeInput.audio` framing, 16 kHz PCM input, `echoTargetLanguage` semantics
- https://ai.google.dev/api/live — `BidiGenerateContentServerMessage` shape: `setupComplete`, `serverContent.{inputTranscription,outputTranscription,turnComplete}`, `goAway`
- https://ai.google.dev/gemini-api/docs/pricing — $0.0053/min in, $0.0315/min out, **effective $0.0368/min**

## Design decisions

### 1. Exclusivity with `cloudRealtimeEnabled` (the important one)

Only one e2e path can own a session. `buildEngineConfig` now expresses the precedence explicitly and pins it with tests, rather than leaving it to declaration order:

- `cloudRealtimeEnabled` **owns the decision outright when set**. gpt-realtime-translate wins whenever both toggles are on (M1 preference — Gemini Live is Preview).
- **A keyless-but-enabled OpenAI path falls back to the LOCAL cascade — never sideways to Gemini.** "Enabled but unusable" is a misconfiguration, not consent to ship audio to a cloud vendor the user did not choose. This was caught in Codex cross-review: the first draft fell through to Gemini and would have silently redirected a user's audio from OpenAI to Google.
- Both off → local-first cascade (Core Value ①).

The realtime flags are passed as an options object rather than two positional booleans: they route *where a user's audio is sent*, and two adjacent same-typed flags are swappable at a call site with no type error. No pre-existing test passed the 4th arg, so this cost zero churn on existing tests.

### 2. `geminiLiveApiKey` (new) rather than reusing `geminiApiKey`

The Live API is separately billed, separately quota'd, and separately gated for model access — a key that works for the cascade `GeminiTranslator` can still 403 on Live. Reusing `geminiApiKey` would surface that as a confusing runtime failure with no way for the user to distinguish which key was at fault. A dedicated key with **no silent fallback** keeps the failure legible. MDM gets a matching `managedGeminiLiveApiKey`, mirroring `managedOpenaiApiKey` (#722).

### 3. Protocol differences — mirrored plainly, no shared abstraction

Deliberately kept as a straight mirror of `CloudRealtimeE2E` (no early refactor into a common base): the two paths are independent, one is Preview and may change under us, and a shared abstraction designed against exactly two samples would be premature. The real differences:

| | CloudRealtimeE2E | GeminiLiveE2E |
|---|---|---|
| Auth | `Authorization: Bearer` header | `?key=` query param (own default factory) |
| Handshake | none — audio flows on socket open | `setup` → **must await `setupComplete`** before audio |
| Audio frame | `session.input_audio_buffer.append` | `realtimeInput.audio` (`audio/pcm;rate=16000`) |
| Final boundary | no documented done event | explicit `turnComplete` |

Preview-hardening, following the existing defensive posture in `CloudRealtimeE2E.ts:313-318`: both lowerCamelCase and proto snake_case spellings are accepted, and `goAway` is surfaced as a status notice while the ensuing close drives the bounded reconnect.

Two Gemini-specific choices worth flagging:
- `responseModalities: ['AUDIO']` is mandatory — the translate model has no TEXT modality. The model therefore also *speaks* the translation; we consume `outputAudioTranscription` for subtitles and drop the synthesized audio parts unread (TTS is out of scope per Won't Do).
- `echoTargetLanguage: true` — the documented default (`false`) makes the model **stay silent** when the speaker is already using the target language, which for a meeting overlay would silently drop those lines.

### 4. Shadow cost model

Gemini's two-rate metering ($0.0053 in / $0.0315 out) does not decompose into `ShadowCostModel.usdPerAudioMinute`. Rather than widen the model for one provider, the harness bills the **effective blended rate Google itself publishes** for this model — $0.0368/min — which already assumes the ~1:1 output:input audio ratio that S2S translation produces. So this is a cited figure, not my estimate.

## UI

New "Realtime Interpretation (Gemini Live)" section with an `EXPERIMENTAL · PREVIEW` badge (amber `#f59e0b`, matching the existing cloudRealtime warning treatment — there was no prior badge precedent). When the OpenAI path is on, the section shows "Inactive — takes precedence", mirroring `buildEngineConfig` so the checkbox never implies an effect it does not have.

## Verification

**Verified by running:**
- `src/engines/e2e/GeminiLiveE2E.test.ts` — 30 cases: setup handshake, audio gating, transcript→sink mapping, snake_case tolerance, abort/stop/flush gating, reconnect cap, key-not-in-URL.
- `shared.test.ts` — 8 new cases pinning the precedence contract above.
- **Throwaway integration probe over a real `ws` socket** against a local mock BidiGenerateContent server (not committed). Confirmed observationally: `?key=` auth on the correct path; frame order `["setup","realtimeInput"]` proving audio is genuinely withheld until `setupComplete`; `audio/pcm;rate=16000` with 4268 b64 chars = exactly 1600 samples × 2 bytes, confirming the 16k→16k resample is a real no-op; `interim` then `FINAL` with correct `ja->en` labels.

**NOT verified (no API key available):**
- No real Gemini Live endpoint was ever contacted. Live audio round-trip, real event names/ordering, actual latency, real billing, and real reconnect/`goAway` behavior are **unconfirmed**. The mock server above is a stand-in built from the docs — it proves this client's plumbing, not Google's behavior. Acceptance criteria "connects to Gemini Live and shows interim/final subtitles" and "shadow-mode comparison" therefore remain unverified against the real service and need a manual pass with a real key.

**Pre-existing, unrelated to this PR:** `src/main/virtual-mic-manager.test.ts` fails 10 tests on this machine (naudiodon/PortAudio is skipped on macOS 26+), and `useLanguageSettings.ts` has one `react-hooks/exhaustive-deps` lint error. Both reproduce on a clean `main` — verified by stashing. Not touched here.

## Self-review (`/review`: 2 parallel agents + Codex cross-review)

**Critical: 0.** Findings acted on:

| Finding | Action |
|---|---|
| `start()` with an already-aborted signal opened a live socket + sent the key (abort never re-fires, so teardown never ran) | Fixed + test |
| `log.warn` bypassed sanitization; `?key=` auth means a ws error echoing the request target could log the raw key — the docstring's "never reaches a log line" claim was unenforced | Added local `redactKey()` on both log paths + test |
| "Cloud takes precedence" notice shown even when the OpenAI toggle is on *without* a key, where in fact neither cloud path runs | Message now distinguishes the two states |
| `reconnectAttempts` reset on `setupComplete` rather than socket open — an undocumented divergence from the sibling engine | Comment explaining it is intentional |
| Shadow harness now runs two live cloud sockets per utterance (both vendors billed) | Comment noting the concurrency/billing shape |

Deliberately not changed: the in-band `{error}` frame does not force teardown, and the socket interface is duplicated rather than shared — both are faithful mirrors of `CloudRealtimeE2E`, and the "avoid an abstraction designed against two samples" call is documented in the file. Worth revisiting if a third BYOK realtime engine lands.
